### PR TITLE
feat: add task manual run runtime support

### DIFF
--- a/src/onestep/app.py
+++ b/src/onestep/app.py
@@ -20,6 +20,37 @@ from .state import InMemoryStateStore, StateStore
 from .task import TaskHandler, TaskHooks, TaskSpec
 
 
+class _SyntheticManualRunDelivery:
+    def __init__(self, envelope: Envelope) -> None:
+        self.envelope = envelope
+        self.acked = False
+        self.failed = False
+        self.retry_requested = False
+        self.retry_delay_s: float | None = None
+
+    @property
+    def payload(self) -> Any:
+        return self.envelope.body
+
+    async def start_processing(self) -> None:
+        return None
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        self.retry_requested = True
+        self.retry_delay_s = delay_s
+        self.envelope = Envelope(
+            body=copy.deepcopy(self.envelope.body),
+            meta=copy.deepcopy(self.envelope.meta),
+            attempts=self.envelope.attempts + 1,
+        )
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        self.failed = True
+
+
 class OneStepApp:
     def __init__(
         self,
@@ -243,6 +274,59 @@ class OneStepApp:
             "empty": attempted_count == 0,
         }
 
+    async def run_task_once(
+        self,
+        task_name: str,
+        *,
+        payload: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        task = self._require_manual_run_task(task_name)
+        delivery = _SyntheticManualRunDelivery(
+            Envelope(
+                body=copy.deepcopy(dict(payload)),
+                meta={
+                    "manual_run": True,
+                    "task_name": task_name,
+                },
+                attempts=0,
+            )
+        )
+        runner = TaskRunner(self, task)
+
+        attempted_count = 0
+        completed = False
+        last_failure: Exception | None = None
+
+        while True:
+            attempted_count += 1
+            await runner._handle_delivery(delivery)
+            if delivery.acked:
+                completed = True
+                break
+            if not delivery.retry_requested:
+                break
+            delivery.retry_requested = False
+            last_failure = RuntimeError("manual run exhausted retries")
+
+        if completed:
+            return {
+                "operation": "run_task_once",
+                "task_name": task_name,
+                "requested": True,
+                "completion": "complete",
+                "attempted_count": attempted_count,
+                "manual_run": True,
+            }
+
+        if delivery.failed:
+            raise RuntimeError(
+                f"manual run failed for task {task_name} after {attempted_count} attempt(s)"
+            ) from last_failure
+
+        raise RuntimeError(
+            f"manual run did not reach a terminal successful state for task {task_name}"
+        )
+
     async def wait_for_shutdown(self) -> None:
         shutdown = self._ensure_shutdown_event()
         await shutdown.wait()
@@ -403,6 +487,8 @@ class OneStepApp:
             supported_commands.append("discard_dead_letters")
         if self._task_supports_dead_letter_replay(task):
             supported_commands.append("replay_dead_letters")
+        if self._task_supports_manual_run(task):
+            supported_commands.append("run_task_once")
         return supported_commands
 
     def supports_dead_letter_replay_commands(self) -> bool:
@@ -410,6 +496,9 @@ class OneStepApp:
 
     def supports_dead_letter_discard_commands(self) -> bool:
         return any(self._task_supports_dead_letter_discard(task) for task in self._tasks)
+
+    def supports_manual_run_commands(self) -> bool:
+        return any(self._task_supports_manual_run(task) for task in self._tasks)
 
     def task_resume_status(self, task_name: str) -> dict[str, Any]:
         status = self._task_runtime_status(task_name)
@@ -710,6 +799,14 @@ class OneStepApp:
             )
         return task
 
+    def _require_manual_run_task(self, task_name: str) -> TaskSpec:
+        task = self._require_controllable_task(task_name)
+        if not self._task_supports_manual_run(task):
+            raise ValueError(
+                f"task {task_name} does not support manual run with the configured source"
+            )
+        return task
+
     def _task_supports_dead_letter_discard(self, task: TaskSpec) -> bool:
         return len(task.dead_letter_sinks) == 1 and isinstance(task.dead_letter_sinks[0], Source)
 
@@ -719,6 +816,9 @@ class OneStepApp:
             and isinstance(task.source, Sink)
             and self._task_supports_dead_letter_discard(task)
         )
+
+    def _task_supports_manual_run(self, task: TaskSpec) -> bool:
+        return task.source is not None and bool(getattr(task.source, "supports_manual_run", False))
 
     def _build_dead_letter_replay_envelope(self, dead_letter_envelope: Envelope) -> Envelope:
         if not isinstance(dead_letter_envelope.body, Mapping):

--- a/src/onestep/connectors/base.py
+++ b/src/onestep/connectors/base.py
@@ -34,6 +34,7 @@ class Delivery(abc.ABC):
 class Source(abc.ABC):
     batch_size: int = 1
     poll_interval_s: float = 1.0
+    supports_manual_run: bool = False
 
     def __init__(self, name: str) -> None:
         self.name = name

--- a/src/onestep/connectors/memory.py
+++ b/src/onestep/connectors/memory.py
@@ -32,6 +32,8 @@ class MemoryDelivery(Delivery):
 
 
 class MemoryQueue(Source, Sink):
+    supports_manual_run = True
+
     def __init__(
         self,
         name: str,

--- a/src/onestep/connectors/schedule.py
+++ b/src/onestep/connectors/schedule.py
@@ -63,6 +63,8 @@ class ScheduleDelivery(Delivery):
 
 
 class BaseScheduleSource(Source):
+    supports_manual_run = True
+
     def __init__(
         self,
         name: str,

--- a/src/onestep/control_plane_ws.py
+++ b/src/onestep/control_plane_ws.py
@@ -39,6 +39,7 @@ DEFAULT_COMMAND_CAPABILITIES = [
     "command.resume_task",
     "command.discard_dead_letters",
     "command.replay_dead_letters",
+    "command.run_task_once",
     "command.sync_now",
     "command.flush_metrics",
     "command.flush_events",
@@ -732,6 +733,11 @@ class ControlPlaneWsSender:
                 self._app is not None
                 and self._app.supports_dead_letter_replay_commands()
             )
+        if kind == "run_task_once":
+            return (
+                self._app is not None
+                and self._app.supports_manual_run_commands()
+            )
         if kind in {"shutdown", "restart", "drain", "pause_task", "resume_task"}:
             return self._app is not None
         if kind in {"sync_now", "flush_metrics", "flush_events"}:
@@ -792,6 +798,12 @@ class ControlPlaneWsSender:
             task_name = _require_task_name_arg(command)
             replay_limit = _require_positive_int_arg(command, "limit", default=10)
             return await self._app.replay_task_dead_letters(task_name, limit=replay_limit)
+        if command.kind == "run_task_once":
+            if self._app is None:
+                raise RuntimeError("app is not bound")
+            task_name = _require_task_name_arg(command)
+            payload = _require_json_object_arg(command, "payload")
+            return await self._app.run_task_once(task_name, payload=payload)
         if self._reporter is None:
             raise RuntimeError("reporter is not bound")
         if command.kind == "sync_now":
@@ -1079,6 +1091,13 @@ def _require_positive_int_arg(command: AgentCommand, key: str, *, default: int |
     value = command.args.get(key, default)
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
         raise ValueError(f"command args.{key} must be a positive integer")
+    return value
+
+
+def _require_json_object_arg(command: AgentCommand, key: str) -> dict[str, Any]:
+    value = command.args.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"command args.{key} must be a JSON object")
     return value
 
 

--- a/tests/contract/test_runtime_contract.py
+++ b/tests/contract/test_runtime_contract.py
@@ -603,6 +603,41 @@ def test_discard_task_dead_letters_acknowledges_dead_letter_batch() -> None:
     asyncio.run(scenario())
 
 
+def test_run_task_once_executes_generic_manual_delivery_contract() -> None:
+    async def scenario() -> None:
+        source = MemoryQueue("incoming", poll_interval_s=0.01)
+        sink = MemoryQueue("processed", poll_interval_s=0.01)
+        app = OneStepApp("manual-run-contract")
+
+        @app.task(source=source, emit=sink)
+        async def consume(ctx, item):
+            return {
+                "value": item["value"] + 1,
+                "manual_run": bool(ctx.delivery.envelope.meta.get("manual_run")),
+            }
+
+        await app.startup()
+        result = await app.run_task_once("consume", payload={"value": 9})
+        processed = await sink.fetch(1)
+        await app.shutdown()
+
+        assert result == {
+            "operation": "run_task_once",
+            "task_name": "consume",
+            "requested": True,
+            "completion": "complete",
+            "attempted_count": 1,
+            "manual_run": True,
+        }
+        assert len(processed) == 1
+        assert processed[0].payload == {
+            "value": 10,
+            "manual_run": True,
+        }
+
+    asyncio.run(scenario())
+
+
 def test_task_events_and_metrics_for_success_and_timeout_dead_letter() -> None:
     async def scenario() -> None:
         source = MemoryQueue("incoming", poll_interval_s=0.01)

--- a/tests/test_control_plane_reporter.py
+++ b/tests/test_control_plane_reporter.py
@@ -187,6 +187,7 @@ def test_reporter_heartbeat_includes_task_control_states() -> None:
             "supported_commands": [
                 "pause_task",
                 "resume_task",
+                "run_task_once",
             ],
             "pause_requested": True,
             "paused": True,

--- a/tests/test_control_plane_ws.py
+++ b/tests/test_control_plane_ws.py
@@ -321,6 +321,57 @@ def test_ws_sender_advertises_dead_letter_replay_only_for_compatible_tasks() -> 
     assert "command.replay_dead_letters" in capabilities
 
 
+def test_ws_sender_advertises_run_task_once_only_for_manual_run_capable_tasks() -> None:
+    connection = FakeWsConnection(
+        initial_messages=[
+            {
+                "type": "hello_ack",
+                "message_id": "msg_server_1",
+                "sent_at": "2026-03-17T12:00:00Z",
+                "payload": {
+                    "session_id": "sess_server_1",
+                    "protocol_version": "1",
+                    "heartbeat_interval_s": 30,
+                    "accepted_capabilities": [
+                        "telemetry.sync",
+                        "telemetry.heartbeat",
+                        "command.run_task_once",
+                    ],
+                    "server_time": "2026-03-17T12:00:00Z",
+                },
+            }
+        ]
+    )
+
+    async def connect_factory(url: str, headers: dict[str, str], subprotocols: list[str]):
+        return connection
+
+    transport = ControlPlaneWsTransport(
+        base_url="https://control-plane.example.com",
+        token="secret-token",
+        connect_factory=connect_factory,
+    )
+    sender = ControlPlaneWsSender(_make_config(), transport=transport)
+    app = OneStepApp("billing-sync")
+    reporter = ControlPlaneReporter(_make_config(), sender=sender)
+    reporter.attach(app)
+    source = MemoryQueue("sync-users.incoming", batch_size=1, poll_interval_s=0.01)
+
+    @app.task(name="sync_users", source=source)
+    async def sync_users(ctx, item):
+        return item
+
+    async def scenario() -> None:
+        await app.startup()
+        await app.shutdown()
+
+    asyncio.run(scenario())
+
+    hello_message = connection.sent_messages[0]
+    capabilities = hello_message["payload"]["capabilities"]
+    assert "command.run_task_once" in capabilities
+
+
 def test_ws_sender_executes_sync_now_command_over_active_session() -> None:
     connection = FakeWsConnection(
         initial_messages=[
@@ -896,6 +947,186 @@ def test_ws_sender_executes_discard_dead_letters_command() -> None:
         "failed_count": 0,
         "empty": False,
     }
+
+
+def test_ws_sender_executes_run_task_once_command() -> None:
+    connection = FakeWsConnection(
+        initial_messages=[
+            {
+                "type": "hello_ack",
+                "message_id": "msg_server_1",
+                "sent_at": "2026-03-17T12:00:00Z",
+                "payload": {
+                    "session_id": "sess_server_1",
+                    "protocol_version": "1",
+                    "heartbeat_interval_s": 30,
+                    "accepted_capabilities": [
+                        "telemetry.sync",
+                        "telemetry.heartbeat",
+                        "command.run_task_once",
+                    ],
+                    "server_time": "2026-03-17T12:00:00Z",
+                },
+            }
+        ]
+    )
+
+    async def connect_factory(url: str, headers: dict[str, str], subprotocols: list[str]):
+        return connection
+
+    transport = ControlPlaneWsTransport(
+        base_url="https://control-plane.example.com",
+        token="secret-token",
+        connect_factory=connect_factory,
+    )
+    app = OneStepApp("billing-sync")
+    source = MemoryQueue("sync-users.incoming", batch_size=1, poll_interval_s=0.01)
+    sink = MemoryQueue("sync-users.processed", batch_size=1, poll_interval_s=0.01)
+    sender = ControlPlaneWsSender(_make_config(), transport=transport)
+    reporter = ControlPlaneReporter(_make_config(), sender=sender)
+    reporter.attach(app)
+
+    @app.task(name="sync_users", source=source, emit=sink)
+    async def sync_users(ctx, item):
+        return {"value": item["value"] * 2}
+
+    async def scenario() -> None:
+        await app.startup()
+        connection.queue_message(
+            {
+                "type": "command",
+                "message_id": "msg_command_run_task_once",
+                "sent_at": "2026-03-17T12:00:02Z",
+                "payload": {
+                    "command_id": "cmd_run_task_once",
+                    "kind": "run_task_once",
+                    "args": {
+                        "task_name": "sync_users",
+                        "payload": {"value": 21},
+                    },
+                    "timeout_s": 30,
+                    "created_at": "2026-03-17T12:00:02Z",
+                },
+            }
+        )
+        for _ in range(50):
+            if any(
+                message["type"] == "command_result"
+                and message["payload"]["command_id"] == "cmd_run_task_once"
+                for message in connection.sent_messages
+            ):
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("run_task_once command_result was not sent")
+        processed = await sink.fetch(1)
+        assert len(processed) == 1
+        assert processed[0].payload == {"value": 42}
+        await app.shutdown()
+
+    asyncio.run(scenario())
+
+    ack_message = next(message for message in connection.sent_messages if message["type"] == "command_ack")
+    result_message = next(
+        message
+        for message in connection.sent_messages
+        if message["type"] == "command_result"
+        and message["payload"]["command_id"] == "cmd_run_task_once"
+    )
+    assert ack_message["payload"]["status"] == "accepted"
+    assert result_message["payload"]["status"] == "succeeded"
+    assert result_message["payload"]["result"] == {
+        "operation": "run_task_once",
+        "task_name": "sync_users",
+        "requested": True,
+        "completion": "complete",
+        "attempted_count": 1,
+        "manual_run": True,
+    }
+
+
+def test_ws_sender_rejects_run_task_once_with_non_object_payload() -> None:
+    connection = FakeWsConnection(
+        initial_messages=[
+            {
+                "type": "hello_ack",
+                "message_id": "msg_server_1",
+                "sent_at": "2026-03-17T12:00:00Z",
+                "payload": {
+                    "session_id": "sess_server_1",
+                    "protocol_version": "1",
+                    "heartbeat_interval_s": 30,
+                    "accepted_capabilities": [
+                        "telemetry.sync",
+                        "telemetry.heartbeat",
+                        "command.run_task_once",
+                    ],
+                    "server_time": "2026-03-17T12:00:00Z",
+                },
+            }
+        ]
+    )
+
+    async def connect_factory(url: str, headers: dict[str, str], subprotocols: list[str]):
+        return connection
+
+    transport = ControlPlaneWsTransport(
+        base_url="https://control-plane.example.com",
+        token="secret-token",
+        connect_factory=connect_factory,
+    )
+    app = OneStepApp("billing-sync")
+    source = MemoryQueue("sync-users.incoming", batch_size=1, poll_interval_s=0.01)
+    sender = ControlPlaneWsSender(_make_config(), transport=transport)
+    reporter = ControlPlaneReporter(_make_config(), sender=sender)
+    reporter.attach(app)
+
+    @app.task(name="sync_users", source=source)
+    async def sync_users(ctx, item):
+        return item
+
+    async def scenario() -> None:
+        await app.startup()
+        connection.queue_message(
+            {
+                "type": "command",
+                "message_id": "msg_command_run_task_once_invalid",
+                "sent_at": "2026-03-17T12:00:02Z",
+                "payload": {
+                    "command_id": "cmd_run_task_once_invalid",
+                    "kind": "run_task_once",
+                    "args": {
+                        "task_name": "sync_users",
+                        "payload": ["invalid"],
+                    },
+                    "timeout_s": 30,
+                    "created_at": "2026-03-17T12:00:02Z",
+                },
+            }
+        )
+        for _ in range(50):
+            if any(
+                message["type"] == "command_result"
+                and message["payload"]["command_id"] == "cmd_run_task_once_invalid"
+                for message in connection.sent_messages
+            ):
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise AssertionError("run_task_once invalid command_result was not sent")
+        await app.shutdown()
+
+    asyncio.run(scenario())
+
+    result_message = next(
+        message
+        for message in connection.sent_messages
+        if message["type"] == "command_result"
+        and message["payload"]["command_id"] == "cmd_run_task_once_invalid"
+    )
+    assert result_message["payload"]["status"] == "failed"
+    assert result_message["payload"]["error_code"] == "command_execution_failed"
+    assert "command args.payload must be a JSON object" in result_message["payload"]["error_message"]
 
 
 def test_ws_transport_reports_timeout_for_slow_command() -> None:


### PR DESCRIPTION
## Summary
- add manual task execution support through OneStepApp.run_task_once
- expose run_task_once as a control plane websocket command when a source supports manual runs
- cover runtime contract and websocket command behavior with tests

## Tests
- Not run in this session