### PR TITLE
feat: expose succeeded notification metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,47 @@ print(snapshot["kinds"])
 - `duration_s`
 - `failure_kind`
 
+Tasks can also opt into webhook-friendly success metadata by returning a reserved `notification` object. The task return value sent to sinks stays unchanged; only the emitted `succeeded` event gains `meta["notification"]`.
+
+```python
+from onestep import MemoryQueue, OneStepApp, StructuredEventLogger
+
+source = MemoryQueue("incoming")
+app = OneStepApp("notification-demo")
+app.on_event(StructuredEventLogger())
+
+
+@app.task(source=source)
+async def sync_status(ctx, item):
+    updated = item["updated"]
+    ctx.app.request_shutdown()
+    return {
+        "success": True,
+        "updated": updated,
+        "notification": {
+            "summary": f"Status sync complete, updated {updated} devices",
+            "metrics": [
+                {"label": "Updated", "value": updated},
+            ],
+        },
+    }
+```
+
+The emitted `TaskEventKind.SUCCEEDED` metadata then includes:
+
+```json
+{
+  "notification": {
+    "summary": "Status sync complete, updated 12 devices",
+    "metrics": [
+      {"label": "Updated", "value": 12}
+    ]
+  }
+}
+```
+
+`notification` values must be JSON-safe. Invalid values are dropped from the emitted metadata instead of failing task execution.
+
 ## Memory Queue Example
 
 ```python

--- a/example/control_plane_reporter_demo.py
+++ b/example/control_plane_reporter_demo.py
@@ -154,6 +154,13 @@ async def process_job(ctx, item) -> dict[str, object]:
         "job_id": job_id,
         "behavior": behavior,
         "status": "processed",
+        "notification": {
+            "summary": f"Processed demo job {job_id} ({behavior})",
+            "metrics": [
+                {"label": "Job ID", "value": job_id},
+                {"label": "Behavior", "value": behavior},
+            ],
+        },
     }
 
 

--- a/src/onestep/runtime/runner.py
+++ b/src/onestep/runtime/runner.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 import copy
 import inspect
 import logging
+import math
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from onestep.context import TaskContext
 from onestep.envelope import Envelope
@@ -18,6 +20,9 @@ from onestep.task import TaskSpec
 if TYPE_CHECKING:
     from onestep.app import OneStepApp
     from onestep.connectors.base import Delivery
+
+
+_INVALID_NOTIFICATION_VALUE = object()
 
 
 class TaskRunner:
@@ -234,10 +239,12 @@ class TaskRunner:
                 for sink in self.task.sinks:
                     await self._send_to_sink(sink, envelope)
             await delivery.ack()
+            event_meta = self._build_succeeded_event_meta(delivery, result)
             await self._emit_event(
                 TaskEventKind.SUCCEEDED,
                 delivery,
                 duration_s=time.perf_counter() - started_at,
+                event_meta=event_meta,
             )
         except asyncio.CancelledError:
             failure = FailureInfo.from_exception(asyncio.CancelledError(), kind=FailureKind.CANCELLED)
@@ -426,6 +433,7 @@ class TaskRunner:
         *,
         duration_s: float | None = None,
         failure: FailureInfo | None = None,
+        event_meta: dict[str, Any] | None = None,
     ) -> None:
         event = TaskEvent(
             kind=kind,
@@ -435,6 +443,49 @@ class TaskRunner:
             attempts=delivery.envelope.attempts,
             duration_s=duration_s,
             failure=failure,
-            meta=copy.deepcopy(delivery.envelope.meta),
+            meta=copy.deepcopy(event_meta) if event_meta is not None else copy.deepcopy(delivery.envelope.meta),
         )
         await self.app.emit_event(event)
+
+    def _build_succeeded_event_meta(self, delivery: "Delivery", result: Any) -> dict[str, Any]:
+        event_meta = copy.deepcopy(delivery.envelope.meta)
+        notification = self._extract_notification_payload(result)
+        if notification is not None:
+            event_meta["notification"] = notification
+        return event_meta
+
+    def _extract_notification_payload(self, result: Any) -> dict[str, Any] | None:
+        if not isinstance(result, Mapping):
+            return None
+        notification = result.get("notification")
+        if not isinstance(notification, Mapping):
+            return None
+        sanitized = self._sanitize_notification_value(notification)
+        if not isinstance(sanitized, dict) or not sanitized:
+            return None
+        return sanitized
+
+    def _sanitize_notification_value(self, value: Any) -> Any:
+        if value is None or isinstance(value, (str, bool, int)):
+            return value
+        if isinstance(value, float):
+            return value if math.isfinite(value) else _INVALID_NOTIFICATION_VALUE
+        if isinstance(value, Mapping):
+            sanitized: dict[str, Any] = {}
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    continue
+                clean_item = self._sanitize_notification_value(item)
+                if clean_item is _INVALID_NOTIFICATION_VALUE:
+                    continue
+                sanitized[key] = clean_item
+            return sanitized
+        if isinstance(value, (list, tuple)):
+            sanitized_items = []
+            for item in value:
+                clean_item = self._sanitize_notification_value(item)
+                if clean_item is _INVALID_NOTIFICATION_VALUE:
+                    continue
+                sanitized_items.append(clean_item)
+            return sanitized_items
+        return _INVALID_NOTIFICATION_VALUE

--- a/tests/contract/test_runtime_contract.py
+++ b/tests/contract/test_runtime_contract.py
@@ -687,6 +687,104 @@ def test_task_events_and_metrics_for_success_and_timeout_dead_letter() -> None:
     asyncio.run(scenario())
 
 
+def test_succeeded_event_includes_notification_metadata_when_task_returns_it() -> None:
+    async def scenario() -> None:
+        source = MemoryQueue("incoming", poll_interval_s=0.01)
+        captured = []
+        app = OneStepApp("events-app")
+
+        @app.on_event
+        def observe(event):
+            captured.append(event)
+
+        @app.on_startup
+        async def seed(app):
+            await source.publish({"kind": "ok"})
+
+        @app.task(source=source)
+        async def consume(ctx, item):
+            ctx.app.request_shutdown()
+            return {
+                "done": True,
+                "notification": {
+                    "summary": "processed one item",
+                    "metrics": [
+                        {"label": "processed", "value": 1},
+                    ],
+                },
+            }
+
+        await asyncio.wait_for(app.serve(), timeout=1.0)
+
+        succeeded = [event for event in captured if event.kind is TaskEventKind.SUCCEEDED]
+        assert len(succeeded) == 1
+        assert succeeded[0].meta == {
+            "notification": {
+                "summary": "processed one item",
+                "metrics": [
+                    {"label": "processed", "value": 1},
+                ],
+            }
+        }
+
+    asyncio.run(scenario())
+
+
+def test_succeeded_event_ignores_or_sanitizes_invalid_notification_payload() -> None:
+    async def scenario() -> None:
+        source = MemoryQueue("incoming", poll_interval_s=0.01)
+        captured = []
+        app = OneStepApp("notification-sanitize")
+
+        @app.on_event
+        def observe(event):
+            captured.append(event)
+
+        @app.on_startup
+        async def seed(app):
+            await source.publish({"kind": "invalid"})
+
+        @app.task(source=source)
+        async def consume(ctx, item):
+            ctx.app.request_shutdown()
+            return {
+                "done": True,
+                "notification": {
+                    "summary": "processed one item",
+                    "metrics": [
+                        {"label": "processed", "value": 1, "extra": object()},
+                        {"label": "ratio", "value": float("nan")},
+                        object(),
+                    ],
+                    "details": {
+                        "kept": True,
+                        "dropped": object(),
+                        1: "not-a-string-key",
+                    },
+                    "bad_root_value": object(),
+                },
+            }
+
+        await asyncio.wait_for(app.serve(), timeout=1.0)
+
+        succeeded = [event for event in captured if event.kind is TaskEventKind.SUCCEEDED]
+        assert len(succeeded) == 1
+        assert succeeded[0].meta == {
+            "notification": {
+                "summary": "processed one item",
+                "metrics": [
+                    {"label": "processed", "value": 1},
+                    {"label": "ratio"},
+                ],
+                "details": {
+                    "kept": True,
+                },
+            }
+        }
+
+    asyncio.run(scenario())
+
+
 def test_structured_event_logger_emits_uniform_log_fields() -> None:
     class ListHandler(logging.Handler):
         def __init__(self) -> None:

--- a/tests/test_control_plane_reporter.py
+++ b/tests/test_control_plane_reporter.py
@@ -340,6 +340,51 @@ def test_reporter_drops_oldest_events_when_pending_buffer_overflows() -> None:
     assert [event["attempts"] for event in events_payload["events"]] == [2, 3]
 
 
+def test_reporter_preserves_notification_metadata_in_event_payload() -> None:
+    recorder = SenderRecorder()
+    app = OneStepApp("billing-sync")
+    reporter = ControlPlaneReporter(_make_config(), sender=recorder)
+    reporter.attach(app)
+
+    async def scenario() -> None:
+        await app.startup()
+        await app.emit_event(
+            TaskEvent(
+                kind=TaskEventKind.SUCCEEDED,
+                app=app.name,
+                task="sync_users",
+                source="interval:3600s",
+                attempts=0,
+                duration_s=0.2,
+                meta={
+                    "trace_id": "trace-1",
+                    "notification": {
+                        "summary": "sync complete",
+                        "metrics": [
+                            {"label": "updated", "value": 12},
+                        ],
+                    },
+                },
+            )
+        )
+        await reporter._flush_event_batches()
+        await app.shutdown()
+
+    asyncio.run(scenario())
+
+    events_payload = next(payload for channel, payload in recorder.calls if channel == "events")
+    assert events_payload["events"][0]["meta"] == {
+        "trace_id": "trace-1",
+        "notification": {
+            "summary": "sync complete",
+            "metrics": [
+                {"label": "updated", "value": 12},
+            ],
+        },
+        "source": "interval:3600s",
+    }
+
+
 def test_reporter_drops_oldest_metric_batches_when_pending_buffer_overflows() -> None:
     recorder = SenderRecorder()
     config = _make_config()


### PR DESCRIPTION
## Summary
- expose a reserved task return `notification` object on `TaskEventKind.SUCCEEDED` as `meta.notification`
- sanitize notification payloads to JSON-safe values without changing sink or hook behavior
- document the convention and cover runtime and reporter flow with tests

## Testing
- `pytest tests/contract/test_runtime_contract.py tests/test_control_plane_reporter.py`

Closes #58
