### PR TITLE
Make control-plane websocket dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Common extras:
 - `pip install 'onestep[rabbitmq]'`
 - `pip install 'onestep[redis]'`
 - `pip install 'onestep[sqs]'`
+- `pip install 'onestep[control-plane]'`
 - `pip install 'onestep[all]'`
 
 From a source checkout:
@@ -277,6 +278,12 @@ The deploy template prepends `APP_CWD` to `PYTHONPATH` so module targets defined
 
 `onestep` can push runtime telemetry to `onestep-control-plane` over a single long-lived
 WebSocket session without adding a new connector or changing task code.
+
+Install the optional control-plane dependency before using the reporter:
+
+```bash
+pip install 'onestep[control-plane]'
+```
 
 The YAML form is intentionally minimal:
 

--- a/docs/yaml-task-definition.md
+++ b/docs/yaml-task-definition.md
@@ -206,6 +206,10 @@ tasks:
 
 Use the built-in reporter only when you need control-plane telemetry. Start with the smallest shape:
 
+```bash
+pip install 'onestep[control-plane]'
+```
+
 ```yaml
 reporter: true
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,12 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: System :: Distributed Computing",
 ]
-dependencies = [
-    "websockets>=12.0",
-]
+dependencies = []
 
 [project.optional-dependencies]
+control-plane = [
+    "websockets>=12.0",
+]
 yaml = [
     "PyYAML>=6.0",
 ]
@@ -59,6 +60,7 @@ integration = [
     "PyMySQL>=1.1.0",
 ]
 all = [
+    "websockets>=12.0",
     "PyYAML>=6.0",
     "SQLAlchemy>=2.0.0",
     "PyMySQL>=1.1.0",
@@ -67,6 +69,7 @@ all = [
     "redis>=4.2.0",
 ]
 dev = [
+    "websockets>=12.0",
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "PyYAML>=6.0",

--- a/src/onestep/control_plane_ws.py
+++ b/src/onestep/control_plane_ws.py
@@ -216,8 +216,9 @@ async def _default_connect_factory(
             from websockets.client import connect as ws_connect
         except ImportError as exc:  # pragma: no cover - exercised via dependency error path
             raise RuntimeError(
-                "websockets is required for WS control plane transport; install it before "
-                "using ControlPlaneWsTransport"
+                "websockets is required for OneStep control-plane WebSocket support. "
+                "Install it with `pip install 'onestep[control-plane]'` before using "
+                "ControlPlaneWsTransport or ControlPlaneReporter."
             ) from exc
         connection = await ws_connect(
             url,

--- a/tests/test_control_plane_ws.py
+++ b/tests/test_control_plane_ws.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 import json
 import logging
 from dataclasses import dataclass, field
@@ -19,6 +20,7 @@ from onestep import (
     build_control_plane_http_base_url,
     build_control_plane_ws_url,
 )
+from onestep.control_plane_ws import _default_connect_factory
 
 
 def _make_config() -> ControlPlaneReporterConfig:
@@ -93,6 +95,31 @@ def test_build_control_plane_urls_handle_prefixed_ws_endpoints() -> None:
         build_control_plane_http_base_url("wss://control-plane.example.com/control/api/v1/agents/ws")
         == "https://control-plane.example.com/control"
     )
+
+
+def test_default_ws_connect_factory_reports_missing_optional_dependency(monkeypatch) -> None:
+    original_import = builtins.__import__
+
+    def missing_websockets_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "websockets" or name.startswith("websockets."):
+            raise ImportError("No module named 'websockets'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", missing_websockets_import)
+
+    async def scenario() -> None:
+        with pytest.raises(RuntimeError) as exc_info:
+            await _default_connect_factory(
+                "wss://control-plane.example.com/api/v1/agents/ws",
+                {"Authorization": "Bearer secret-token"},
+                ["onestep-agent.v1"],
+            )
+        message = str(exc_info.value)
+        assert "websockets is required for OneStep control-plane WebSocket support" in message
+        assert "pip install 'onestep[control-plane]'" in message
+        assert "ControlPlaneReporter" in message
+
+    asyncio.run(scenario())
 
 
 def test_ws_transport_connect_sends_hello_and_parses_hello_ack() -> None:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+PYPROJECT_PATH = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _read_array(section: str, key: str) -> list[str]:
+    lines = PYPROJECT_PATH.read_text(encoding="utf-8").splitlines()
+    in_section = False
+    collecting = False
+    collected: list[str] = []
+    prefix = f"{key} = "
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_section = stripped == section
+            if collecting:
+                break
+            continue
+        if not in_section:
+            continue
+        if not collecting and stripped.startswith(prefix):
+            raw_value = stripped.removeprefix(prefix).strip()
+            if raw_value.endswith("]"):
+                return ast.literal_eval(raw_value)
+            collecting = True
+            collected.append(raw_value)
+            continue
+        if collecting:
+            collected.append(stripped)
+            if stripped == "]":
+                return ast.literal_eval("\n".join(collected))
+
+    raise AssertionError(f"did not find {key!r} in {section}")
+
+
+def test_websockets_is_control_plane_optional_dependency_only() -> None:
+    dependencies = _read_array("[project]", "dependencies")
+    control_plane = _read_array("[project.optional-dependencies]", "control-plane")
+    all_extra = _read_array("[project.optional-dependencies]", "all")
+    dev_extra = _read_array("[project.optional-dependencies]", "dev")
+    test_extra = _read_array("[project.optional-dependencies]", "test")
+
+    assert all("websockets" not in dependency for dependency in dependencies)
+    assert control_plane == ["websockets>=12.0"]
+    assert "websockets>=12.0" in all_extra
+    assert "websockets>=12.0" in dev_extra
+    assert "websockets>=12.0" not in test_extra
+
+
+def test_core_import_path_does_not_require_websockets() -> None:
+    script = """
+import builtins
+
+original_import = builtins.__import__
+
+def missing_websockets_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "websockets" or name.startswith("websockets."):
+        raise ImportError("No module named 'websockets'")
+    return original_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = missing_websockets_import
+
+from onestep import MemoryQueue, OneStepApp
+
+app = OneStepApp("core-only")
+queue = MemoryQueue("core.queue")
+assert app.name == "core-only"
+assert queue.name == "core.queue"
+"""
+    repo_root = PYPROJECT_PATH.parent
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(repo_root / "src"),
+    }
+    subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        cwd=repo_root,
+        env=env,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -451,10 +451,6 @@ wheels = [
 name = "onestep"
 version = "1.2.4"
 source = { editable = "." }
-dependencies = [
-    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-]
 
 [package.optional-dependencies]
 all = [
@@ -466,6 +462,12 @@ all = [
     { name = "redis", version = "7.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "redis", version = "7.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "sqlalchemy" },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+control-plane = [
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 dev = [
     { name = "aio-pika", version = "9.5.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -480,6 +482,8 @@ dev = [
     { name = "redis", version = "7.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "redis", version = "7.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "sqlalchemy" },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 integration = [
     { name = "aio-pika", version = "9.5.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -556,9 +560,11 @@ requires-dist = [
     { name = "sqlalchemy", marker = "extra == 'integration'", specifier = ">=2.0.0" },
     { name = "sqlalchemy", marker = "extra == 'mysql'", specifier = ">=2.0.0" },
     { name = "sqlalchemy", marker = "extra == 'test'", specifier = ">=2.0.0" },
-    { name = "websockets", specifier = ">=12.0" },
+    { name = "websockets", marker = "extra == 'all'", specifier = ">=12.0" },
+    { name = "websockets", marker = "extra == 'control-plane'", specifier = ">=12.0" },
+    { name = "websockets", marker = "extra == 'dev'", specifier = ">=12.0" },
 ]
-provides-extras = ["yaml", "mysql", "rabbitmq", "redis", "sqs", "test", "integration", "all", "dev"]
+provides-extras = ["control-plane", "yaml", "mysql", "rabbitmq", "redis", "sqs", "test", "integration", "all", "dev"]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
## Summary
- move `websockets` out of core dependencies into a new `control-plane` extra
- keep `websockets` in `all` and `dev`, but not in `test`
- improve the missing dependency message for control-plane WS usage
- document the optional install path for reporter/control-plane users
- add tests for core import without `websockets`, packaging metadata, and missing dependency messaging

## Tests
- `python -m pytest tests/test_packaging.py tests/test_control_plane_ws.py::test_default_ws_connect_factory_reports_missing_optional_dependency tests/test_cli.py::test_cli_check_json_supports_factory_targets tests/test_cli.py::test_yaml_target_attaches_reporter_from_env`
- `python -m pytest tests/test_packaging.py tests/test_control_plane_ws.py tests/test_control_plane_reporter.py tests/test_control_plane_reconnect.py tests/test_runtime_identity.py tests/test_cli.py -q`
- `uv sync --frozen --extra test`
- `uv run --extra test python - <<'PY' ... importlib.util.find_spec('websockets') ... PY` returned `None`
- `uv run --extra test pytest -q -m "not integration"`

Closes #60