### PR TITLE
Preserve schedule timezone names in reporter

### DIFF
--- a/src/onestep/connectors/schedule.py
+++ b/src/onestep/connectors/schedule.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import heapq
+import os
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone, tzinfo
@@ -85,6 +86,7 @@ class BaseScheduleSource(Source):
         self.overlap = overlap
         resolved_timezone = timezone if timezone is not None else timezone_name
         self.timezone = resolve_timezone(resolved_timezone)
+        self.timezone_name = resolve_timezone_name(resolved_timezone)
         self.poll_interval_s = max(0.01, poll_interval_s)
         self._clock = clock or self._default_now
         self._initialized = False
@@ -410,6 +412,7 @@ class CronSchedule:
         self.expression = normalized
         resolved_timezone = timezone if timezone is not None else timezone_name
         self.timezone = resolve_timezone(resolved_timezone)
+        self.timezone_name = resolve_timezone_name(resolved_timezone)
         self.minute = CronField(fields[0], minimum=0, maximum=59)
         self.hour = CronField(fields[1], minimum=0, maximum=23)
         self.day_of_month = CronField(fields[2], minimum=1, maximum=31)
@@ -502,6 +505,18 @@ def resolve_timezone(value: str | tzinfo | None) -> tzinfo:
     if isinstance(value, str):
         return ZoneInfo(value)
     return datetime.now().astimezone().tzinfo or timezone.utc
+
+
+def resolve_timezone_name(value: str | tzinfo | None) -> str:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    key = getattr(value, "key", None)
+    if isinstance(key, str) and key.strip():
+        return key.strip()
+    env_timezone = os.environ.get("TZ", "").strip()
+    if env_timezone:
+        return env_timezone
+    return str(resolve_timezone(value))
 
 
 __all__ = [

--- a/src/onestep/reporter.py
+++ b/src/onestep/reporter.py
@@ -717,7 +717,7 @@ class ControlPlaneReporter:
                 "seconds": _seconds_value(resource.interval.total_seconds()),
                 "immediate": resource.immediate,
                 "overlap": resource.overlap,
-                "timezone": str(resource.timezone),
+                "timezone": resource.timezone_name,
                 "poll_interval_s": resource.poll_interval_s,
             }
         if class_name == "CronSource":
@@ -725,7 +725,7 @@ class ControlPlaneReporter:
                 "expression": resource.schedule.expression,
                 "immediate": resource.immediate,
                 "overlap": resource.overlap,
-                "timezone": str(resource.timezone),
+                "timezone": resource.timezone_name,
                 "poll_interval_s": resource.poll_interval_s,
             }
         if class_name == "MemoryQueue":

--- a/tests/test_control_plane_reporter.py
+++ b/tests/test_control_plane_reporter.py
@@ -131,7 +131,7 @@ def test_reporter_sync_payload_includes_task_topology() -> None:
                     "seconds": 3600,
                     "immediate": True,
                     "overlap": "skip",
-                    "timezone": str(source.timezone),
+                    "timezone": source.timezone_name,
                     "poll_interval_s": source.poll_interval_s,
                 },
             },
@@ -157,6 +157,29 @@ def test_reporter_sync_payload_includes_task_topology() -> None:
             },
         }
     ]
+
+
+def test_reporter_sync_payload_uses_tz_environment_name_for_schedule_timezone(monkeypatch) -> None:
+    monkeypatch.setenv("TZ", "Asia/Shanghai")
+    recorder = SenderRecorder()
+    source = IntervalSource.every(hours=1)
+    app = OneStepApp("billing-sync")
+
+    @app.task(source=source)
+    async def sync_users(ctx, payload):
+        return payload
+
+    reporter = ControlPlaneReporter(_make_config(), sender=recorder)
+    reporter.attach(app)
+
+    async def scenario() -> None:
+        await app.startup()
+        await app.shutdown()
+
+    asyncio.run(scenario())
+
+    sync_payload = [payload for channel, payload in recorder.calls if channel == "sync"][0]
+    assert sync_payload["app"]["tasks"][0]["source"]["config"]["timezone"] == "Asia/Shanghai"
 
 
 def test_reporter_heartbeat_includes_task_control_states() -> None:


### PR DESCRIPTION
Refs #62

Preserve a stable schedule timezone name when reporting cron/interval sources so control-plane consumers can round-trip TZ-derived deployments like Asia/Shanghai.

Changes:
- keep a separate schedule timezone name on sources
- report that name instead of a tzinfo string in topology sync payloads
- add regression coverage for TZ=Asia/Shanghai

Tests:
- uv run pytest tests/test_control_plane_reporter.py tests/test_schedule_sources.py