### PR TITLE
Add HTTP sink and passthrough YAML tasks

### DIFF
--- a/src/onestep/__init__.py
+++ b/src/onestep/__init__.py
@@ -38,6 +38,7 @@ from .retry import (
 from .state import CursorStore, InMemoryCursorStore, InMemoryStateStore, ScopedState, StateStore
 from .state_sqlalchemy import SQLAlchemyCursorStore, SQLAlchemyStateStore
 from .connectors.base import Delivery, Sink, Source
+from .connectors.http import HttpSink, HttpSinkStatusError
 from .connectors.memory import MemoryQueue
 from .connectors.mysql import MySQLConnector
 from .connectors.rabbitmq import RabbitMQConnector
@@ -68,6 +69,8 @@ __all__ = [
     "Envelope",
     "FailureInfo",
     "FailureKind",
+    "HttpSink",
+    "HttpSinkStatusError",
     "IdentityLockError",
     "IdentityStateError",
     "IdentityStore",

--- a/src/onestep/config.py
+++ b/src/onestep/config.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from .app import OneStepApp
 from .connectors.base import Sink, Source
+from .connectors.http import HttpSink
 from .connectors.memory import MemoryQueue
 from .connectors.mysql import MySQLConnector
 from .connectors.rabbitmq import RabbitMQConnector
@@ -116,6 +117,9 @@ _STRICT_RESOURCE_FIELDS: dict[str, frozenset[str]] = {
             "batch_size",
             "poll_interval_s",
         }
+    ),
+    "http_sink": frozenset(
+        {"type", "name", "url", "method", "headers", "timeout_s", "success_statuses"}
     ),
     "rabbitmq": frozenset({"type", "url", "options"}),
     "rabbitmq_queue": frozenset(
@@ -309,18 +313,27 @@ def load_app_config(
         if not isinstance(task_config, Mapping):
             raise TypeError(f"'tasks[{index}]' must be a mapping")
         task_name = _optional_string(task_config, "name")
-        handler, handler_ref = _build_handler(task_config.get("handler"), task_name=task_name)
+        source = _resolve_optional_source(resources, task_config.get("source"), task_index=index)
+        emit = _resolve_optional_sinks(resources, task_config.get("emit"), field="emit", task_index=index)
+        dead_letter = _resolve_optional_sinks(
+            resources,
+            task_config.get("dead_letter"),
+            field="dead_letter",
+            task_index=index,
+        )
+        handler, handler_ref = _build_task_handler(
+            task_config.get("handler"),
+            has_handler="handler" in task_config,
+            has_emit=bool(emit),
+            task_name=task_name,
+            task_index=index,
+        )
         app.task(
             name=task_name,
             description=_optional_string(task_config, "description"),
-            source=_resolve_optional_source(resources, task_config.get("source"), task_index=index),
-            emit=_resolve_optional_sinks(resources, task_config.get("emit"), field="emit", task_index=index),
-            dead_letter=_resolve_optional_sinks(
-                resources,
-                task_config.get("dead_letter"),
-                field="dead_letter",
-                task_index=index,
-            ),
+            source=source,
+            emit=emit,
+            dead_letter=dead_letter,
             config=_mapping_value(task_config.get("config"), field=f"tasks[{index}].config"),
             metadata=_mapping_value(task_config.get("metadata"), field=f"tasks[{index}].metadata"),
             handler_ref=handler_ref,
@@ -435,6 +448,15 @@ def _build_resource(name: str, spec: Mapping[str, Any], *, resolve: Callable[[st
             batch_size=spec.get("batch_size", 100),
             poll_interval_s=spec.get("poll_interval_s", 0.1),
             name=resource_name,
+        )
+    if resource_type == "http_sink":
+        return HttpSink(
+            resource_name,
+            url=_require_string(spec, "url"),
+            method=spec.get("method", "POST"),
+            headers=_mapping_value(spec.get("headers"), field=f"resources.{name}.headers"),
+            timeout_s=spec.get("timeout_s", 5.0),
+            success_statuses=spec.get("success_statuses"),
         )
     if resource_type == "rabbitmq":
         return RabbitMQConnector(
@@ -591,6 +613,29 @@ def _build_resource(name: str, spec: Mapping[str, Any], *, resolve: Callable[[st
         )
 
     raise ValueError(f"unsupported resource type {resource_type!r} for resource {name!r}")
+
+
+def _build_task_handler(
+    raw_handler: Any,
+    *,
+    has_handler: bool,
+    has_emit: bool,
+    task_name: str | None,
+    task_index: int,
+):
+    if has_handler:
+        return _build_handler(raw_handler, task_name=task_name)
+    if not has_emit:
+        raise ValueError(f"tasks[{task_index}] must define either 'handler' or 'emit'")
+    return _build_passthrough_handler(task_name), None
+
+
+def _build_passthrough_handler(task_name: str | None):
+    async def passthrough(ctx, payload):
+        return payload
+
+    passthrough.__name__ = task_name or "passthrough"
+    return passthrough
 
 
 def _build_handler(raw_handler: Any, *, task_name: str | None):
@@ -844,6 +889,8 @@ def _validate_resource_sections(config: Mapping[str, Any]) -> None:
             _validate_unknown_fields(raw_spec, allowed, field=field)
             if normalized_type == "webhook":
                 _validate_webhook_resource(raw_spec, field=field)
+            elif normalized_type == "http_sink":
+                _validate_http_sink_resource(raw_spec, field=field)
 
 
 def _validate_tasks(raw_tasks: Any) -> None:
@@ -856,7 +903,10 @@ def _validate_tasks(raw_tasks: Any) -> None:
             raise TypeError(f"'tasks[{index}]' must be a mapping")
         field = f"tasks[{index}]"
         _validate_unknown_fields(raw_task, _STRICT_TASK_FIELDS, field=field)
-        _validate_ref_entry(raw_task.get("handler"), field=f"{field}.handler")
+        if "handler" in raw_task:
+            _validate_ref_entry(raw_task.get("handler"), field=f"{field}.handler")
+        elif not _task_emit_configured(raw_task.get("emit")):
+            raise ValueError(f"{field} must define either 'handler' or 'emit'")
         _validate_hooks_config(
             raw_task.get("hooks"),
             field=f"{field}.hooks",
@@ -946,6 +996,40 @@ def _validate_webhook_resource(spec: Mapping[str, Any], *, field: str) -> None:
         if not isinstance(raw_response, Mapping):
             raise TypeError(f"'{field}.response' must be a mapping")
         _validate_unknown_fields(raw_response, _STRICT_WEBHOOK_RESPONSE_FIELDS, field=f"{field}.response")
+
+
+def _validate_http_sink_resource(spec: Mapping[str, Any], *, field: str) -> None:
+    _require_string(spec, "url")
+    if "method" in spec:
+        _string_value(spec.get("method"), field=f"{field}.method")
+    raw_headers = spec.get("headers")
+    if raw_headers is not None and not isinstance(raw_headers, Mapping):
+        raise TypeError(f"'{field}.headers' must be a mapping")
+    raw_timeout = spec.get("timeout_s")
+    if raw_timeout is not None:
+        if isinstance(raw_timeout, bool) or not isinstance(raw_timeout, (int, float)):
+            raise TypeError(f"'{field}.timeout_s' must be a number")
+        if raw_timeout <= 0:
+            raise ValueError(f"'{field}.timeout_s' must be > 0")
+    raw_success_statuses = spec.get("success_statuses")
+    if raw_success_statuses is not None:
+        if not isinstance(raw_success_statuses, Sequence) or isinstance(raw_success_statuses, (str, bytes)):
+            raise TypeError(f"'{field}.success_statuses' must be a list of integers")
+        if not raw_success_statuses:
+            raise ValueError(f"'{field}.success_statuses' must not be empty")
+        for index, status in enumerate(raw_success_statuses):
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise TypeError(f"'{field}.success_statuses[{index}]' must be an integer")
+            if status < 100 or status > 599:
+                raise ValueError(f"'{field}.success_statuses[{index}]' must be an HTTP status code")
+
+
+def _task_emit_configured(raw_emit: Any) -> bool:
+    if raw_emit is None:
+        return False
+    if isinstance(raw_emit, Sequence) and not isinstance(raw_emit, (str, bytes)):
+        return bool(raw_emit)
+    return True
 
 
 def _validate_unknown_fields(mapping: Mapping[str, Any], allowed: frozenset[str], *, field: str) -> None:

--- a/src/onestep/connectors/__init__.py
+++ b/src/onestep/connectors/__init__.py
@@ -1,4 +1,5 @@
 from .base import Delivery, Sink, Source
+from .http import HttpSink, HttpSinkStatusError
 from .memory import MemoryQueue
 from .mysql import MySQLConnector
 from .rabbitmq import RabbitMQConnector
@@ -11,6 +12,8 @@ __all__ = [
     "BearerAuth",
     "CronSource",
     "Delivery",
+    "HttpSink",
+    "HttpSinkStatusError",
     "IntervalSource",
     "MemoryQueue",
     "MySQLConnector",

--- a/src/onestep/connectors/http.py
+++ b/src/onestep/connectors/http.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.error
+import urllib.request
+from collections.abc import Mapping, Sequence
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from onestep.envelope import Envelope
+from onestep.resilience import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError
+
+from .base import Sink
+
+_DEFAULT_SUCCESS_STATUSES = (200, 201, 202, 204)
+_DEFAULT_TIMEOUT_S = 5.0
+_REDACTED = "<redacted>"
+
+
+class HttpSinkStatusError(RuntimeError):
+    def __init__(self, *, name: str, status: int, reason: str, body: bytes) -> None:
+        self.name = name
+        self.status = status
+        self.reason = reason
+        self.body = body
+        super().__init__(f"http_sink {name!r} returned HTTP {status} {reason}".rstrip())
+
+
+class HttpSink(Sink):
+    def __init__(
+        self,
+        name: str,
+        *,
+        url: str,
+        method: str = "POST",
+        headers: Mapping[str, Any] | None = None,
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+        success_statuses: Sequence[int] | None = None,
+    ) -> None:
+        super().__init__(name)
+        self.url = _normalize_url(url)
+        self.method = _normalize_method(method)
+        self.headers = _normalize_headers(headers)
+        self.timeout_s = _normalize_timeout(timeout_s)
+        self.success_statuses = _normalize_success_statuses(success_statuses)
+
+    async def send(self, envelope: Envelope) -> None:
+        payload = json.dumps(envelope.body, default=str).encode("utf-8")
+        headers = dict(self.headers)
+        _set_header_default(headers, "Content-Type", "application/json")
+        request = urllib.request.Request(
+            self.url,
+            data=payload,
+            headers=headers,
+            method=self.method,
+        )
+        try:
+            status, reason, body = await asyncio.to_thread(self._send_request, request)
+        except ConnectorOperationError:
+            raise
+        except (TimeoutError, urllib.error.URLError, OSError) as exc:
+            raise ConnectorOperationError(
+                backend="http_sink",
+                operation=ConnectorOperation.SEND,
+                kind=_classify_transport_error(exc),
+                source_name=self.name,
+                retry_delay_s=self.timeout_s,
+                cause=exc,
+            ) from exc
+
+        if status not in self.success_statuses:
+            status_error = HttpSinkStatusError(
+                name=self.name,
+                status=status,
+                reason=reason,
+                body=body,
+            )
+            raise ConnectorOperationError(
+                backend="http_sink",
+                operation=ConnectorOperation.SEND,
+                kind=_classify_status(status),
+                source_name=self.name,
+                cause=status_error,
+                message=f"http_sink send failed for {self.name!r}: HTTP {status} {reason}".rstrip(),
+            ) from status_error
+
+    def control_plane_descriptor(self) -> dict[str, Any]:
+        return {
+            "kind": "http_sink",
+            "name": self.name,
+            "config": {
+                "url": _redact_url(self.url),
+                "method": self.method,
+                "headers": {key: _REDACTED for key in sorted(self.headers)},
+                "timeout_s": self.timeout_s,
+                "success_statuses": list(self.success_statuses),
+            },
+        }
+
+    def _send_request(self, request: urllib.request.Request) -> tuple[int, str, bytes]:
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_s) as response:
+                return response.status, response.reason, response.read()
+        except urllib.error.HTTPError as exc:
+            try:
+                body = exc.read()
+            finally:
+                exc.close()
+            reason = str(getattr(exc, "reason", None) or getattr(exc, "msg", ""))
+            return exc.code, reason, body
+
+
+def _normalize_url(value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("'url' must be a non-empty string")
+    normalized = value.strip()
+    parsed = urlsplit(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("'url' must be an http or https URL")
+    return normalized
+
+
+def _normalize_method(value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("'method' must be a non-empty string")
+    return value.strip().upper()
+
+
+def _normalize_headers(value: Mapping[str, Any] | None) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError("'headers' must be a mapping")
+    headers: dict[str, str] = {}
+    for key, item in value.items():
+        name = str(key).strip()
+        if not name:
+            raise ValueError("header names must be non-empty")
+        headers[name] = str(item)
+    return headers
+
+
+def _normalize_timeout(value: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError("'timeout_s' must be a number")
+    normalized = float(value)
+    if normalized <= 0:
+        raise ValueError("'timeout_s' must be > 0")
+    return normalized
+
+
+def _normalize_success_statuses(value: Sequence[int] | None) -> tuple[int, ...]:
+    if value is None:
+        return _DEFAULT_SUCCESS_STATUSES
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise TypeError("'success_statuses' must be a list of integers")
+    statuses: list[int] = []
+    for status in value:
+        if isinstance(status, bool) or not isinstance(status, int):
+            raise TypeError("'success_statuses' must be a list of integers")
+        if status < 100 or status > 599:
+            raise ValueError("'success_statuses' must contain HTTP status codes")
+        statuses.append(status)
+    if not statuses:
+        raise ValueError("'success_statuses' must not be empty")
+    return tuple(dict.fromkeys(statuses))
+
+
+def _set_header_default(headers: dict[str, str], name: str, value: str) -> None:
+    if any(key.lower() == name.lower() for key in headers):
+        return
+    headers[name] = value
+
+
+def _classify_status(status: int) -> ConnectorErrorKind:
+    if status == 429:
+        return ConnectorErrorKind.THROTTLED
+    if status in {408, 425} or status >= 500:
+        return ConnectorErrorKind.TRANSIENT
+    return ConnectorErrorKind.PERMANENT
+
+
+def _classify_transport_error(exc: BaseException) -> ConnectorErrorKind:
+    if isinstance(exc, TimeoutError):
+        return ConnectorErrorKind.DISCONNECTED
+    if isinstance(exc, urllib.error.URLError):
+        reason = getattr(exc, "reason", None)
+        if isinstance(reason, (TimeoutError, OSError)):
+            return ConnectorErrorKind.DISCONNECTED
+    if isinstance(exc, OSError):
+        return ConnectorErrorKind.DISCONNECTED
+    return ConnectorErrorKind.TRANSIENT
+
+
+def _redact_url(value: str) -> str:
+    parsed = urlsplit(value)
+    netloc = parsed.netloc
+    if "@" in netloc:
+        _, host = netloc.rsplit("@", 1)
+        netloc = f"{_REDACTED}@{host}"
+    return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))

--- a/src/onestep/reporter.py
+++ b/src/onestep/reporter.py
@@ -100,6 +100,7 @@ def _read_env(*names: str) -> str | None:
 
 _KIND_OVERRIDES = {
     "CronSource": "cron",
+    "HttpSink": "http_sink",
     "IncrementalTableSource": "mysql_incremental",
     "IntervalSource": "interval",
     "MaxAttempts": "max_attempts",

--- a/tests/test_http_sink.py
+++ b/tests/test_http_sink.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from control_plane_testkit import SenderRecorder, make_config
+from onestep import ControlPlaneReporter, Envelope, HttpSink, MemoryQueue, OneStepApp
+from onestep.config import load_app_config
+from onestep.connectors.http import HttpSinkStatusError
+from onestep.resilience import ConnectorErrorKind, ConnectorOperationError
+
+
+async def _start_http_server(
+    *,
+    status: int = 202,
+    body: bytes = b"ok",
+) -> tuple[asyncio.AbstractServer, list[dict[str, Any]], str]:
+    requests: list[dict[str, Any]] = []
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        request = await _read_request(reader)
+        requests.append(request)
+        response = (
+            f"HTTP/1.1 {status} {_reason(status)}\r\n"
+            f"Content-Length: {len(body)}\r\n"
+            "Connection: close\r\n"
+            "\r\n"
+        ).encode("ascii") + body
+        writer.write(response)
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    assert server.sockets is not None
+    host, port = server.sockets[0].getsockname()[:2]
+    return server, requests, f"http://{host}:{port}"
+
+
+async def _read_request(reader: asyncio.StreamReader) -> dict[str, Any]:
+    header_block = await reader.readuntil(b"\r\n\r\n")
+    header_text = header_block.decode("iso-8859-1")
+    lines = header_text.split("\r\n")
+    method, target, _ = lines[0].split(" ", 2)
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if not line:
+            continue
+        name, _, value = line.partition(":")
+        headers[name.lower()] = value.strip()
+    content_length = int(headers.get("content-length", "0"))
+    body = await reader.readexactly(content_length) if content_length else b""
+    return {
+        "method": method,
+        "target": target,
+        "headers": headers,
+        "body": body,
+    }
+
+
+def _reason(status: int) -> str:
+    return {
+        200: "OK",
+        202: "Accepted",
+        500: "Internal Server Error",
+    }.get(status, "Status")
+
+
+async def _close_server(server: asyncio.AbstractServer) -> None:
+    server.close()
+    await server.wait_closed()
+
+
+def test_http_sink_sends_json_body_and_headers() -> None:
+    async def scenario() -> None:
+        server, requests, base_url = await _start_http_server(status=202)
+        try:
+            sink = HttpSink(
+                "notify",
+                url=f"{base_url}/events",
+                headers={"Authorization": "Bearer secret-token"},
+                timeout_s=1.0,
+            )
+            await sink.open()
+            await sink.send(Envelope(body={"id": 123, "kind": "order"}))
+            await sink.close()
+        finally:
+            await _close_server(server)
+
+        assert len(requests) == 1
+        request = requests[0]
+        assert request["method"] == "POST"
+        assert request["target"] == "/events"
+        assert request["headers"]["authorization"] == "Bearer secret-token"
+        assert request["headers"]["content-type"] == "application/json"
+        assert json.loads(request["body"].decode("utf-8")) == {
+            "id": 123,
+            "kind": "order",
+        }
+
+    asyncio.run(scenario())
+
+
+def test_http_sink_raises_send_failure_for_non_success_status() -> None:
+    async def scenario() -> None:
+        server, requests, base_url = await _start_http_server(status=500, body=b"failed")
+        try:
+            sink = HttpSink("notify", url=f"{base_url}/events", timeout_s=1.0)
+            with pytest.raises(ConnectorOperationError) as raised:
+                await sink.send(Envelope(body={"id": 123}))
+        finally:
+            await _close_server(server)
+
+        assert len(requests) == 1
+        assert raised.value.backend == "http_sink"
+        assert raised.value.kind is ConnectorErrorKind.TRANSIENT
+        assert isinstance(raised.value.cause, HttpSinkStatusError)
+        assert raised.value.cause.status == 500
+
+    asyncio.run(scenario())
+
+
+def test_yaml_http_sink_and_passthrough_task_emit_payload() -> None:
+    async def scenario() -> None:
+        server, requests, base_url = await _start_http_server(status=202)
+        try:
+            app = load_app_config(
+                {
+                    "apiVersion": "onestep/v1alpha1",
+                    "kind": "App",
+                    "app": {"name": "yaml-http"},
+                    "resources": {
+                        "incoming": {"type": "memory"},
+                        "notify": {
+                            "type": "http_sink",
+                            "url": f"{base_url}/notify",
+                            "headers": {"X-Api-Key": "secret-token"},
+                        },
+                    },
+                    "tasks": [
+                        {
+                            "name": "forward",
+                            "source": "incoming",
+                            "emit": "notify",
+                        }
+                    ],
+                },
+                strict=True,
+            )
+            assert app.tasks[0].handler_ref is None
+            assert isinstance(app.resources["notify"], HttpSink)
+
+            await app.startup()
+            try:
+                result = await app.run_task_once("forward", payload={"value": 7})
+            finally:
+                await app.shutdown()
+        finally:
+            await _close_server(server)
+
+        assert result["completion"] == "complete"
+        assert len(requests) == 1
+        assert json.loads(requests[0]["body"].decode("utf-8")) == {"value": 7}
+
+    asyncio.run(scenario())
+
+
+def test_strict_yaml_rejects_passthrough_task_without_emit() -> None:
+    with pytest.raises(ValueError, match=r"tasks\[0\] must define either 'handler' or 'emit'"):
+        load_app_config(
+            {
+                "apiVersion": "onestep/v1alpha1",
+                "kind": "App",
+                "app": {"name": "yaml-invalid"},
+                "resources": {
+                    "incoming": {"type": "memory"},
+                },
+                "tasks": [
+                    {
+                        "name": "missing",
+                        "source": "incoming",
+                    }
+                ],
+            },
+            strict=True,
+        )
+
+
+def test_strict_yaml_rejects_unknown_http_sink_fields() -> None:
+    with pytest.raises(ValueError, match="unsupported fields for resources.notify: token"):
+        load_app_config(
+            {
+                "apiVersion": "onestep/v1alpha1",
+                "kind": "App",
+                "app": {"name": "yaml-invalid-http"},
+                "resources": {
+                    "notify": {
+                        "type": "http_sink",
+                        "url": "https://example.com/notify",
+                        "token": "secret-token",
+                    },
+                },
+                "tasks": [],
+            },
+            strict=True,
+        )
+
+
+def test_reporter_describes_http_sink_kind_and_redacts_config() -> None:
+    recorder = SenderRecorder()
+    app = OneStepApp("billing-sync")
+    sink = HttpSink(
+        "notify",
+        url="https://user:password@example.com/hooks?token=secret-token&safe=1#fragment",
+        headers={
+            "Authorization": "Bearer secret-token",
+            "X-Api-Key": "secret-token",
+        },
+        timeout_s=2.5,
+        success_statuses=[202],
+    )
+
+    @app.task(source=MemoryQueue("incoming"), emit=sink)
+    async def forward(ctx, payload):
+        return payload
+
+    reporter = ControlPlaneReporter(make_config(), sender=recorder)
+    reporter.attach(app)
+
+    async def scenario() -> None:
+        await reporter.send_sync_now()
+
+    asyncio.run(scenario())
+
+    sync_payload = next(payload for channel, payload in recorder.calls if channel == "sync")
+    emit = sync_payload["app"]["tasks"][0]["emit"][0]
+    assert emit == {
+        "kind": "http_sink",
+        "name": "notify",
+        "config": {
+            "url": "https://<redacted>@example.com/hooks",
+            "method": "POST",
+            "headers": {
+                "Authorization": "<redacted>",
+                "X-Api-Key": "<redacted>",
+            },
+            "timeout_s": 2.5,
+            "success_statuses": [202],
+        },
+    }
+    assert "secret-token" not in json.dumps(sync_payload["app"])


### PR DESCRIPTION
## Summary

- Add `HttpSink` as an outbound HTTP sink using existing `emit` semantics.
- Add YAML `type: http_sink` resource support with strict validation.
- Allow YAML tasks without `handler` when `emit` is configured by injecting a passthrough handler.
- Redact HTTP sink URL credentials/query strings and header values in control-plane topology descriptors.

Closes #64

## Tests

- `uv run pytest tests/test_http_sink.py tests/test_cli.py -q`
- `uv run pytest tests --ignore=tests/integration -q`
- `uv run ruff check src/onestep/connectors/http.py tests/test_http_sink.py src/onestep/config.py src/onestep/reporter.py src/onestep/__init__.py src/onestep/connectors/__init__.py`
- `git diff --check`
