### PR TITLE
feat: add official worker runtime image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build:
@@ -34,6 +35,9 @@ jobs:
 
       - name: Run non-integration tests
         run: uv run pytest -q -m "not integration"
+
+      - name: Smoke test worker image
+        run: ./scripts/run-worker-image-smoke.sh
 
       - name: Build distributions
         run: uv build
@@ -72,6 +76,52 @@ jobs:
         with:
           files: dist/*
           generate_release_notes: true
+
+  worker-image:
+    name: Publish worker image
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          MAJOR_MINOR="${VERSION%.*}"
+          IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/onestep-worker"
+          {
+            echo "VERSION=$VERSION"
+            echo "MAJOR_MINOR=$MAJOR_MINOR"
+            echo "IMAGE_NAME=$IMAGE_NAME"
+          } >> "$GITHUB_ENV"
+
+      - name: Build and push worker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/worker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+            ${{ env.IMAGE_NAME }}:${{ env.MAJOR_MINOR }}
+            ${{ env.IMAGE_NAME }}:latest
 
   pypi:
     name: Publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
       checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
       version: ${{ steps.resolve.outputs.version }}
       major_minor: ${{ steps.resolve.outputs.major_minor }}
+      run_build: ${{ steps.resolve.outputs.run_build }}
       publish_worker_image: ${{ steps.resolve.outputs.publish_worker_image }}
       publish_pypi: ${{ steps.resolve.outputs.publish_pypi }}
       publish_github_release: ${{ steps.resolve.outputs.publish_github_release }}
@@ -58,6 +59,7 @@ jobs:
 
           if [ "$EVENT_NAME" = "push" ]; then
             CHECKOUT_REF="$REF_NAME"
+            RUN_BUILD=true
             PUBLISH_WORKER_IMAGE=true
             PUBLISH_PYPI=true
             PUBLISH_GITHUB_RELEASE=true
@@ -66,6 +68,14 @@ jobs:
             PUBLISH_WORKER_IMAGE="$INPUT_PUBLISH_WORKER_IMAGE"
             PUBLISH_PYPI="$INPUT_PUBLISH_PYPI"
             PUBLISH_GITHUB_RELEASE="$INPUT_PUBLISH_GITHUB_RELEASE"
+
+            if [ "$PUBLISH_PYPI" = "true" ] || [ "$PUBLISH_GITHUB_RELEASE" = "true" ]; then
+              RUN_BUILD=true
+            elif [ "$PUBLISH_WORKER_IMAGE" = "true" ]; then
+              RUN_BUILD=false
+            else
+              RUN_BUILD=true
+            fi
           fi
 
           VERSION=""
@@ -87,6 +97,7 @@ jobs:
             echo "checkout_ref=$CHECKOUT_REF"
             echo "version=$VERSION"
             echo "major_minor=$MAJOR_MINOR"
+            echo "run_build=$RUN_BUILD"
             echo "publish_worker_image=$PUBLISH_WORKER_IMAGE"
             echo "publish_pypi=$PUBLISH_PYPI"
             echo "publish_github_release=$PUBLISH_GITHUB_RELEASE"
@@ -96,6 +107,7 @@ jobs:
     name: Build release artifacts
     runs-on: ubuntu-latest
     needs: prepare
+    if: needs.prepare.outputs.run_build == 'true'
 
     steps:
       - name: Checkout
@@ -119,7 +131,19 @@ jobs:
         run: uv run pytest -q -m "not integration"
 
       - name: Smoke test worker image
-        run: ./scripts/run-worker-image-smoke.sh
+        env:
+          CHECKOUT_REF: ${{ needs.prepare.outputs.checkout_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          REQUIRE_WORKER_IMAGE: ${{ needs.prepare.outputs.publish_worker_image }}
+        run: |
+          if [ -f scripts/run-worker-image-smoke.sh ] && [ -f docker/worker/Dockerfile ]; then
+            ./scripts/run-worker-image-smoke.sh
+          elif [ "$EVENT_NAME" = "push" ] || [ "$REQUIRE_WORKER_IMAGE" = "true" ]; then
+            echo "Selected ref '$CHECKOUT_REF' does not include worker image sources." >&2
+            exit 1
+          else
+            echo "Skipping worker image smoke for '$CHECKOUT_REF'; worker image sources are not present in this ref."
+          fi
 
       - name: Build distributions
         run: uv build
@@ -178,7 +202,12 @@ jobs:
     needs:
       - prepare
       - build
-    if: needs.prepare.outputs.publish_worker_image == 'true'
+    if: >-
+      ${{
+        always() &&
+        needs.prepare.outputs.publish_worker_image == 'true' &&
+        (needs.prepare.outputs.run_build != 'true' || needs.build.result == 'success')
+      }}
     permissions:
       contents: read
       packages: write
@@ -191,6 +220,15 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Verify worker image sources exist
+        env:
+          CHECKOUT_REF: ${{ needs.prepare.outputs.checkout_ref }}
+        run: |
+          if [ ! -f docker/worker/Dockerfile ] || [ ! -f docker/worker/entrypoint.sh ]; then
+            echo "Selected ref '$CHECKOUT_REF' does not include worker image sources. Choose a release tag created after worker image support landed." >&2
+            exit 1
+          fi
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,21 +6,103 @@ on:
       - "v*"
       - "*.*.*"
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag to build from, for example v1.2.3"
+        required: false
+        type: string
+      publish_worker_image:
+        description: "Build and publish the worker image to GHCR"
+        required: false
+        default: false
+        type: boolean
+      publish_pypi:
+        description: "Publish the package to PyPI"
+        required: false
+        default: false
+        type: boolean
+      publish_github_release:
+        description: "Create or update the GitHub release"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
   packages: write
 
 jobs:
+  prepare:
+    name: Resolve release target
+    runs-on: ubuntu-latest
+    outputs:
+      checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
+      version: ${{ steps.resolve.outputs.version }}
+      major_minor: ${{ steps.resolve.outputs.major_minor }}
+      publish_worker_image: ${{ steps.resolve.outputs.publish_worker_image }}
+      publish_pypi: ${{ steps.resolve.outputs.publish_pypi }}
+      publish_github_release: ${{ steps.resolve.outputs.publish_github_release }}
+
+    steps:
+      - name: Resolve checkout ref and publish targets
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag || '' }}
+          INPUT_PUBLISH_WORKER_IMAGE: ${{ github.event.inputs.publish_worker_image || 'false' }}
+          INPUT_PUBLISH_PYPI: ${{ github.event.inputs.publish_pypi || 'false' }}
+          INPUT_PUBLISH_GITHUB_RELEASE: ${{ github.event.inputs.publish_github_release || 'false' }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "push" ]; then
+            CHECKOUT_REF="$REF_NAME"
+            PUBLISH_WORKER_IMAGE=true
+            PUBLISH_PYPI=true
+            PUBLISH_GITHUB_RELEASE=true
+          else
+            CHECKOUT_REF="${INPUT_RELEASE_TAG:-$REF_NAME}"
+            PUBLISH_WORKER_IMAGE="$INPUT_PUBLISH_WORKER_IMAGE"
+            PUBLISH_PYPI="$INPUT_PUBLISH_PYPI"
+            PUBLISH_GITHUB_RELEASE="$INPUT_PUBLISH_GITHUB_RELEASE"
+          fi
+
+          VERSION=""
+          MAJOR_MINOR=""
+          if [ "$EVENT_NAME" = "push" ] || [ "$PUBLISH_WORKER_IMAGE" = "true" ] || [ "$PUBLISH_PYPI" = "true" ] || [ "$PUBLISH_GITHUB_RELEASE" = "true" ]; then
+            case "$CHECKOUT_REF" in
+              v[0-9]*.[0-9]*.[0-9]*|[0-9]*.[0-9]*.[0-9]*)
+                VERSION="${CHECKOUT_REF#v}"
+                MAJOR_MINOR="${VERSION%.*}"
+                ;;
+              *)
+                echo "Publishing requires release_tag to look like v1.2.3 or 1.2.3; got '$CHECKOUT_REF'." >&2
+                exit 1
+                ;;
+            esac
+          fi
+
+          {
+            echo "checkout_ref=$CHECKOUT_REF"
+            echo "version=$VERSION"
+            echo "major_minor=$MAJOR_MINOR"
+            echo "publish_worker_image=$PUBLISH_WORKER_IMAGE"
+            echo "publish_pypi=$PUBLISH_PYPI"
+            echo "publish_github_release=$PUBLISH_GITHUB_RELEASE"
+          } >> "$GITHUB_OUTPUT"
+
   build:
     name: Build release artifacts
     runs-on: ubuntu-latest
+    needs: prepare
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -62,7 +144,19 @@ jobs:
   github-release:
     name: Publish GitHub release
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - prepare
+      - build
+      - worker-image
+      - pypi
+    if: >-
+      ${{
+        always() &&
+        needs.build.result == 'success' &&
+        needs.prepare.outputs.publish_github_release == 'true' &&
+        (needs.prepare.outputs.publish_worker_image != 'true' || needs.worker-image.result == 'success') &&
+        (needs.prepare.outputs.publish_pypi != 'true' || needs.pypi.result == 'success')
+      }}
 
     steps:
       - name: Download artifacts
@@ -74,14 +168,17 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.prepare.outputs.checkout_ref }}
           files: dist/*
           generate_release_notes: true
 
   worker-image:
     name: Publish worker image
     runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'push'
+    needs:
+      - prepare
+      - build
+    if: needs.prepare.outputs.publish_worker_image == 'true'
     permissions:
       contents: read
       packages: write
@@ -89,6 +186,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -102,12 +201,10 @@ jobs:
 
       - name: Derive image tags
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          MAJOR_MINOR="${VERSION%.*}"
           IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/onestep-worker"
           {
-            echo "VERSION=$VERSION"
-            echo "MAJOR_MINOR=$MAJOR_MINOR"
+            echo "VERSION=${{ needs.prepare.outputs.version }}"
+            echo "MAJOR_MINOR=${{ needs.prepare.outputs.major_minor }}"
             echo "IMAGE_NAME=$IMAGE_NAME"
           } >> "$GITHUB_ENV"
 
@@ -126,8 +223,17 @@ jobs:
   pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'push'
+    needs:
+      - prepare
+      - build
+      - worker-image
+    if: >-
+      ${{
+        always() &&
+        needs.build.result == 'success' &&
+        needs.prepare.outputs.publish_pypi == 'true' &&
+        (needs.prepare.outputs.publish_worker_image != 'true' || needs.worker-image.result == 'success')
+      }}
 
     steps:
       - name: Download artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,19 @@ on:
         description: "Existing release tag to build from, for example v1.2.3"
         required: false
         type: string
+      worker_image_source_ref:
+        description: "Branch, tag, or commit SHA containing worker image sources for manual backfills"
+        required: false
+        type: string
+      worker_image_version:
+        description: "Exact worker image version tag to publish, defaults to release_tag"
+        required: false
+        type: string
+      publish_worker_alias_tags:
+        description: "Also publish the worker image's major.minor and latest tags"
+        required: false
+        default: false
+        type: boolean
       publish_worker_image:
         description: "Build and publish the worker image to GHCR"
         required: false
@@ -40,6 +53,10 @@ jobs:
       version: ${{ steps.resolve.outputs.version }}
       major_minor: ${{ steps.resolve.outputs.major_minor }}
       run_build: ${{ steps.resolve.outputs.run_build }}
+      worker_image_ref: ${{ steps.resolve.outputs.worker_image_ref }}
+      worker_image_version: ${{ steps.resolve.outputs.worker_image_version }}
+      worker_image_major_minor: ${{ steps.resolve.outputs.worker_image_major_minor }}
+      publish_worker_alias_tags: ${{ steps.resolve.outputs.publish_worker_alias_tags }}
       publish_worker_image: ${{ steps.resolve.outputs.publish_worker_image }}
       publish_pypi: ${{ steps.resolve.outputs.publish_pypi }}
       publish_github_release: ${{ steps.resolve.outputs.publish_github_release }}
@@ -51,6 +68,9 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
           INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag || '' }}
+          INPUT_WORKER_IMAGE_SOURCE_REF: ${{ github.event.inputs.worker_image_source_ref || '' }}
+          INPUT_WORKER_IMAGE_VERSION: ${{ github.event.inputs.worker_image_version || '' }}
+          INPUT_PUBLISH_WORKER_ALIAS_TAGS: ${{ github.event.inputs.publish_worker_alias_tags || 'false' }}
           INPUT_PUBLISH_WORKER_IMAGE: ${{ github.event.inputs.publish_worker_image || 'false' }}
           INPUT_PUBLISH_PYPI: ${{ github.event.inputs.publish_pypi || 'false' }}
           INPUT_PUBLISH_GITHUB_RELEASE: ${{ github.event.inputs.publish_github_release || 'false' }}
@@ -85,17 +105,54 @@ jobs:
             return 1
           }
 
+          assign_version_fields() {
+            local raw_version="$1"
+            local version_var="$2"
+            local major_minor_var="$3"
+            local version
+            case "$raw_version" in
+              v[0-9]*.[0-9]*.[0-9]*|[0-9]*.[0-9]*.[0-9]*)
+                version="${raw_version#v}"
+                printf -v "$version_var" '%s' "$version"
+                printf -v "$major_minor_var" '%s' "${version%.*}"
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+          }
+
+          VERSION=""
+          MAJOR_MINOR=""
+          WORKER_IMAGE_REF=""
+          WORKER_IMAGE_VERSION=""
+          WORKER_IMAGE_MAJOR_MINOR=""
+          PUBLISH_WORKER_ALIAS_TAGS=false
+
           if [ "$EVENT_NAME" = "push" ]; then
             CHECKOUT_REF="$REF_NAME"
             RUN_BUILD=true
             PUBLISH_WORKER_IMAGE=true
             PUBLISH_PYPI=true
             PUBLISH_GITHUB_RELEASE=true
+            WORKER_IMAGE_REF="$CHECKOUT_REF"
+            PUBLISH_WORKER_ALIAS_TAGS=true
           else
             CHECKOUT_REF="${INPUT_RELEASE_TAG:-$REF_NAME}"
             PUBLISH_WORKER_IMAGE="$INPUT_PUBLISH_WORKER_IMAGE"
             PUBLISH_PYPI="$INPUT_PUBLISH_PYPI"
             PUBLISH_GITHUB_RELEASE="$INPUT_PUBLISH_GITHUB_RELEASE"
+            PUBLISH_WORKER_ALIAS_TAGS="$INPUT_PUBLISH_WORKER_ALIAS_TAGS"
+
+            if [ "$PUBLISH_WORKER_IMAGE" != "true" ] && { [ -n "$INPUT_WORKER_IMAGE_SOURCE_REF" ] || [ -n "$INPUT_WORKER_IMAGE_VERSION" ] || [ "$PUBLISH_WORKER_ALIAS_TAGS" = "true" ]; }; then
+              echo "worker_image_source_ref, worker_image_version, and publish_worker_alias_tags require publish_worker_image=true." >&2
+              exit 1
+            fi
+
+            if { [ "$PUBLISH_PYPI" = "true" ] || [ "$PUBLISH_GITHUB_RELEASE" = "true" ]; } && { [ -n "$INPUT_WORKER_IMAGE_SOURCE_REF" ] || [ -n "$INPUT_WORKER_IMAGE_VERSION" ]; }; then
+              echo "worker_image_source_ref and worker_image_version can only be used when publishing the worker image alone." >&2
+              exit 1
+            fi
 
             if [ "$PUBLISH_PYPI" = "true" ] || [ "$PUBLISH_GITHUB_RELEASE" = "true" ]; then
               RUN_BUILD=true
@@ -105,27 +162,42 @@ jobs:
               RUN_BUILD=true
             fi
 
-            if [ "$PUBLISH_WORKER_IMAGE" = "true" ] || [ "$PUBLISH_PYPI" = "true" ] || [ "$PUBLISH_GITHUB_RELEASE" = "true" ]; then
+            if [ "$PUBLISH_PYPI" = "true" ] || [ "$PUBLISH_GITHUB_RELEASE" = "true" ] || [ -n "$INPUT_RELEASE_TAG" ]; then
               if ! CHECKOUT_REF="$(resolve_tag_ref "$CHECKOUT_REF")"; then
                 echo "Could not find a release tag matching '$CHECKOUT_REF'. Try the exact tag name from the repository, for example '1.2.62'." >&2
                 exit 1
               fi
             fi
+
+            if [ "$PUBLISH_WORKER_IMAGE" = "true" ]; then
+              if [ -n "$INPUT_WORKER_IMAGE_SOURCE_REF" ]; then
+                WORKER_IMAGE_REF="$INPUT_WORKER_IMAGE_SOURCE_REF"
+              else
+                WORKER_IMAGE_REF="$CHECKOUT_REF"
+              fi
+            fi
           fi
 
-          VERSION=""
-          MAJOR_MINOR=""
-          if [ "$EVENT_NAME" = "push" ] || [ "$PUBLISH_WORKER_IMAGE" = "true" ] || [ "$PUBLISH_PYPI" = "true" ] || [ "$PUBLISH_GITHUB_RELEASE" = "true" ]; then
-            case "$CHECKOUT_REF" in
-              v[0-9]*.[0-9]*.[0-9]*|[0-9]*.[0-9]*.[0-9]*)
-                VERSION="${CHECKOUT_REF#v}"
-                MAJOR_MINOR="${VERSION%.*}"
-                ;;
-              *)
-                echo "Publishing requires release_tag to look like v1.2.3 or 1.2.3; got '$CHECKOUT_REF'." >&2
+          if [ "$EVENT_NAME" = "push" ] || [ "$PUBLISH_PYPI" = "true" ] || [ "$PUBLISH_GITHUB_RELEASE" = "true" ] || [ -n "$INPUT_RELEASE_TAG" ]; then
+            if ! assign_version_fields "$CHECKOUT_REF" VERSION MAJOR_MINOR; then
+              echo "Publishing requires release_tag to look like v1.2.3 or 1.2.3; got '$CHECKOUT_REF'." >&2
+              exit 1
+            fi
+          fi
+
+          if [ "$PUBLISH_WORKER_IMAGE" = "true" ]; then
+            if [ -n "$INPUT_WORKER_IMAGE_VERSION" ]; then
+              if ! assign_version_fields "$INPUT_WORKER_IMAGE_VERSION" WORKER_IMAGE_VERSION WORKER_IMAGE_MAJOR_MINOR; then
+                echo "worker_image_version must look like v1.2.3 or 1.2.3; got '$INPUT_WORKER_IMAGE_VERSION'." >&2
                 exit 1
-                ;;
-            esac
+              fi
+            elif [ -n "$VERSION" ]; then
+              WORKER_IMAGE_VERSION="$VERSION"
+              WORKER_IMAGE_MAJOR_MINOR="$MAJOR_MINOR"
+            else
+              echo "publish_worker_image requires release_tag or worker_image_version." >&2
+              exit 1
+            fi
           fi
 
           {
@@ -133,6 +205,10 @@ jobs:
             echo "version=$VERSION"
             echo "major_minor=$MAJOR_MINOR"
             echo "run_build=$RUN_BUILD"
+            echo "worker_image_ref=$WORKER_IMAGE_REF"
+            echo "worker_image_version=$WORKER_IMAGE_VERSION"
+            echo "worker_image_major_minor=$WORKER_IMAGE_MAJOR_MINOR"
+            echo "publish_worker_alias_tags=$PUBLISH_WORKER_ALIAS_TAGS"
             echo "publish_worker_image=$PUBLISH_WORKER_IMAGE"
             echo "publish_pypi=$PUBLISH_PYPI"
             echo "publish_github_release=$PUBLISH_GITHUB_RELEASE"
@@ -251,17 +327,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.checkout_ref }}
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.worker_image_ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Verify worker image sources exist
         env:
-          CHECKOUT_REF: ${{ needs.prepare.outputs.checkout_ref }}
+          WORKER_IMAGE_REF: ${{ needs.prepare.outputs.worker_image_ref }}
         run: |
           if [ ! -f docker/worker/Dockerfile ] || [ ! -f docker/worker/entrypoint.sh ]; then
-            echo "Selected ref '$CHECKOUT_REF' does not include worker image sources. Choose a release tag created after worker image support landed." >&2
+            echo "Selected worker_image_source_ref '$WORKER_IMAGE_REF' does not include worker image sources." >&2
             exit 1
           fi
 
@@ -275,10 +352,19 @@ jobs:
       - name: Derive image tags
         run: |
           IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/onestep-worker"
+          IMAGE_TAGS="${IMAGE_NAME}:${{ needs.prepare.outputs.worker_image_version }}"
+
+          if [ "${{ needs.prepare.outputs.publish_worker_alias_tags }}" = "true" ]; then
+            IMAGE_TAGS="${IMAGE_TAGS}"$'\n'"${IMAGE_NAME}:${{ needs.prepare.outputs.worker_image_major_minor }}"$'\n'"${IMAGE_NAME}:latest"
+          fi
+
           {
-            echo "VERSION=${{ needs.prepare.outputs.version }}"
-            echo "MAJOR_MINOR=${{ needs.prepare.outputs.major_minor }}"
             echo "IMAGE_NAME=$IMAGE_NAME"
+            echo "VERSION=${{ needs.prepare.outputs.worker_image_version }}"
+            echo "MAJOR_MINOR=${{ needs.prepare.outputs.worker_image_major_minor }}"
+            echo "IMAGE_TAGS<<EOF"
+            printf '%s\n' "$IMAGE_TAGS"
+            echo "EOF"
           } >> "$GITHUB_ENV"
 
       - name: Build and push worker image
@@ -288,10 +374,7 @@ jobs:
           file: docker/worker/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
-            ${{ env.IMAGE_NAME }}:${{ env.MAJOR_MINOR }}
-            ${{ env.IMAGE_NAME }}:latest
+          tags: ${{ env.IMAGE_TAGS }}
 
   pypi:
     name: Publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,36 @@ jobs:
           INPUT_PUBLISH_WORKER_IMAGE: ${{ github.event.inputs.publish_worker_image || 'false' }}
           INPUT_PUBLISH_PYPI: ${{ github.event.inputs.publish_pypi || 'false' }}
           INPUT_PUBLISH_GITHUB_RELEASE: ${{ github.event.inputs.publish_github_release || 'false' }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+
+          resolve_tag_ref() {
+            local requested_ref="$1"
+            local remote_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+            local stripped_ref="${requested_ref#v}"
+            local prefixed_ref="v${stripped_ref}"
+            local candidate
+            local candidates=("$requested_ref")
+
+            if [ "$stripped_ref" != "$requested_ref" ]; then
+              candidates+=("$stripped_ref")
+            fi
+
+            if [ "$prefixed_ref" != "$requested_ref" ]; then
+              candidates+=("$prefixed_ref")
+            fi
+
+            for candidate in "${candidates[@]}"; do
+              if git ls-remote --exit-code --refs --tags "$remote_url" "refs/tags/$candidate" >/dev/null 2>&1; then
+                echo "$candidate"
+                return 0
+              fi
+            done
+
+            return 1
+          }
 
           if [ "$EVENT_NAME" = "push" ]; then
             CHECKOUT_REF="$REF_NAME"
@@ -75,6 +103,13 @@ jobs:
               RUN_BUILD=false
             else
               RUN_BUILD=true
+            fi
+
+            if [ "$PUBLISH_WORKER_IMAGE" = "true" ] || [ "$PUBLISH_PYPI" = "true" ] || [ "$PUBLISH_GITHUB_RELEASE" = "true" ]; then
+              if ! CHECKOUT_REF="$(resolve_tag_ref "$CHECKOUT_REF")"; then
+                echo "Could not find a release tag matching '$CHECKOUT_REF'. Try the exact tag name from the repository, for example '1.2.62'." >&2
+                exit 1
+              fi
             fi
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,9 @@ name: CI
 on:
   push:
     paths:
+      - ".github/workflows/release.yml"
       - ".github/workflows/test.yml"
+      - "docker/**"
       - "docker-compose.integration.yml"
       - "pyproject.toml"
       - "scripts/**"
@@ -12,7 +14,9 @@ on:
       - "uv.lock"
   pull_request:
     paths:
+      - ".github/workflows/release.yml"
       - ".github/workflows/test.yml"
+      - "docker/**"
       - "docker-compose.integration.yml"
       - "pyproject.toml"
       - "scripts/**"
@@ -52,10 +56,23 @@ jobs:
       - name: Run unit and contract tests
         run: uv run pytest -q -m "not integration"
 
+  worker-image:
+    name: Worker image smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run worker image smoke tests
+        run: ./scripts/run-worker-image-smoke.sh
+
   integration:
     name: Integration (py3.11)
     runs-on: ubuntu-latest
-    needs: unit
+    needs:
+      - unit
+      - worker-image
     timeout-minutes: 20
 
     steps:

--- a/README.md
+++ b/README.md
@@ -280,6 +280,35 @@ sudo journalctl -u onestep-app -f
 See `deploy/README.md` for the expected directory layout and the env vars you need to adjust first.
 The deploy template prepends `APP_CWD` to `PYTHONPATH` so module targets defined inside the repo can be imported by the `onestep` console script.
 
+## Official worker image
+
+`onestep` also ships an official worker runtime image for YAML-oriented workers.
+
+Mounted workspace usage:
+
+```bash
+docker run --rm \
+  -e ONESTEP_TARGET=/workspace/worker.yaml \
+  -v "$PWD:/workspace" \
+  ghcr.io/repository-owner/onestep-worker:1.2.62
+```
+
+Derived image usage:
+
+```dockerfile
+FROM ghcr.io/repository-owner/onestep-worker:1.2.62
+
+WORKDIR /workspace
+COPY . /workspace
+ENV ONESTEP_TARGET=/workspace/worker.yaml
+```
+
+`ONESTEP_TARGET` points to the YAML file path or Python import target the container should start.
+The runtime automatically adds `/workspace` and `/workspace/src` to `PYTHONPATH`.
+If `/workspace/requirements.txt` exists it is installed first; otherwise the runtime falls back to installing `/workspace` when `/workspace/pyproject.toml` exists.
+
+See `deploy/worker-runtime-image.md` for the full usage guide and troubleshooting notes.
+
 ## Control Plane Reporter
 
 `onestep` can push runtime telemetry to `onestep-control-plane` over a single long-lived

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,6 +8,7 @@ Included files:
 - `env/onestep-app.env.example`: service environment variables
 - `systemd/onestep-app.service`: example `systemd` unit
 - `bin/onestep-preflight.sh`: startup check script used by `ExecStartPre`
+- `worker-runtime-image.md`: official container runtime guide for mounted and derived worker images
 - `web-service-integration.md`: recommended deployment shape for FastAPI/Django and other web apps
 
 ## Expected layout

--- a/deploy/worker-runtime-image.md
+++ b/deploy/worker-runtime-image.md
@@ -1,0 +1,47 @@
+# Worker Runtime Image
+
+The official worker image packages `onestep[all]` plus a small startup entrypoint.
+
+## Required environment
+
+- `ONESTEP_TARGET`: YAML file path or Python import target to start
+
+## Mode A: mounted workspace
+
+```bash
+docker run --rm \
+  -e ONESTEP_TARGET=/workspace/worker.yaml \
+  -v "$PWD:/workspace" \
+  ghcr.io/repository-owner/onestep-worker:1.2.62
+```
+
+Behavior:
+
+- adds `/workspace` and `/workspace/src` to `PYTHONPATH`
+- installs `/workspace/requirements.txt` when present
+- otherwise installs `/workspace` when `/workspace/pyproject.toml` exists
+- runs `onestep check` before `onestep run`
+
+## Mode B: derived image
+
+```dockerfile
+FROM ghcr.io/repository-owner/onestep-worker:1.2.62
+
+WORKDIR /workspace
+COPY . /workspace
+ENV ONESTEP_TARGET=/workspace/worker.yaml
+```
+
+Then build and run:
+
+```bash
+docker build -t my-worker .
+docker run --rm my-worker
+```
+
+## Troubleshooting
+
+- `ONESTEP_TARGET is required`: add the environment variable
+- `target file is not readable`: fix the mounted path or `WORKDIR`
+- dependency install failure: verify `requirements.txt` or `pyproject.toml` inside `/workspace`
+- `onestep check` failure: run the same target locally to inspect YAML or import errors

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /workspace
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml README.md /tmp/onestep/
+COPY src/onestep /tmp/onestep/src/onestep
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install "/tmp/onestep[all]" \
+    && rm -rf /tmp/onestep
+
+COPY docker/worker/entrypoint.sh /usr/local/bin/onestep-worker-entrypoint
+RUN chmod +x /usr/local/bin/onestep-worker-entrypoint
+
+ENTRYPOINT ["onestep-worker-entrypoint"]

--- a/docker/worker/entrypoint.sh
+++ b/docker/worker/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+WORKSPACE_DIR="${WORKSPACE_DIR:-/workspace}"
+: "${ONESTEP_TARGET:?ONESTEP_TARGET is required}"
+
+append_pythonpath() {
+  if [ -n "${PYTHONPATH:-}" ]; then
+    PYTHONPATH="$1:$PYTHONPATH"
+  else
+    PYTHONPATH="$1"
+  fi
+  export PYTHONPATH
+}
+
+append_pythonpath "$WORKSPACE_DIR"
+
+if [ -d "$WORKSPACE_DIR/src" ]; then
+  append_pythonpath "$WORKSPACE_DIR/src"
+fi
+
+cd "$WORKSPACE_DIR"
+
+case "$ONESTEP_TARGET" in
+  /*|./*|../*|*.yaml|*.yml)
+    if [ ! -r "$ONESTEP_TARGET" ]; then
+      echo "onestep-worker: target file is not readable: $ONESTEP_TARGET" >&2
+      exit 1
+    fi
+    ;;
+esac
+
+echo "onestep-worker: workspace=$WORKSPACE_DIR"
+echo "onestep-worker: target=$ONESTEP_TARGET"
+echo "onestep-worker: pythonpath=$PYTHONPATH"
+echo "onestep-worker: running check for $ONESTEP_TARGET"
+onestep check "$ONESTEP_TARGET"
+echo "onestep-worker: starting run for $ONESTEP_TARGET"
+exec onestep run "$ONESTEP_TARGET"

--- a/docker/worker/entrypoint.sh
+++ b/docker/worker/entrypoint.sh
@@ -33,6 +33,17 @@ esac
 echo "onestep-worker: workspace=$WORKSPACE_DIR"
 echo "onestep-worker: target=$ONESTEP_TARGET"
 echo "onestep-worker: pythonpath=$PYTHONPATH"
+
+if [ -f "$WORKSPACE_DIR/requirements.txt" ]; then
+  echo "onestep-worker: installing requirements from $WORKSPACE_DIR/requirements.txt"
+  python -m pip install --no-build-isolation -r "$WORKSPACE_DIR/requirements.txt"
+elif [ -f "$WORKSPACE_DIR/pyproject.toml" ]; then
+  echo "onestep-worker: installing project from $WORKSPACE_DIR/pyproject.toml"
+  python -m pip install --no-build-isolation "$WORKSPACE_DIR"
+else
+  echo "onestep-worker: no workspace dependency file found"
+fi
+
 echo "onestep-worker: running check for $ONESTEP_TARGET"
 onestep check "$ONESTEP_TARGET"
 echo "onestep-worker: starting run for $ONESTEP_TARGET"

--- a/docs/superpowers/plans/2026-05-21-onestep-worker-runtime-image.md
+++ b/docs/superpowers/plans/2026-05-21-onestep-worker-runtime-image.md
@@ -1,0 +1,917 @@
+# Onestep Worker Runtime Image Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship an official multi-platform `onestep` worker runtime image that supports direct mounted-workspace usage, derived-image usage, CI smoke coverage, and GHCR publishing from the existing release flow.
+
+**Architecture:** Add a small Docker runtime surface under `docker/worker/` with a shell entrypoint that owns preflight validation, `PYTHONPATH` setup, optional workspace dependency installation, and `onestep check/run`. Validate that runtime through a repo-local smoke script plus fixed test assets, then wire that smoke path into branch CI and tag-based GHCR publishing.
+
+**Tech Stack:** Docker, POSIX shell, GitHub Actions, Python packaging, pytest fixtures already present in the repo, existing `onestep` CLI/runtime
+
+---
+
+## File Structure
+
+- `docker/worker/Dockerfile`
+  Builds the official runtime image from the repo source checkout and installs `onestep[all]`.
+- `docker/worker/entrypoint.sh`
+  Implements the container startup contract: preflight, `PYTHONPATH`, dependency discovery, `onestep check`, `onestep run`.
+- `scripts/run-worker-image-smoke.sh`
+  Single local/CI smoke harness for failure cases, Mode A mounted workspaces, and Mode B derived images.
+- `tests/assets/worker_image/invalid_yaml/worker.yaml`
+  Fixed broken YAML fixture for preflight/check failure coverage.
+- `tests/assets/worker_image/mounted_requirements/*`
+  Mounted workspace fixture that exercises the `requirements.txt` branch.
+- `tests/assets/worker_image/mounted_pyproject/*`
+  Mounted workspace fixture that exercises the `pyproject.toml` fallback branch.
+- `tests/assets/worker_image/derived/Dockerfile`
+  Derived-image fixture that validates the `FROM ghcr.io/.../onestep-worker` workflow locally against a test tag.
+- `.github/workflows/test.yml`
+  Adds Docker asset path triggers and a worker-image smoke job in normal CI.
+- `.github/workflows/release.yml`
+  Reuses the release tag flow to smoke-test and publish the multi-platform worker image to GHCR.
+- `README.md`
+  Adds discoverable, top-level user guidance for the official worker image.
+- `deploy/worker-runtime-image.md`
+  Holds the full A/B usage guide and troubleshooting notes.
+- `deploy/README.md`
+  Links the new worker image guide from the deployment index.
+
+### Task 1: Add the runtime image skeleton and preflight smoke coverage
+
+**Files:**
+- Create: `docker/worker/Dockerfile`
+- Create: `docker/worker/entrypoint.sh`
+- Create: `scripts/run-worker-image-smoke.sh`
+- Create: `tests/assets/worker_image/invalid_yaml/worker.yaml`
+
+- [ ] **Step 1: Write the failing smoke harness**
+
+Create `tests/assets/worker_image/invalid_yaml/worker.yaml` with deliberately broken YAML:
+
+```yaml
+app:
+  name: broken-worker
+tasks: [
+```
+
+Create `scripts/run-worker-image-smoke.sh` with the initial failure-path-only harness:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_TAG="onestep-worker-local:test"
+
+docker build -f docker/worker/Dockerfile -t "$IMAGE_TAG" .
+
+missing_target_output="$(mktemp)"
+if docker run --rm "$IMAGE_TAG" >"$missing_target_output" 2>&1; then
+  echo "expected container without ONESTEP_TARGET to fail" >&2
+  exit 1
+fi
+grep -F "ONESTEP_TARGET is required" "$missing_target_output"
+
+invalid_yaml_output="$(mktemp)"
+if docker run --rm \
+  -e ONESTEP_TARGET=/workspace/worker.yaml \
+  -v "$PWD/tests/assets/worker_image/invalid_yaml:/workspace" \
+  "$IMAGE_TAG" >"$invalid_yaml_output" 2>&1; then
+  echo "expected invalid YAML worker to fail" >&2
+  exit 1
+fi
+grep -F "onestep-worker: running check for /workspace/worker.yaml" "$invalid_yaml_output"
+```
+
+- [ ] **Step 2: Run the smoke harness to verify it fails**
+
+Run:
+
+```bash
+chmod +x scripts/run-worker-image-smoke.sh
+./scripts/run-worker-image-smoke.sh
+```
+
+Expected:
+
+- Docker build fails because `docker/worker/Dockerfile` does not exist yet
+
+- [ ] **Step 3: Write the minimal runtime image implementation**
+
+Create `docker/worker/Dockerfile`:
+
+```dockerfile
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /workspace
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml README.md /tmp/onestep/
+COPY src/onestep /tmp/onestep/src/onestep
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install "/tmp/onestep[all]" \
+    && rm -rf /tmp/onestep
+
+COPY docker/worker/entrypoint.sh /usr/local/bin/onestep-worker-entrypoint
+RUN chmod +x /usr/local/bin/onestep-worker-entrypoint
+
+ENTRYPOINT ["onestep-worker-entrypoint"]
+```
+
+Create `docker/worker/entrypoint.sh` with preflight, `PYTHONPATH`, and check/run behavior:
+
+```sh
+#!/bin/sh
+set -eu
+
+WORKSPACE_DIR="${WORKSPACE_DIR:-/workspace}"
+: "${ONESTEP_TARGET:?ONESTEP_TARGET is required}"
+
+append_pythonpath() {
+  if [ -n "${PYTHONPATH:-}" ]; then
+    PYTHONPATH="$1:$PYTHONPATH"
+  else
+    PYTHONPATH="$1"
+  fi
+  export PYTHONPATH
+}
+
+append_pythonpath "$WORKSPACE_DIR"
+
+if [ -d "$WORKSPACE_DIR/src" ]; then
+  append_pythonpath "$WORKSPACE_DIR/src"
+fi
+
+cd "$WORKSPACE_DIR"
+
+case "$ONESTEP_TARGET" in
+  /*|./*|../*|*.yaml|*.yml)
+    if [ ! -r "$ONESTEP_TARGET" ]; then
+      echo "onestep-worker: target file is not readable: $ONESTEP_TARGET" >&2
+      exit 1
+    fi
+    ;;
+esac
+
+echo "onestep-worker: workspace=$WORKSPACE_DIR"
+echo "onestep-worker: target=$ONESTEP_TARGET"
+echo "onestep-worker: pythonpath=$PYTHONPATH"
+echo "onestep-worker: running check for $ONESTEP_TARGET"
+onestep check "$ONESTEP_TARGET"
+echo "onestep-worker: starting run for $ONESTEP_TARGET"
+exec onestep run "$ONESTEP_TARGET"
+```
+
+- [ ] **Step 4: Run the smoke harness to verify it passes**
+
+Run:
+
+```bash
+./scripts/run-worker-image-smoke.sh
+```
+
+Expected:
+
+- the no-target container exits non-zero and prints `ONESTEP_TARGET is required`
+- the invalid-YAML container exits non-zero after printing `onestep-worker: running check for /workspace/worker.yaml`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/worker/Dockerfile docker/worker/entrypoint.sh scripts/run-worker-image-smoke.sh tests/assets/worker_image/invalid_yaml/worker.yaml
+git commit -m "feat: add worker runtime image skeleton"
+```
+
+### Task 2: Support mounted workspaces, dependency discovery, and Mode A smoke coverage
+
+**Files:**
+- Modify: `docker/worker/entrypoint.sh`
+- Modify: `scripts/run-worker-image-smoke.sh`
+- Create: `tests/assets/worker_image/mounted_requirements/pyproject.toml`
+- Create: `tests/assets/worker_image/mounted_requirements/requirements.txt`
+- Create: `tests/assets/worker_image/mounted_requirements/src/worker_image_demo/__init__.py`
+- Create: `tests/assets/worker_image/mounted_requirements/src/worker_image_demo/tasks.py`
+- Create: `tests/assets/worker_image/mounted_requirements/worker.yaml`
+- Create: `tests/assets/worker_image/mounted_pyproject/pyproject.toml`
+- Create: `tests/assets/worker_image/mounted_pyproject/src/worker_image_demo_pyproject/__init__.py`
+- Create: `tests/assets/worker_image/mounted_pyproject/src/worker_image_demo_pyproject/tasks.py`
+- Create: `tests/assets/worker_image/mounted_pyproject/worker.yaml`
+
+- [ ] **Step 1: Write the failing Mode A smoke fixtures and assertions**
+
+Create `tests/assets/worker_image/mounted_requirements/pyproject.toml`:
+
+```toml
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "worker-image-mounted-requirements"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]
+```
+
+Create `tests/assets/worker_image/mounted_requirements/requirements.txt`:
+
+```text
+-e /workspace
+```
+
+Create `tests/assets/worker_image/mounted_requirements/src/worker_image_demo/__init__.py`:
+
+```python
+MARKER = "mounted-requirements"
+```
+
+Create `tests/assets/worker_image/mounted_requirements/src/worker_image_demo/tasks.py`:
+
+```python
+from __future__ import annotations
+
+import json
+
+from worker_image_demo import MARKER
+
+
+async def run_once(ctx, payload):
+    print(json.dumps({"marker": MARKER, "payload": payload}, ensure_ascii=False))
+    ctx.app.request_shutdown()
+```
+
+Create `tests/assets/worker_image/mounted_requirements/worker.yaml`:
+
+```yaml
+app:
+  name: mounted-requirements
+
+resources:
+  tick:
+    type: interval
+    seconds: 60
+    immediate: true
+    payload:
+      source: mounted-requirements
+
+tasks:
+  - name: run_once
+    source: tick
+    handler:
+      ref: worker_image_demo.tasks:run_once
+```
+
+Create `tests/assets/worker_image/mounted_pyproject/pyproject.toml`:
+
+```toml
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "worker-image-mounted-pyproject"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]
+```
+
+Create `tests/assets/worker_image/mounted_pyproject/src/worker_image_demo_pyproject/__init__.py`:
+
+```python
+MARKER = "mounted-pyproject"
+```
+
+Create `tests/assets/worker_image/mounted_pyproject/src/worker_image_demo_pyproject/tasks.py`:
+
+```python
+from __future__ import annotations
+
+import json
+
+from worker_image_demo_pyproject import MARKER
+
+
+async def run_once(ctx, payload):
+    print(json.dumps({"marker": MARKER, "payload": payload}, ensure_ascii=False))
+    ctx.app.request_shutdown()
+```
+
+Create `tests/assets/worker_image/mounted_pyproject/worker.yaml`:
+
+```yaml
+app:
+  name: mounted-pyproject
+
+resources:
+  tick:
+    type: interval
+    seconds: 60
+    immediate: true
+    payload:
+      source: mounted-pyproject
+
+tasks:
+  - name: run_once
+    source: tick
+    handler:
+      ref: worker_image_demo_pyproject.tasks:run_once
+```
+
+Extend `scripts/run-worker-image-smoke.sh` with two new assertions:
+
+```bash
+requirements_output="$(mktemp)"
+docker run --rm \
+  -e ONESTEP_TARGET=worker.yaml \
+  -v "$PWD/tests/assets/worker_image/mounted_requirements:/workspace" \
+  "$IMAGE_TAG" >"$requirements_output" 2>&1
+grep -F "onestep-worker: installing requirements from /workspace/requirements.txt" "$requirements_output"
+grep -F '"marker": "mounted-requirements"' "$requirements_output"
+
+pyproject_output="$(mktemp)"
+docker run --rm \
+  -e ONESTEP_TARGET=worker.yaml \
+  -v "$PWD/tests/assets/worker_image/mounted_pyproject:/workspace" \
+  "$IMAGE_TAG" >"$pyproject_output" 2>&1
+grep -F "onestep-worker: installing project from /workspace/pyproject.toml" "$pyproject_output"
+grep -F '"marker": "mounted-pyproject"' "$pyproject_output"
+```
+
+- [ ] **Step 2: Run the smoke harness to verify it fails**
+
+Run:
+
+```bash
+./scripts/run-worker-image-smoke.sh
+```
+
+Expected:
+
+- the new mounted workspace cases fail because the entrypoint does not install `requirements.txt`
+- the new mounted workspace cases fail because the entrypoint does not install the workspace project from `pyproject.toml`
+
+- [ ] **Step 3: Write the minimal dependency-discovery implementation**
+
+Update `docker/worker/entrypoint.sh` so the final file is:
+
+```sh
+#!/bin/sh
+set -eu
+
+WORKSPACE_DIR="${WORKSPACE_DIR:-/workspace}"
+: "${ONESTEP_TARGET:?ONESTEP_TARGET is required}"
+
+append_pythonpath() {
+  if [ -n "${PYTHONPATH:-}" ]; then
+    PYTHONPATH="$1:$PYTHONPATH"
+  else
+    PYTHONPATH="$1"
+  fi
+  export PYTHONPATH
+}
+
+append_pythonpath "$WORKSPACE_DIR"
+
+if [ -d "$WORKSPACE_DIR/src" ]; then
+  append_pythonpath "$WORKSPACE_DIR/src"
+fi
+
+cd "$WORKSPACE_DIR"
+
+case "$ONESTEP_TARGET" in
+  /*|./*|../*|*.yaml|*.yml)
+    if [ ! -r "$ONESTEP_TARGET" ]; then
+      echo "onestep-worker: target file is not readable: $ONESTEP_TARGET" >&2
+      exit 1
+    fi
+    ;;
+esac
+
+echo "onestep-worker: workspace=$WORKSPACE_DIR"
+echo "onestep-worker: target=$ONESTEP_TARGET"
+echo "onestep-worker: pythonpath=$PYTHONPATH"
+
+if [ -f "$WORKSPACE_DIR/requirements.txt" ]; then
+  echo "onestep-worker: installing requirements from $WORKSPACE_DIR/requirements.txt"
+  python -m pip install --no-build-isolation -r "$WORKSPACE_DIR/requirements.txt"
+elif [ -f "$WORKSPACE_DIR/pyproject.toml" ]; then
+  echo "onestep-worker: installing project from $WORKSPACE_DIR/pyproject.toml"
+  python -m pip install --no-build-isolation "$WORKSPACE_DIR"
+else
+  echo "onestep-worker: no workspace dependency file found"
+fi
+
+echo "onestep-worker: running check for $ONESTEP_TARGET"
+onestep check "$ONESTEP_TARGET"
+echo "onestep-worker: starting run for $ONESTEP_TARGET"
+exec onestep run "$ONESTEP_TARGET"
+```
+
+- [ ] **Step 4: Run the smoke harness to verify it passes**
+
+Run:
+
+```bash
+./scripts/run-worker-image-smoke.sh
+```
+
+Expected:
+
+- the `requirements.txt` fixture logs `installing requirements` and prints `mounted-requirements`
+- the `pyproject.toml` fixture logs `installing project` and prints `mounted-pyproject`
+- the original failure-path checks still pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/worker/entrypoint.sh scripts/run-worker-image-smoke.sh tests/assets/worker_image/mounted_requirements tests/assets/worker_image/mounted_pyproject
+git commit -m "feat: support mounted worker workspaces"
+```
+
+### Task 3: Validate the derived-image workflow for Mode B
+
+**Files:**
+- Modify: `scripts/run-worker-image-smoke.sh`
+- Create: `tests/assets/worker_image/derived/Dockerfile`
+
+- [ ] **Step 1: Write the failing Mode B smoke case**
+
+Extend `scripts/run-worker-image-smoke.sh` with a derived-image assertion that references a not-yet-created fixture Dockerfile:
+
+```bash
+DERIVED_TAG="onestep-worker-derived:test"
+
+docker build \
+  -f tests/assets/worker_image/derived/Dockerfile \
+  -t "$DERIVED_TAG" \
+  .
+
+derived_output="$(mktemp)"
+docker run --rm "$DERIVED_TAG" >"$derived_output" 2>&1
+grep -F '"marker": "mounted-pyproject"' "$derived_output"
+grep -F "onestep-worker: target=/workspace/worker.yaml" "$derived_output"
+```
+
+- [ ] **Step 2: Run the smoke harness to verify it fails**
+
+Run:
+
+```bash
+./scripts/run-worker-image-smoke.sh
+```
+
+Expected:
+
+- the new derived-image build fails because `tests/assets/worker_image/derived/Dockerfile` does not exist yet
+
+- [ ] **Step 3: Write the minimal Mode B support**
+
+Create `tests/assets/worker_image/derived/Dockerfile`:
+
+```dockerfile
+FROM onestep-worker-local:test
+
+WORKDIR /workspace
+COPY tests/assets/worker_image/mounted_pyproject /workspace
+ENV ONESTEP_TARGET=/workspace/worker.yaml
+```
+
+Update `scripts/run-worker-image-smoke.sh` so the final file is:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_TAG="onestep-worker-local:test"
+DERIVED_TAG="onestep-worker-derived:test"
+
+docker build -f docker/worker/Dockerfile -t "$IMAGE_TAG" .
+
+missing_target_output="$(mktemp)"
+if docker run --rm "$IMAGE_TAG" >"$missing_target_output" 2>&1; then
+  echo "expected container without ONESTEP_TARGET to fail" >&2
+  exit 1
+fi
+grep -F "ONESTEP_TARGET is required" "$missing_target_output"
+
+invalid_yaml_output="$(mktemp)"
+if docker run --rm \
+  -e ONESTEP_TARGET=/workspace/worker.yaml \
+  -v "$PWD/tests/assets/worker_image/invalid_yaml:/workspace" \
+  "$IMAGE_TAG" >"$invalid_yaml_output" 2>&1; then
+  echo "expected invalid YAML worker to fail" >&2
+  exit 1
+fi
+grep -F "onestep-worker: running check for /workspace/worker.yaml" "$invalid_yaml_output"
+
+requirements_output="$(mktemp)"
+docker run --rm \
+  -e ONESTEP_TARGET=worker.yaml \
+  -v "$PWD/tests/assets/worker_image/mounted_requirements:/workspace" \
+  "$IMAGE_TAG" >"$requirements_output" 2>&1
+grep -F "onestep-worker: installing requirements from /workspace/requirements.txt" "$requirements_output"
+grep -F '"marker": "mounted-requirements"' "$requirements_output"
+
+pyproject_output="$(mktemp)"
+docker run --rm \
+  -e ONESTEP_TARGET=worker.yaml \
+  -v "$PWD/tests/assets/worker_image/mounted_pyproject:/workspace" \
+  "$IMAGE_TAG" >"$pyproject_output" 2>&1
+grep -F "onestep-worker: installing project from /workspace/pyproject.toml" "$pyproject_output"
+grep -F '"marker": "mounted-pyproject"' "$pyproject_output"
+
+docker build \
+  -f tests/assets/worker_image/derived/Dockerfile \
+  -t "$DERIVED_TAG" \
+  .
+
+derived_output="$(mktemp)"
+docker run --rm "$DERIVED_TAG" >"$derived_output" 2>&1
+grep -F "onestep-worker: target=/workspace/worker.yaml" "$derived_output"
+grep -F '"marker": "mounted-pyproject"' "$derived_output"
+```
+
+- [ ] **Step 4: Run the smoke harness to verify it passes**
+
+Run:
+
+```bash
+./scripts/run-worker-image-smoke.sh
+```
+
+Expected:
+
+- the derived image builds successfully from `FROM onestep-worker-local:test`
+- the derived image starts without extra run flags and prints `mounted-pyproject`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/run-worker-image-smoke.sh tests/assets/worker_image/derived/Dockerfile
+git commit -m "test: cover derived worker images"
+```
+
+### Task 4: Add CI smoke coverage and GHCR release publishing
+
+**Files:**
+- Modify: `.github/workflows/test.yml:3-77`
+- Modify: `.github/workflows/release.yml:3-92`
+
+- [ ] **Step 1: Write the failing workflow assertions**
+
+Create a local workflow shape check and keep it in your shell history while editing:
+
+```bash
+uv run python - <<'PY'
+import yaml
+from pathlib import Path
+
+ci = yaml.safe_load(Path(".github/workflows/test.yml").read_text())
+release = yaml.safe_load(Path(".github/workflows/release.yml").read_text())
+
+assert "docker/**" in ci["on"]["push"]["paths"]
+assert "docker/**" in ci["on"]["pull_request"]["paths"]
+assert "worker-image" in ci["jobs"]
+assert "worker-image" in release["jobs"]
+assert release["permissions"]["packages"] == "write"
+PY
+```
+
+- [ ] **Step 2: Run the workflow assertions to verify they fail**
+
+Run:
+
+```bash
+uv run python - <<'PY'
+import yaml
+from pathlib import Path
+
+ci = yaml.safe_load(Path(".github/workflows/test.yml").read_text())
+release = yaml.safe_load(Path(".github/workflows/release.yml").read_text())
+
+assert "docker/**" in ci["on"]["push"]["paths"]
+assert "docker/**" in ci["on"]["pull_request"]["paths"]
+assert "worker-image" in ci["jobs"]
+assert "worker-image" in release["jobs"]
+assert release["permissions"]["packages"] == "write"
+PY
+```
+
+Expected:
+
+- the assertions fail because the CI workflow does not watch `docker/**`
+- the assertions fail because no worker-image jobs exist yet
+- the assertions fail because release permissions do not include `packages: write`
+
+- [ ] **Step 3: Write the minimal CI and release workflow implementation**
+
+Update `.github/workflows/test.yml` so the relevant sections are:
+
+```yaml
+on:
+  push:
+    paths:
+      - ".github/workflows/test.yml"
+      - ".github/workflows/release.yml"
+      - "docker/**"
+      - "docker-compose.integration.yml"
+      - "pyproject.toml"
+      - "scripts/**"
+      - "src/**"
+      - "tests/**"
+      - "uv.lock"
+  pull_request:
+    paths:
+      - ".github/workflows/test.yml"
+      - ".github/workflows/release.yml"
+      - "docker/**"
+      - "docker-compose.integration.yml"
+      - "pyproject.toml"
+      - "scripts/**"
+      - "src/**"
+      - "tests/**"
+      - "uv.lock"
+```
+
+Add a new job to `.github/workflows/test.yml`:
+
+```yaml
+  worker-image:
+    name: Worker image smoke
+    runs-on: ubuntu-latest
+    needs: unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build and smoke test worker image
+        run: ./scripts/run-worker-image-smoke.sh
+```
+
+Change the integration job dependency in `.github/workflows/test.yml` to:
+
+```yaml
+  integration:
+    name: Integration (py3.11)
+    runs-on: ubuntu-latest
+    needs:
+      - unit
+      - worker-image
+    timeout-minutes: 20
+```
+
+Update `.github/workflows/release.yml` permissions:
+
+```yaml
+permissions:
+  contents: write
+  packages: write
+```
+
+Add a release smoke step to the existing `build` job:
+
+```yaml
+      - name: Smoke test worker image
+        run: ./scripts/run-worker-image-smoke.sh
+```
+
+Add a new publish job to `.github/workflows/release.yml`:
+
+```yaml
+  worker-image:
+    name: Publish worker image
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          MAJOR_MINOR="${VERSION%.*}"
+          IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/onestep-worker"
+          {
+            echo "VERSION=$VERSION"
+            echo "MAJOR_MINOR=$MAJOR_MINOR"
+            echo "IMAGE_NAME=$IMAGE_NAME"
+          } >> "$GITHUB_ENV"
+
+      - name: Build and push worker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/worker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+            ${{ env.IMAGE_NAME }}:${{ env.MAJOR_MINOR }}
+            ${{ env.IMAGE_NAME }}:latest
+```
+
+- [ ] **Step 4: Run the workflow assertions and smoke script to verify they pass**
+
+Run:
+
+```bash
+uv run python - <<'PY'
+import yaml
+from pathlib import Path
+
+ci = yaml.safe_load(Path(".github/workflows/test.yml").read_text())
+release = yaml.safe_load(Path(".github/workflows/release.yml").read_text())
+
+assert "docker/**" in ci["on"]["push"]["paths"]
+assert "docker/**" in ci["on"]["pull_request"]["paths"]
+assert "worker-image" in ci["jobs"]
+assert "worker-image" in release["jobs"]
+assert release["permissions"]["packages"] == "write"
+PY
+./scripts/run-worker-image-smoke.sh
+```
+
+Expected:
+
+- the YAML assertions pass
+- the smoke script still passes after workflow changes
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/test.yml .github/workflows/release.yml
+git commit -m "ci: publish worker image to ghcr"
+```
+
+### Task 5: Document A/B usage, target contract, and troubleshooting
+
+**Files:**
+- Modify: `README.md:56-180`
+- Create: `deploy/worker-runtime-image.md`
+- Modify: `deploy/README.md:1-40`
+
+- [ ] **Step 1: Write the failing documentation checks**
+
+Use these grep checks as the doc acceptance gate:
+
+```bash
+rg -n "Official worker image|ONESTEP_TARGET|ghcr.io/.+/onestep-worker" README.md deploy/README.md deploy/worker-runtime-image.md
+rg -n "requirements.txt|pyproject.toml|docker run --rm|FROM ghcr.io" deploy/worker-runtime-image.md
+```
+
+- [ ] **Step 2: Run the documentation checks to verify they fail**
+
+Run:
+
+```bash
+rg -n "Official worker image|ONESTEP_TARGET|ghcr.io/.+/onestep-worker" README.md deploy/README.md deploy/worker-runtime-image.md
+```
+
+Expected:
+
+- `deploy/worker-runtime-image.md` does not exist yet
+- README does not yet mention the official worker image or `ONESTEP_TARGET`
+
+- [ ] **Step 3: Write the minimal user-facing documentation**
+
+Add this section to `README.md` after the YAML CLI examples:
+
+````md
+## Official worker image
+
+`onestep` also ships an official worker runtime image for YAML-oriented workers.
+
+Mounted workspace usage:
+
+```bash
+docker run --rm \
+  -e ONESTEP_TARGET=/workspace/worker.yaml \
+  -v "$PWD:/workspace" \
+  ghcr.io/repository-owner/onestep-worker:1.2.62
+```
+
+Derived image usage:
+
+```dockerfile
+FROM ghcr.io/repository-owner/onestep-worker:1.2.62
+
+WORKDIR /workspace
+COPY . /workspace
+ENV ONESTEP_TARGET=/workspace/worker.yaml
+```
+
+The runtime automatically adds `/workspace` and `/workspace/src` to `PYTHONPATH`.
+If `/workspace/requirements.txt` exists it is installed first; otherwise the runtime
+falls back to installing `/workspace` when `/workspace/pyproject.toml` exists.
+
+See `deploy/worker-runtime-image.md` for the full usage guide and troubleshooting notes.
+````
+
+Create `deploy/worker-runtime-image.md`:
+
+````md
+# Worker Runtime Image
+
+The official worker image packages `onestep[all]` plus a small startup entrypoint.
+
+## Required environment
+
+- `ONESTEP_TARGET`: YAML file path or Python import target to start
+
+## Mode A: mounted workspace
+
+```bash
+docker run --rm \
+  -e ONESTEP_TARGET=/workspace/worker.yaml \
+  -v "$PWD:/workspace" \
+  ghcr.io/repository-owner/onestep-worker:1.2.62
+```
+
+Behavior:
+
+- adds `/workspace` and `/workspace/src` to `PYTHONPATH`
+- installs `/workspace/requirements.txt` when present
+- otherwise installs `/workspace` when `/workspace/pyproject.toml` exists
+- runs `onestep check` before `onestep run`
+
+## Mode B: derived image
+
+```dockerfile
+FROM ghcr.io/repository-owner/onestep-worker:1.2.62
+
+WORKDIR /workspace
+COPY . /workspace
+ENV ONESTEP_TARGET=/workspace/worker.yaml
+```
+
+Then build and run:
+
+```bash
+docker build -t my-worker .
+docker run --rm my-worker
+```
+
+## Troubleshooting
+
+- `ONESTEP_TARGET is required`: add the environment variable
+- `target file is not readable`: fix the mounted path or `WORKDIR`
+- `installing requirements` fails: verify `requirements.txt` contents inside `/workspace`
+- `onestep check` fails: run the same target locally to inspect YAML or import errors
+````
+
+Add this bullet to `deploy/README.md` under the included files list:
+
+```md
+- `worker-runtime-image.md`: official container runtime guide for mounted and derived worker images
+```
+
+- [ ] **Step 4: Run the documentation checks to verify they pass**
+
+Run:
+
+```bash
+rg -n "Official worker image|ONESTEP_TARGET|ghcr.io/.+/onestep-worker" README.md deploy/README.md deploy/worker-runtime-image.md
+rg -n "requirements.txt|pyproject.toml|docker run --rm|FROM ghcr.io" deploy/worker-runtime-image.md
+```
+
+Expected:
+
+- all three docs contain the new worker image guidance
+- the deployment guide includes both Mode A and Mode B examples plus troubleshooting
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md deploy/README.md deploy/worker-runtime-image.md
+git commit -m "docs: add worker image usage guide"
+```

--- a/docs/superpowers/specs/2026-05-21-onestep-worker-runtime-image-design.md
+++ b/docs/superpowers/specs/2026-05-21-onestep-worker-runtime-image-design.md
@@ -1,0 +1,396 @@
+# Onestep Worker Runtime Image Design
+
+## Summary
+
+Add an official multi-platform worker runtime image for `onestep` so adopters can start a worker by supplying only:
+
+- a `worker.yaml`
+- Python task code
+- optional business dependencies
+
+The design uses one shared runtime image that supports two consumption modes:
+
+- `A`: run the official image directly by mounting a workspace
+- `B`: build a project-specific image with `FROM ghcr.io/${GITHUB_REPOSITORY_OWNER}/onestep-worker`
+
+The first version intentionally keeps the surface small:
+
+- publish one official runtime image
+- include `onestep[all]`
+- support `linux/amd64` and `linux/arm64`
+- use `ONESTEP_TARGET` as the single required entrypoint contract
+- automatically add `/workspace` and `/workspace/src` to `PYTHONPATH`
+- optionally install project dependencies from the mounted workspace before startup
+
+## Problem
+
+`onestep` already supports a project shape where runtime wiring lives in `worker.yaml` and business logic lives in Python modules. That makes local development straightforward, but there is no official container runtime that turns this shape into a standardized deployment product.
+
+Today a user who wants to run a YAML worker in a container still has to decide all of the following on their own:
+
+- which base image to use
+- which `onestep` extras to install
+- how to expose project code to the runtime
+- how to set `PYTHONPATH`
+- how to validate the target before starting
+- how to publish a multi-platform image if they want to inherit from a shared base
+
+That gap makes adoption heavier than it should be for the intended YAML worker flow.
+
+## Goals
+
+- Provide an official runtime image for YAML-oriented `onestep` workers.
+- Support both direct-run and derived-image usage with one shared runtime product.
+- Keep the worker startup contract simple and explicit.
+- Publish official images to GHCR as part of the normal release flow.
+- Support both `linux/amd64` and `linux/arm64`.
+- Make startup failures diagnosable from container logs.
+
+## Non-Goals
+
+- No attempt to containerize the control plane in this design.
+- No automatic code generation inside the runtime container.
+- No workflow DSL, YAML transform language, or embedded business logic expansion.
+- No runtime dependency cache service or shared package volume management.
+- No first-version support for additional architectures such as `linux/arm/v7`.
+- No separate public images for direct-run and derived-image scenarios.
+
+## User Model
+
+The official image should feel like a runtime product rather than a container recipe.
+
+Users interact with one image and choose one of two modes:
+
+### Mode A: Mounted workspace
+
+The user runs the official image directly and mounts a project directory into `/workspace`.
+
+That project directory contains:
+
+- `worker.yaml`
+- Python task modules
+- optional `requirements.txt` or `pyproject.toml`
+
+The user sets `ONESTEP_TARGET` to the YAML file or Python target to run.
+
+Example mental model:
+
+```bash
+docker run --rm \
+  -e ONESTEP_TARGET=/workspace/worker.yaml \
+  -v "$PWD:/workspace" \
+  ghcr.io/repository-owner/onestep-worker:1.2.62
+```
+
+### Mode B: Derived image
+
+The user builds their own image from the official runtime image and bakes in code, config, and optionally dependencies.
+
+Example mental model:
+
+```dockerfile
+FROM ghcr.io/repository-owner/onestep-worker:1.2.62
+
+WORKDIR /workspace
+COPY . /workspace
+ENV ONESTEP_TARGET=/workspace/worker.yaml
+```
+
+The same startup contract applies in both modes. The only difference is whether project files arrive at runtime or at image build time.
+
+## Recommended Approach
+
+Publish one official runtime image with a single entrypoint contract.
+
+Why this approach:
+
+- one runtime product is easier to document and support
+- A and B become two usage patterns rather than two products
+- versioning stays aligned with the Python package release
+- the startup path can be validated in one place
+
+Rejected alternatives:
+
+- two public images, one for mounted workspaces and one for derived images
+  - clearer role separation, but doubles release and support burden
+- a very thin image with no startup automation
+  - smaller implementation, but fails the goal of "write YAML and task code, then run"
+
+## Image Scope
+
+The official image should contain only the runtime pieces needed to execute a worker reliably:
+
+- Python runtime
+- `onestep[all]`
+- container entrypoint script
+- minimal system packages needed by the runtime and package installation flow
+- default `WORKDIR /workspace`
+
+It should not contain:
+
+- example projects
+- test fixtures
+- control plane services
+- repository-only build tooling that is not required at runtime
+
+The image is a worker runtime, not a general project development environment.
+
+## Runtime Contract
+
+The runtime contract is intentionally narrow and explicit.
+
+### Required input
+
+- `ONESTEP_TARGET`
+
+`ONESTEP_TARGET` points to the worker entrypoint and can be either:
+
+- a YAML file path such as `/workspace/worker.yaml`
+- a Python import target such as `your_pkg.tasks:app`
+
+The runtime must not guess between multiple targets. If `ONESTEP_TARGET` is missing or invalid, startup fails immediately with a clear error.
+
+### Working directory and import path
+
+The image defaults to:
+
+- `WORKDIR=/workspace`
+
+At startup, the runtime appends these paths to `PYTHONPATH`:
+
+- `/workspace`
+- `/workspace/src`
+
+This supports the common `src/` project shape without requiring users to manually inject `PYTHONPATH`.
+
+### Optional dependency discovery
+
+Before running the worker, the entrypoint checks for project-local dependency declarations in this order:
+
+1. `/workspace/requirements.txt`
+2. `/workspace/pyproject.toml`
+
+If `requirements.txt` exists, install from it.
+
+Otherwise, if `pyproject.toml` exists, install the project dependencies from it.
+
+If neither exists, skip dependency installation.
+
+This behavior exists primarily to make Mode A usable when business logic depends on packages beyond `onestep[all]`.
+
+## Startup Flow
+
+The entrypoint performs four steps:
+
+1. Preflight validation
+2. Project dependency installation
+3. `onestep check`
+4. `onestep run`
+
+### 1. Preflight validation
+
+Validate:
+
+- `ONESTEP_TARGET` is set
+- when the target is a file path, the file exists and is readable
+
+Log:
+
+- current working directory
+- target value
+- effective `PYTHONPATH`
+
+### 2. Project dependency installation
+
+Install project dependencies when a recognized dependency file is present in `/workspace`.
+
+Behavior should stay intentionally small:
+
+- do not scan nested directories
+- do not try to infer multiple project roots
+- do not implement persistent cross-container caching behavior
+
+### 3. `onestep check`
+
+Run `onestep check "$ONESTEP_TARGET"` before startup.
+
+This catches:
+
+- YAML schema errors
+- missing imports
+- invalid app wiring
+
+before the container enters the long-running execution path.
+
+### 4. `onestep run`
+
+Only after validation passes does the runtime execute:
+
+```bash
+onestep run "$ONESTEP_TARGET"
+```
+
+## Failure Handling
+
+The runtime should fail fast and loudly.
+
+Expected hard-failure cases:
+
+- `ONESTEP_TARGET` missing
+- target file missing
+- dependency installation failure
+- `onestep check` failure
+- `onestep run` startup failure
+
+Failure handling rules:
+
+- exit non-zero
+- print the failing phase
+- print the relevant target or file path
+- do not silently skip validation or fallback to guessed defaults
+
+This is especially important for Mode A, where runtime behavior is more dynamic.
+
+## Logging And Observability
+
+The first version only needs basic container-level observability.
+
+Required startup logs:
+
+- target being used
+- whether dependency installation ran, and from which file
+- result of `onestep check`
+- transition into `onestep run`
+
+This keeps failures diagnosable in plain container logs without adding a larger observability subsystem.
+
+## Versioning And Tagging
+
+The image version should align with the `onestep` package release version.
+
+Recommended public tags:
+
+- full version tag, for example `1.2.62`
+- minor convenience tag, for example `1.2`
+- `latest`
+
+The tag source of truth should remain the existing repository release flow. The image should not introduce a separate version lifecycle.
+
+## Registry And Distribution
+
+Publish the runtime image to GHCR:
+
+- canonical image name: `onestep-worker`
+- full image reference derived by release workflow: `ghcr.io/${GITHUB_REPOSITORY_OWNER}/onestep-worker`
+
+First-version platform targets:
+
+- `linux/amd64`
+- `linux/arm64`
+
+Use Docker Buildx to publish a multi-platform manifest under each released tag.
+
+## Release Flow
+
+The repository already has a release workflow that builds distributions, runs tests, and publishes to GitHub Releases and PyPI. The container image should be added to that same release path instead of introducing an independent image-release system.
+
+Recommended release behavior:
+
+- on release tags, build and push the runtime image to GHCR
+- publish a multi-platform manifest for `amd64` and `arm64`
+- tag the image with the same version as the Python package
+
+Recommended CI behavior outside release:
+
+- validate that the Dockerfile builds
+- validate that the entrypoint starts and fails correctly in expected bad-input cases
+- do not push release images from ordinary PR or branch CI
+
+This preserves the current release discipline while adding the image as another official artifact.
+
+## Validation Strategy
+
+Validation should cover both failure paths and happy paths.
+
+### 1. Image-level failure cases
+
+Verify:
+
+- container fails when `ONESTEP_TARGET` is missing
+- container fails when the target file path does not exist
+- container fails when `onestep check` fails because of invalid YAML
+- container fails when import resolution fails
+
+### 2. Mode A happy path
+
+Use a mounted example worker project and verify that:
+
+- `/workspace` import resolution works
+- `/workspace/src` import resolution works
+- optional dependency installation path behaves correctly
+- the worker reaches the `onestep run` phase successfully
+
+The repo's existing `example/yaml_project/` is the best first validation target.
+
+### 3. Mode B happy path
+
+Build a small derived image with:
+
+- copied project files
+- `ENV ONESTEP_TARGET=/workspace/worker.yaml`
+
+Verify the derived image starts successfully with the same entrypoint contract.
+
+### 4. Release-path validation
+
+During release:
+
+- build and push the multi-platform image
+- ensure the GHCR publish step uses the release tag-derived version
+
+## Documentation Changes
+
+The feature is incomplete without container-focused docs.
+
+Minimum required documentation:
+
+- how to run a mounted workspace worker with the official image
+- how to build a derived worker image with `FROM ghcr.io/repository-owner/onestep-worker`
+- what `ONESTEP_TARGET` means
+- how dependency discovery works in Mode A
+- common failure cases and how to diagnose them
+
+Likely doc touch points:
+
+- `README.md`
+- a dedicated runtime image or deployment document under `docs/` or `deploy/`
+
+## Risks And Tradeoffs
+
+### Larger base image
+
+Shipping `onestep[all]` makes the image easier to adopt but larger than a narrower connector-specific image. This is an explicit tradeoff in favor of product simplicity for the first version.
+
+### Slower Mode A startup
+
+If Mode A installs project dependencies at container start, startup time becomes sensitive to project size and network availability. That is acceptable because Mode A is meant to optimize ease of use, while Mode B remains the production-friendly path for teams that want fixed artifacts.
+
+### Ambiguous `pyproject.toml` installs
+
+Project-local `pyproject.toml` handling can vary depending on packaging shape. The implementation should keep the install rule narrow and document the expected supported project layout rather than trying to handle every Python packaging style in the first version.
+
+### Runtime script complexity
+
+Supporting both A and B in one entrypoint increases script responsibility slightly. This is acceptable because it centralizes behavior and avoids a larger product split.
+
+## Implementation Boundaries
+
+Expected implementation areas:
+
+- container build files for the runtime image
+- an entrypoint script that owns the startup flow
+- CI changes for Docker build validation
+- release workflow changes for GHCR multi-platform publish
+- user-facing docs and examples for A and B usage
+
+The implementation should stay focused on the runtime image product. It should not expand into unrelated deployment refactors or control-plane packaging work.

--- a/scripts/run-worker-image-smoke.sh
+++ b/scripts/run-worker-image-smoke.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 IMAGE_TAG="onestep-worker-local:test"
+DERIVED_TAG="onestep-worker-derived:test"
 
 docker build -f docker/worker/Dockerfile -t "$IMAGE_TAG" .
 
@@ -37,3 +38,13 @@ docker run --rm \
   "$IMAGE_TAG" >"$pyproject_output" 2>&1
 grep -F "onestep-worker: installing project from /workspace/pyproject.toml" "$pyproject_output"
 grep -F '"marker": "mounted-pyproject"' "$pyproject_output"
+
+docker build \
+  -f tests/assets/worker_image/derived/Dockerfile \
+  -t "$DERIVED_TAG" \
+  .
+
+derived_output="$(mktemp)"
+docker run --rm "$DERIVED_TAG" >"$derived_output" 2>&1
+grep -F "onestep-worker: target=/workspace/worker.yaml" "$derived_output"
+grep -F '"marker": "mounted-pyproject"' "$derived_output"

--- a/scripts/run-worker-image-smoke.sh
+++ b/scripts/run-worker-image-smoke.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_TAG="onestep-worker-local:test"
+
+docker build -f docker/worker/Dockerfile -t "$IMAGE_TAG" .
+
+missing_target_output="$(mktemp)"
+if docker run --rm "$IMAGE_TAG" >"$missing_target_output" 2>&1; then
+  echo "expected container without ONESTEP_TARGET to fail" >&2
+  exit 1
+fi
+grep -F "ONESTEP_TARGET is required" "$missing_target_output"
+
+invalid_yaml_output="$(mktemp)"
+if docker run --rm \
+  -e ONESTEP_TARGET=/workspace/worker.yaml \
+  -v "$PWD/tests/assets/worker_image/invalid_yaml:/workspace" \
+  "$IMAGE_TAG" >"$invalid_yaml_output" 2>&1; then
+  echo "expected invalid YAML worker to fail" >&2
+  exit 1
+fi
+grep -F "onestep-worker: running check for /workspace/worker.yaml" "$invalid_yaml_output"

--- a/scripts/run-worker-image-smoke.sh
+++ b/scripts/run-worker-image-smoke.sh
@@ -21,3 +21,19 @@ if docker run --rm \
   exit 1
 fi
 grep -F "onestep-worker: running check for /workspace/worker.yaml" "$invalid_yaml_output"
+
+requirements_output="$(mktemp)"
+docker run --rm \
+  -e ONESTEP_TARGET=worker.yaml \
+  -v "$PWD/tests/assets/worker_image/mounted_requirements:/workspace" \
+  "$IMAGE_TAG" >"$requirements_output" 2>&1
+grep -F "onestep-worker: installing requirements from /workspace/requirements.txt" "$requirements_output"
+grep -F '"marker": "mounted-requirements"' "$requirements_output"
+
+pyproject_output="$(mktemp)"
+docker run --rm \
+  -e ONESTEP_TARGET=worker.yaml \
+  -v "$PWD/tests/assets/worker_image/mounted_pyproject:/workspace" \
+  "$IMAGE_TAG" >"$pyproject_output" 2>&1
+grep -F "onestep-worker: installing project from /workspace/pyproject.toml" "$pyproject_output"
+grep -F '"marker": "mounted-pyproject"' "$pyproject_output"

--- a/tests/assets/worker_image/derived/Dockerfile
+++ b/tests/assets/worker_image/derived/Dockerfile
@@ -1,0 +1,9 @@
+FROM onestep-worker-local:test
+
+WORKDIR /workspace
+
+COPY tests/assets/worker_image/mounted_pyproject/pyproject.toml /workspace/pyproject.toml
+COPY tests/assets/worker_image/mounted_pyproject/worker.yaml /workspace/worker.yaml
+COPY tests/assets/worker_image/mounted_pyproject/src/worker_image_demo_pyproject /workspace/src/worker_image_demo_pyproject
+
+ENV ONESTEP_TARGET=/workspace/worker.yaml

--- a/tests/assets/worker_image/invalid_yaml/worker.yaml
+++ b/tests/assets/worker_image/invalid_yaml/worker.yaml
@@ -1,0 +1,3 @@
+app:
+  name: broken-worker
+tasks: [

--- a/tests/assets/worker_image/mounted_pyproject/pyproject.toml
+++ b/tests/assets/worker_image/mounted_pyproject/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "worker-image-mounted-pyproject"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/tests/assets/worker_image/mounted_pyproject/src/worker_image_demo_pyproject/__init__.py
+++ b/tests/assets/worker_image/mounted_pyproject/src/worker_image_demo_pyproject/__init__.py
@@ -1,0 +1,1 @@
+MARKER = "mounted-pyproject"

--- a/tests/assets/worker_image/mounted_pyproject/src/worker_image_demo_pyproject/tasks.py
+++ b/tests/assets/worker_image/mounted_pyproject/src/worker_image_demo_pyproject/tasks.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import json
+
+from worker_image_demo_pyproject import MARKER
+
+
+async def run_once(ctx, payload):
+    print(json.dumps({"marker": MARKER, "payload": payload}, ensure_ascii=False))
+    ctx.app.request_shutdown()

--- a/tests/assets/worker_image/mounted_pyproject/worker.yaml
+++ b/tests/assets/worker_image/mounted_pyproject/worker.yaml
@@ -1,0 +1,16 @@
+app:
+  name: mounted-pyproject
+
+resources:
+  tick:
+    type: interval
+    seconds: 60
+    immediate: true
+    payload:
+      source: mounted-pyproject
+
+tasks:
+  - name: run_once
+    source: tick
+    handler:
+      ref: worker_image_demo_pyproject.tasks:run_once

--- a/tests/assets/worker_image/mounted_requirements/pyproject.toml
+++ b/tests/assets/worker_image/mounted_requirements/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "worker-image-mounted-requirements"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/tests/assets/worker_image/mounted_requirements/requirements.txt
+++ b/tests/assets/worker_image/mounted_requirements/requirements.txt
@@ -1,0 +1,1 @@
+-e /workspace

--- a/tests/assets/worker_image/mounted_requirements/src/worker_image_demo/__init__.py
+++ b/tests/assets/worker_image/mounted_requirements/src/worker_image_demo/__init__.py
@@ -1,0 +1,1 @@
+MARKER = "mounted-requirements"

--- a/tests/assets/worker_image/mounted_requirements/src/worker_image_demo/tasks.py
+++ b/tests/assets/worker_image/mounted_requirements/src/worker_image_demo/tasks.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import json
+
+from worker_image_demo import MARKER
+
+
+async def run_once(ctx, payload):
+    print(json.dumps({"marker": MARKER, "payload": payload}, ensure_ascii=False))
+    ctx.app.request_shutdown()

--- a/tests/assets/worker_image/mounted_requirements/worker.yaml
+++ b/tests/assets/worker_image/mounted_requirements/worker.yaml
@@ -1,0 +1,16 @@
+app:
+  name: mounted-requirements
+
+resources:
+  tick:
+    type: interval
+    seconds: 60
+    immediate: true
+    payload:
+      source: mounted-requirements
+
+tasks:
+  - name: run_once
+    source: tick
+    handler:
+      ref: worker_image_demo.tasks:run_once


### PR DESCRIPTION
## Summary
- add an official worker runtime image and entrypoint under `docker/worker`
- add smoke coverage for mounted and derived worker image flows
- wire worker image smoke tests into CI and GHCR publishing in release workflow
- document worker image usage in README and deploy docs

## Testing
- ./scripts/run-worker-image-smoke.sh