### PR TITLE
Bump onestep version to 1.2.7 and align release docs (Vibe Kanban)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.2.62
+## 1.2.7
 
 - Adds pure YAML `app.logging.level` support for framework logger control.
 - Emits uniform DEBUG-level sink success logs from the shared runtime send path.

--- a/README.md
+++ b/README.md
@@ -290,13 +290,13 @@ Mounted workspace usage:
 docker run --rm \
   -e ONESTEP_TARGET=/workspace/worker.yaml \
   -v "$PWD:/workspace" \
-  ghcr.io/repository-owner/onestep-worker:1.2.62
+  ghcr.io/repository-owner/onestep-worker:1.2.7
 ```
 
 Derived image usage:
 
 ```dockerfile
-FROM ghcr.io/repository-owner/onestep-worker:1.2.62
+FROM ghcr.io/repository-owner/onestep-worker:1.2.7
 
 WORKDIR /workspace
 COPY . /workspace

--- a/deploy/worker-runtime-image.md
+++ b/deploy/worker-runtime-image.md
@@ -12,7 +12,7 @@ The official worker image packages `onestep[all]` plus a small startup entrypoin
 docker run --rm \
   -e ONESTEP_TARGET=/workspace/worker.yaml \
   -v "$PWD:/workspace" \
-  ghcr.io/repository-owner/onestep-worker:1.2.62
+  ghcr.io/repository-owner/onestep-worker:1.2.7
 ```
 
 Behavior:
@@ -25,7 +25,7 @@ Behavior:
 ## Mode B: derived image
 
 ```dockerfile
-FROM ghcr.io/repository-owner/onestep-worker:1.2.62
+FROM ghcr.io/repository-owner/onestep-worker:1.2.7
 
 WORKDIR /workspace
 COPY . /workspace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep"
-version = "1.2.62"
+version = "1.2.7"
 description = "Async task runtime for queue, polling, schedule, and webhook workloads."
 authors = [
     { name = "miclon", email = "jcnd@163.com" }

--- a/uv.lock
+++ b/uv.lock
@@ -449,7 +449,7 @@ wheels = [
 
 [[package]]
 name = "onestep"
-version = "1.2.62"
+version = "1.2.7"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- bumps the published `onestep` package version from `1.2.62` to `1.2.7` in `pyproject.toml`
- syncs the editable package entry in `uv.lock` to `1.2.7`
- updates the top changelog release heading from `1.2.62` to `1.2.7`
- updates the worker image examples in `README.md` and `deploy/worker-runtime-image.md` to use the `1.2.7` image tag

## Why
This branch was created to upgrade the `onestep` release/version references to `1.2.7` for the requested 1.2.7 branch update. The changes keep the package metadata, lockfile metadata, changelog entry, and user-facing worker image documentation aligned to the same release version.

## Implementation Details
- No runtime code paths or connector behavior were changed in this branch.
- The change is limited to version metadata and release-facing documentation.
- Historical design and plan documents that still mention `1.2.62` were intentionally left untouched, since they describe prior planning context rather than current release metadata.

This PR was written using [Vibe Kanban](https://vibekanban.com)