### PR TITLE
Release claimed table_queue rows when stop signals interrupt fetch

### DIFF
--- a/src/onestep/connectors/base.py
+++ b/src/onestep/connectors/base.py
@@ -18,6 +18,9 @@ class Delivery(abc.ABC):
     async def start_processing(self) -> None:
         return None
 
+    async def release_unstarted(self) -> None:
+        return None
+
     @abc.abstractmethod
     async def ack(self) -> None:
         raise NotImplementedError
@@ -35,6 +38,7 @@ class Source(abc.ABC):
     batch_size: int = 1
     poll_interval_s: float = 1.0
     supports_manual_run: bool = False
+    fetch_is_cancel_safe: bool = True
 
     def __init__(self, name: str) -> None:
         self.name = name

--- a/src/onestep/connectors/mysql.py
+++ b/src/onestep/connectors/mysql.py
@@ -188,8 +188,13 @@ class TableQueueDelivery(Delivery):
     async def fail(self, exc: Exception | None = None) -> None:
         await self._source.fail_row(self._row_ref, exc=exc)
 
+    async def release_unstarted(self) -> None:
+        await self._source.release_row(self._row_ref)
+
 
 class TableQueueSource(Source):
+    fetch_is_cancel_safe = False
+
     def __init__(
         self,
         *,
@@ -263,6 +268,9 @@ class TableQueueSource(Source):
         await self.update_row(row_ref, self.nack)
 
     async def fail_row(self, row_ref: _TableRowRef, exc: Exception | None = None) -> None:
+        await self.update_row(row_ref, self.nack)
+
+    async def release_row(self, row_ref: _TableRowRef) -> None:
         await self.update_row(row_ref, self.nack)
 
     async def update_row(self, row_ref: _TableRowRef, values: Mapping[str, Any]) -> None:

--- a/src/onestep/runtime/runner.py
+++ b/src/onestep/runtime/runner.py
@@ -130,17 +130,19 @@ class TaskRunner:
         )
         try:
             if stop_fetching_task in done:
-                fetch_task.cancel()
-                await asyncio.gather(fetch_task, return_exceptions=True)
+                if self.task.source.fetch_is_cancel_safe:
+                    fetch_task.cancel()
+                    await asyncio.gather(fetch_task, return_exceptions=True)
+                else:
+                    deliveries = await self._resolve_fetch_task(fetch_task)
+                    await self._release_unstarted_deliveries(deliveries)
                 return []
             if fetch_task in done:
-                try:
-                    return fetch_task.result()
-                except ConnectorOperationError as exc:
-                    if not is_retryable_connector_error(exc):
-                        raise
-                    await self._handle_source_fetch_error(exc)
+                deliveries = await self._resolve_fetch_task(fetch_task)
+                if self.app.is_stopping or self.app.is_draining or self.app.is_task_paused(self.task.name):
+                    await self._release_unstarted_deliveries(deliveries)
                     return []
+                return deliveries
             fetch_task.cancel()
             await asyncio.gather(fetch_task, return_exceptions=True)
             return []
@@ -149,6 +151,22 @@ class TaskRunner:
             for pending_task in pending:
                 pending_task.cancel()
             await asyncio.gather(*pending, return_exceptions=True)
+
+    async def _resolve_fetch_task(self, fetch_task: asyncio.Task[list["Delivery"]]) -> list["Delivery"]:
+        try:
+            return await fetch_task
+        except ConnectorOperationError as exc:
+            if not is_retryable_connector_error(exc):
+                raise
+            await self._handle_source_fetch_error(exc)
+            return []
+
+    async def _release_unstarted_deliveries(self, deliveries: list["Delivery"]) -> None:
+        for delivery in deliveries:
+            try:
+                await delivery.release_unstarted()
+            except Exception:
+                self._logger.exception("releasing unstarted delivery failed")
 
     def _track_inflight(self, task: asyncio.Task[None]) -> None:
         self._inflight.add(task)

--- a/tests/contract/test_runtime_contract.py
+++ b/tests/contract/test_runtime_contract.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import signal
+import time
+from pathlib import Path
+
+import sqlalchemy as sa
 
 from onestep import (
     ConnectorErrorKind,
@@ -13,6 +17,7 @@ from onestep import (
     InMemoryStateStore,
     MaxAttempts,
     MemoryQueue,
+    MySQLConnector,
     NoRetry,
     OneStepApp,
     RetryAction,
@@ -398,6 +403,168 @@ def test_task_pause_and_resume_control_intake_contract() -> None:
         ]
 
     asyncio.run(scenario())
+
+
+def _build_table_queue_db(tmp_path: Path) -> tuple[str, sa.Table]:
+    db_url = f"sqlite:///{tmp_path / 'queue.db'}"
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    orders = sa.Table(
+        "orders",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("payload", sa.String, nullable=False),
+        sa.Column("status", sa.Integer, nullable=False),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(sa.insert(orders), [{"id": 1, "payload": "A", "status": 0}])
+    engine.dispose()
+    return db_url, orders
+
+
+def _load_order_rows(db_url: str, orders: sa.Table) -> list[tuple[int, int]]:
+    engine = sa.create_engine(db_url, future=True)
+    with engine.begin() as conn:
+        rows = conn.execute(sa.select(orders.c.id, orders.c.status).order_by(orders.c.id)).all()
+    engine.dispose()
+    return list(rows)
+
+
+def test_table_queue_drain_releases_claimed_rows_when_fetch_is_stopped_contract(tmp_path: Path) -> None:
+    db_url, orders = _build_table_queue_db(tmp_path)
+
+    async def scenario() -> list[int]:
+        app = OneStepApp("table-queue-drain-contract", shutdown_timeout_s=1.0)
+        db = MySQLConnector(db_url)
+        source = db.table_queue(
+            table="orders",
+            key="id",
+            where="status = 0",
+            claim={"status": 9},
+            ack={"status": 1},
+            nack={"status": 0},
+            batch_size=1,
+            poll_interval_s=0.01,
+        )
+        original_fetch = source._fetch_sync
+
+        def slow_fetch(limit: int):
+            rows = original_fetch(limit)
+            time.sleep(0.2)
+            return rows
+
+        source._fetch_sync = slow_fetch
+        seen: list[int] = []
+
+        @app.task(source=source, concurrency=1)
+        async def consume(ctx, row):
+            seen.append(row["id"])
+
+        async def controller() -> None:
+            await asyncio.sleep(0.05)
+            app.request_drain()
+            await asyncio.wait_for(app.wait_for_drain(), timeout=1.0)
+            app.request_shutdown()
+
+        await asyncio.wait_for(asyncio.gather(app.serve(), controller()), timeout=2.0)
+        await db.close()
+        return seen
+
+    seen = asyncio.run(scenario())
+
+    assert seen == []
+    assert _load_order_rows(db_url, orders) == [(1, 0)]
+
+
+def test_table_queue_pause_releases_claimed_rows_when_fetch_is_stopped_contract(tmp_path: Path) -> None:
+    db_url, orders = _build_table_queue_db(tmp_path)
+
+    async def scenario() -> list[int]:
+        app = OneStepApp("table-queue-pause-contract", shutdown_timeout_s=1.0)
+        db = MySQLConnector(db_url)
+        source = db.table_queue(
+            table="orders",
+            key="id",
+            where="status = 0",
+            claim={"status": 9},
+            ack={"status": 1},
+            nack={"status": 0},
+            batch_size=1,
+            poll_interval_s=0.01,
+        )
+        original_fetch = source._fetch_sync
+
+        def slow_fetch(limit: int):
+            rows = original_fetch(limit)
+            time.sleep(0.2)
+            return rows
+
+        source._fetch_sync = slow_fetch
+        seen: list[int] = []
+
+        @app.task(source=source, concurrency=1)
+        async def consume(ctx, row):
+            seen.append(row["id"])
+
+        async def controller() -> None:
+            await asyncio.sleep(0.05)
+            app.request_task_pause("consume")
+            await asyncio.wait_for(app.wait_for_task_pause("consume"), timeout=1.0)
+            app.request_shutdown()
+
+        await asyncio.wait_for(asyncio.gather(app.serve(), controller()), timeout=2.0)
+        await db.close()
+        return seen
+
+    seen = asyncio.run(scenario())
+
+    assert seen == []
+    assert _load_order_rows(db_url, orders) == [(1, 0)]
+
+
+def test_table_queue_shutdown_releases_claimed_rows_when_fetch_is_stopped_contract(tmp_path: Path) -> None:
+    db_url, orders = _build_table_queue_db(tmp_path)
+
+    async def scenario() -> list[int]:
+        app = OneStepApp("table-queue-shutdown-contract", shutdown_timeout_s=1.0)
+        db = MySQLConnector(db_url)
+        source = db.table_queue(
+            table="orders",
+            key="id",
+            where="status = 0",
+            claim={"status": 9},
+            ack={"status": 1},
+            nack={"status": 0},
+            batch_size=1,
+            poll_interval_s=0.01,
+        )
+        original_fetch = source._fetch_sync
+
+        def slow_fetch(limit: int):
+            rows = original_fetch(limit)
+            time.sleep(0.2)
+            return rows
+
+        source._fetch_sync = slow_fetch
+        seen: list[int] = []
+
+        @app.task(source=source, concurrency=1)
+        async def consume(ctx, row):
+            seen.append(row["id"])
+
+        async def controller() -> None:
+            await asyncio.sleep(0.05)
+            app.request_shutdown()
+
+        await asyncio.wait_for(asyncio.gather(app.serve(), controller()), timeout=2.0)
+        await db.close()
+        return seen
+
+    seen = asyncio.run(scenario())
+
+    assert seen == []
+    assert _load_order_rows(db_url, orders) == [(1, 0)]
 
 
 def test_ctx_emit_and_return_follow_separate_contracts() -> None:


### PR DESCRIPTION
## Summary
- treat `table_queue` fetches as not cancel-safe once rows have been claimed
- release unstarted claimed rows when `drain`, `pause_task`, or `shutdown` interrupts fetch completion
- add contract coverage for drain/pause/shutdown against a real sqlite-backed `table_queue`

Closes #69.

## Testing
- `uv run --extra dev pytest tests/contract/test_runtime_contract.py -q`
- `uv run --extra dev pytest tests/test_mysql_table_queue.py tests/test_control_plane_ws.py -q`
- `uv run --extra dev pytest -m "not integration"` *(still fails on the pre-existing `tests/test_mysql_table_queue.py` ordering assertion unrelated to this fix)*