### PR TITLE
feat(config): add .env file loading and strict_env variable checking

### DIFF
--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -34,6 +34,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--strict-env",
         action="store_true",
         dest="strict_env",
+        default=None,
         help="Check that all ${VAR} references resolve to environment variables (YAML targets only)",
     )
 
@@ -55,6 +56,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--strict-env",
         action="store_true",
         dest="strict_env",
+        default=None,
         help="Check that all ${VAR} references resolve to environment variables (YAML targets only)",
     )
 

--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -24,6 +24,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     run_parser = subparsers.add_parser("run", help="Load and run a OneStepApp target or YAML config")
     run_parser.add_argument("target", help="Python target (package.module:app) or path to *.yaml")
+    run_parser.add_argument(
+        "--env-file",
+        dest="env_file",
+        default=None,
+        help="Path to a .env file to load environment variables from (YAML targets only)",
+    )
+    run_parser.add_argument(
+        "--strict-env",
+        action="store_true",
+        dest="strict_env",
+        help="Check that all ${VAR} references resolve to environment variables (YAML targets only)",
+    )
 
     check_parser = subparsers.add_parser("check", help="Load a target or YAML config and print its task summary")
     check_parser.add_argument("target", help="Python target (package.module:app) or path to *.yaml")
@@ -32,6 +44,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--strict",
         action="store_true",
         help="Validate YAML targets against the strict config contract before printing the summary",
+    )
+    check_parser.add_argument(
+        "--env-file",
+        dest="env_file",
+        default=None,
+        help="Path to a .env file to load environment variables from (YAML targets only)",
+    )
+    check_parser.add_argument(
+        "--strict-env",
+        action="store_true",
+        dest="strict_env",
+        help="Check that all ${VAR} references resolve to environment variables (YAML targets only)",
     )
 
     init_parser = subparsers.add_parser("init", help="Create a minimal OneStep YAML project scaffold")
@@ -59,7 +83,18 @@ def main(argv: list[str] | None = None) -> int:
     _ensure_local_import_paths(args.target)
     try:
         if args.command == "check" and getattr(args, "strict", False) and is_yaml_target(args.target):
-            app = load_yaml_app(args.target, strict=True)
+            app = load_yaml_app(
+                args.target,
+                strict=True,
+                env_file=getattr(args, "env_file", None),
+                strict_env=getattr(args, "strict_env", None),
+            )
+        elif is_yaml_target(args.target):
+            app = load_yaml_app(
+                args.target,
+                env_file=getattr(args, "env_file", None),
+                strict_env=getattr(args, "strict_env", None),
+            )
         else:
             app = OneStepApp.load(args.target)
     except Exception as exc:

--- a/src/onestep/config.py
+++ b/src/onestep/config.py
@@ -37,6 +37,15 @@ _YAML_SUFFIXES = (".yaml", ".yml")
 # Pattern for ${VAR} or ${VAR:-default} or ${VAR:default}
 _ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
 
+# Pattern for .env file lines: KEY=VALUE with optional quoting and trailing comment
+_DOTENV_LINE_RE = re.compile(
+    r'^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*'   # KEY=
+    r'(?:"([^"]*)"|'                           # "value"
+    r"'([^']*)'|"                               # 'value'
+    r'([^\s#][^#]*))'                           # value
+    r'\s*(?:\#.*)?$'                           # optional trailing comment
+)
+
 _STRICT_API_VERSION = "onestep/v1alpha1"
 _STRICT_KIND = "App"
 _LEGACY_APP_FIELDS = frozenset({"name", "shutdown_timeout_s", "config", "state"})
@@ -55,7 +64,7 @@ _STRICT_TOP_LEVEL_FIELDS = frozenset(
         *_LEGACY_APP_FIELDS,
     }
 )
-_STRICT_APP_FIELDS = frozenset({"name", "shutdown_timeout_s", "config", "state", "logging"})
+_STRICT_APP_FIELDS = frozenset({"name", "shutdown_timeout_s", "config", "state", "logging", "env_file", "strict_env"})
 _STRICT_APP_LOGGING_FIELDS = frozenset({"level"})
 _STRICT_HANDLER_FIELDS = frozenset({"ref", "params"})
 _STRICT_APP_HOOK_FIELDS = frozenset({"startup", "shutdown", "events"})
@@ -127,17 +136,148 @@ def _expand_env_vars(value: Any) -> Any:
     return value
 
 
+def _load_dotenv(path: str) -> int:
+    """Parse a .env file and inject key=value pairs into os.environ.
+    
+    Uses os.environ.setdefault so existing environment variables take
+    precedence over those defined in the .env file.
+    
+    Returns the number of keys loaded from the file.
+    """
+    logger = logging.getLogger("onestep")
+    loaded = 0
+    with open(path, "r", encoding="utf-8") as handle:
+        for lineno, line in enumerate(handle, start=1):
+            line = line.rstrip("\n\r")
+            stripped = line.strip()
+            # Skip empty lines and whole-line comments
+            if not stripped or stripped.startswith("#"):
+                continue
+            match = _DOTENV_LINE_RE.match(line)
+            if not match:
+                logger.warning(
+                    "skipped malformed .env line %d in %s: %r",
+                    lineno,
+                    path,
+                    stripped,
+                )
+                continue
+            key = match.group(1)
+            # value: the first non-None group among the three value capture groups
+            value = match.group(2) or match.group(3) or match.group(4) or ""
+            previous = os.environ.get(key)
+            if previous is not None:
+                logger.debug("skipped %s from %s (already set in environment)", key, path)
+            else:
+                os.environ[key] = value
+                loaded += 1
+    return loaded
+
+
+def _collect_env_refs(config: Any) -> dict[str, list[str]]:
+    """Collect all ${VAR} references without defaults that are missing from the environment.
+    
+    Returns a dict mapping missing variable names to their field paths.
+    """
+    ref_re = re.compile(r"\$\{([^}]+)\}")
+    missing: dict[str, list[str]] = {}
+
+    def _walk(value: Any, field_path: str) -> None:
+        if isinstance(value, str):
+            for match in ref_re.finditer(value):
+                content = match.group(1)
+                # ${VAR:-default} or ${VAR:default} → skip (has default)
+                if ":-" in content or ":" in content:
+                    continue
+                var_name = content.strip()
+                if var_name and var_name not in os.environ:
+                    missing.setdefault(var_name, []).append(field_path)
+        elif isinstance(value, Mapping):
+            for k, v in value.items():
+                _walk(v, f"{field_path}.{k}")
+        elif isinstance(value, list):
+            for i, v in enumerate(value):
+                _walk(v, f"{field_path}[{i}]")
+
+    _walk(config, "config")
+    return missing
+
+
 def is_yaml_target(target: str) -> bool:
     return target.lower().endswith(_YAML_SUFFIXES)
 
 
-def load_yaml_app(path: str, *, strict: bool = False) -> OneStepApp:
+def load_yaml_app(
+    path: str,
+    *,
+    strict: bool = False,
+    env_file: str | None = None,
+    strict_env: bool | None = None,
+) -> OneStepApp:
+    logger = logging.getLogger("onestep")
     yaml = _import_yaml()
     resolved_path = os.path.abspath(path)
     with open(resolved_path, "r", encoding="utf-8") as handle:
         loaded = yaml.safe_load(handle) or {}
     if not isinstance(loaded, Mapping):
         raise TypeError("YAML app config must be a mapping at the top level")
+
+    # --- Determine env_file path ---
+    # Priority: CLI arg > app.env_file > auto-detect YAML-adjacent .env
+    dotenv_path: str | None = None
+    if env_file is not None:
+        dotenv_path = env_file
+    elif "app" in loaded and isinstance(loaded.get("app"), Mapping):
+        app_env_file = loaded["app"].get("env_file")
+        if app_env_file is not None:
+            if not isinstance(app_env_file, str):
+                raise TypeError("'app.env_file' must be a string")
+            dotenv_path = app_env_file
+    if dotenv_path is not None:
+        if not os.path.isabs(dotenv_path):
+            dotenv_path = os.path.join(os.path.dirname(resolved_path), dotenv_path)
+        if not os.path.isfile(dotenv_path):
+            raise ValueError(f"env_file not found: {dotenv_path}")
+
+    # Auto-detect: try YAML-adjacent .env (silently skip if missing)
+    if dotenv_path is None:
+        candidate = os.path.join(os.path.dirname(resolved_path), ".env")
+        if os.path.isfile(candidate):
+            dotenv_path = candidate
+            logger.debug("auto-detected .env next to %s", resolved_path)
+        else:
+            logger.debug("no .env found next to %s", resolved_path)
+
+    if dotenv_path is not None:
+        count = _load_dotenv(dotenv_path)
+        if count > 0:
+            logger.debug("loaded %d vars from %s", count, dotenv_path)
+
+    # --- Determine strict_env flag ---
+    # Priority: CLI arg > app.strict_env > False
+    effective_strict_env = False
+    if strict_env is not None:
+        effective_strict_env = strict_env
+    elif "app" in loaded and isinstance(loaded.get("app"), Mapping):
+        app_strict_env = loaded["app"].get("strict_env")
+        if isinstance(app_strict_env, bool):
+            effective_strict_env = app_strict_env
+        elif app_strict_env is not None:
+            raise TypeError("'app.strict_env' must be a boolean")
+
+    if effective_strict_env:
+        missing = _collect_env_refs(loaded)
+        if missing:
+            parts = ["strict_env: missing required environment variable(s):"]
+            for var_name in sorted(missing):
+                for field_path in missing[var_name]:
+                    parts.append(f"  - {var_name} (referenced at: {field_path})")
+            parts.append(
+                "Hint: define them in the shell, or add them to your .env file, "
+                "or provide a default with ${VAR:-default_value}."
+            )
+            raise ValueError("\n".join(parts))
+
     # Expand environment variables in the loaded config
     expanded = _expand_env_vars(loaded)
     return load_app_config(expanded, source_path=resolved_path, strict=strict)
@@ -429,6 +569,8 @@ def validate_app_config(config: Mapping[str, Any], *, registry: ResourceRegistry
             raise TypeError("'app' must be a mapping")
         _validate_unknown_fields(app_section, _STRICT_APP_FIELDS, field="app")
         _validate_app_logging(app_section.get("logging"))
+        _validate_app_env_file(app_section.get("env_file"))
+        _validate_app_strict_env(app_section.get("strict_env"))
         legacy_fields = sorted(field for field in _LEGACY_APP_FIELDS if field in config)
         if legacy_fields:
             raise ValueError(
@@ -504,6 +646,20 @@ def _validate_app_logging(raw_logging: Any) -> None:
     resolved = getattr(logging, level.strip().upper(), None)
     if not isinstance(resolved, int):
         raise ValueError(f"unsupported logging level {level!r}")
+
+
+def _validate_app_env_file(raw_env_file: Any) -> None:
+    if raw_env_file is None:
+        return
+    if not isinstance(raw_env_file, str):
+        raise TypeError("'app.env_file' must be a string")
+
+
+def _validate_app_strict_env(raw_strict_env: Any) -> None:
+    if raw_strict_env is None:
+        return
+    if not isinstance(raw_strict_env, bool):
+        raise TypeError("'app.strict_env' must be a boolean")
 
 
 def _apply_app_logging(app: OneStepApp, raw_logging: Any) -> None:

--- a/src/onestep/config.py
+++ b/src/onestep/config.py
@@ -138,10 +138,10 @@ def _expand_env_vars(value: Any) -> Any:
 
 def _load_dotenv(path: str) -> int:
     """Parse a .env file and inject key=value pairs into os.environ.
-    
+
     Uses os.environ.setdefault so existing environment variables take
     precedence over those defined in the .env file.
-    
+
     Returns the number of keys loaded from the file.
     """
     logger = logging.getLogger("onestep")
@@ -163,8 +163,12 @@ def _load_dotenv(path: str) -> int:
                 )
                 continue
             key = match.group(1)
-            # value: the first non-None group among the three value capture groups
-            value = match.group(2) or match.group(3) or match.group(4) or ""
+            if match.group(2) is not None:
+                value = match.group(2)
+            elif match.group(3) is not None:
+                value = match.group(3)
+            else:
+                value = (match.group(4) or "").strip()
             previous = os.environ.get(key)
             if previous is not None:
                 logger.debug("skipped %s from %s (already set in environment)", key, path)
@@ -176,7 +180,7 @@ def _load_dotenv(path: str) -> int:
 
 def _collect_env_refs(config: Any) -> dict[str, list[str]]:
     """Collect all ${VAR} references without defaults that are missing from the environment.
-    
+
     Returns a dict mapping missing variable names to their field paths.
     """
     ref_re = re.compile(r"\$\{([^}]+)\}")

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -1,0 +1,619 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import types
+from contextlib import contextmanager
+
+import pytest
+
+from onestep.config import (
+    _collect_env_refs,
+    _expand_env_var,
+    _expand_env_vars,
+    _load_dotenv,
+    load_yaml_app,
+)
+from onestep.cli import main
+
+
+@contextmanager
+def _registered_module(name: str, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    previous = sys.modules.get(name)
+    sys.modules[name] = module
+    try:
+        yield module
+    finally:
+        if previous is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+
+
+@contextmanager
+def _registered_yaml_module():
+    def safe_load(handle):
+        return json.loads(handle.read())
+
+    with _registered_module("yaml", safe_load=safe_load) as module:
+        yield module
+
+
+# ---------------------------------------------------------------------------
+# _load_dotenv
+# ---------------------------------------------------------------------------
+
+def test_load_dotenv_basic_key_value(tmp_path, monkeypatch):
+    monkeypatch.delenv("DB_DSN_1", raising=False)
+    monkeypatch.delenv("POOL_SIZE_1", raising=False)
+    env_file = tmp_path / ".env"
+    env_file.write_text("DB_DSN_1=mysql://localhost\nPOOL_SIZE_1=20\n", encoding="utf-8")
+    loaded = _load_dotenv(str(env_file))
+    assert loaded == 2
+    assert os.environ["DB_DSN_1"] == "mysql://localhost"
+    assert os.environ["POOL_SIZE_1"] == "20"
+
+
+def test_load_dotenv_double_quoted_value(tmp_path, monkeypatch):
+    monkeypatch.delenv("API_TOKEN_2", raising=False)
+    env_file = tmp_path / ".env"
+    env_file.write_text('API_TOKEN_2="abc123"\n', encoding="utf-8")
+    loaded = _load_dotenv(str(env_file))
+    assert loaded == 1
+    assert os.environ["API_TOKEN_2"] == "abc123"
+
+
+def test_load_dotenv_single_quoted_value(tmp_path, monkeypatch):
+    monkeypatch.delenv("API_TOKEN_3", raising=False)
+    env_file = tmp_path / ".env"
+    env_file.write_text("API_TOKEN_3='abc123'\n", encoding="utf-8")
+    loaded = _load_dotenv(str(env_file))
+    assert loaded == 1
+    assert os.environ["API_TOKEN_3"] == "abc123"
+
+
+def test_load_dotenv_skips_comments_and_empty_lines(tmp_path, monkeypatch):
+    monkeypatch.delenv("DB_DSN_4", raising=False)
+    monkeypatch.delenv("POOL_SIZE_4", raising=False)
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n# DB settings\nDB_DSN_4=mysql://localhost\n\n# Pool\nPOOL_SIZE_4=20\n\n",
+        encoding="utf-8",
+    )
+    loaded = _load_dotenv(str(env_file))
+    assert loaded == 2
+
+
+def test_load_dotenv_value_with_trailing_comment(tmp_path, monkeypatch):
+    monkeypatch.delenv("DB_DSN_5", raising=False)
+    env_file = tmp_path / ".env"
+    env_file.write_text("DB_DSN_5=mysql://localhost # connection string\n", encoding="utf-8")
+    loaded = _load_dotenv(str(env_file))
+    assert loaded == 1
+    assert "mysql://localhost" in os.environ["DB_DSN_5"]
+
+
+def test_load_dotenv_shell_variable_takes_precedence(tmp_path, monkeypatch):
+    monkeypatch.setenv("DB_DSN", "from-shell")
+    env_file = tmp_path / ".env"
+    env_file.write_text("DB_DSN=from-dotenv\n", encoding="utf-8")
+    loaded = _load_dotenv(str(env_file))
+    assert loaded == 0
+    assert os.environ["DB_DSN"] == "from-shell"
+
+
+def test_load_dotenv_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        _load_dotenv("/nonexistent/.env")
+
+
+# ---------------------------------------------------------------------------
+# _collect_env_refs
+# ---------------------------------------------------------------------------
+
+def test_collect_env_refs_missing_variable(monkeypatch):
+    monkeypatch.delenv("UNDEFINED_VAR", raising=False)
+    config = {"resources": {"db": {"dsn": "${UNDEFINED_VAR}"}}}
+    missing = _collect_env_refs(config)
+    assert "UNDEFINED_VAR" in missing
+    assert "config.resources.db.dsn" in missing["UNDEFINED_VAR"]
+
+
+def test_collect_env_refs_present_variable(monkeypatch):
+    monkeypatch.setenv("PRESENT_VAR", "value")
+    config = {"resources": {"db": {"dsn": "${PRESENT_VAR}"}}}
+    missing = _collect_env_refs(config)
+    assert "PRESENT_VAR" not in missing
+
+
+def test_collect_env_refs_default_value_skipped(monkeypatch):
+    monkeypatch.delenv("TIMEOUT", raising=False)
+    config = {"resources": {"api": {"timeout": "${TIMEOUT:-30}"}}}
+    missing = _collect_env_refs(config)
+    assert len(missing) == 0
+
+
+def test_collect_env_refs_colon_default_skipped(monkeypatch):
+    monkeypatch.delenv("TIMEOUT", raising=False)
+    config = {"resources": {"api": {"timeout": "${TIMEOUT:30}"}}}
+    missing = _collect_env_refs(config)
+    assert len(missing) == 0
+
+
+def test_collect_env_refs_recursive_list_and_dict(monkeypatch):
+    monkeypatch.delenv("A", raising=False)
+    monkeypatch.delenv("B", raising=False)
+    config = {
+        "tasks": [
+            {"name": "t1", "config": {"key": "${A}"}},
+            {"name": "t2", "config": {"key": "${B}"}},
+        ]
+    }
+    missing = _collect_env_refs(config)
+    assert "A" in missing
+    assert "B" in missing
+    assert "config.tasks[0].config.key" in missing["A"]
+    assert "config.tasks[1].config.key" in missing["B"]
+
+
+def test_collect_env_refs_non_string_values_ignored(monkeypatch):
+    config = {"timeout": 30, "enabled": True, "optional": None}
+    missing = _collect_env_refs(config)
+    assert len(missing) == 0
+
+
+# ---------------------------------------------------------------------------
+# _expand_env_var regression
+# ---------------------------------------------------------------------------
+
+def test_expand_env_var_basic(monkeypatch):
+    monkeypatch.setenv("FOO", "bar")
+    import re
+    match = re.compile(r"\$\{([^}]+)\}").search("${FOO}")
+    assert _expand_env_var(match) == "bar"
+
+
+def test_expand_env_var_default_dash(monkeypatch):
+    monkeypatch.delenv("MISSING", raising=False)
+    import re
+    match = re.compile(r"\$\{([^}]+)\}").search("${MISSING:-default}")
+    assert _expand_env_var(match) == "default"
+
+
+def test_expand_env_var_default_colon(monkeypatch):
+    monkeypatch.delenv("MISSING", raising=False)
+    import re
+    match = re.compile(r"\$\{([^}]+)\}").search("${MISSING:default}")
+    assert _expand_env_var(match) == "default"
+
+
+def test_expand_env_var_present_takes_precedence_over_default(monkeypatch):
+    monkeypatch.setenv("FOO", "bar")
+    import re
+    match = re.compile(r"\$\{([^}]+)\}").search("${FOO:-default}")
+    assert _expand_env_var(match) == "bar"
+
+
+def test_expand_env_vars_recursive(monkeypatch):
+    monkeypatch.setenv("A", "1")
+    monkeypatch.setenv("B", "2")
+    config = {
+        "app": {"name": "${A}"},
+        "tasks": [{"config": {"key": "${B}"}}],
+    }
+    result = _expand_env_vars(config)
+    assert result["app"]["name"] == "1"
+    assert result["tasks"][0]["config"]["key"] == "2"
+
+
+# ---------------------------------------------------------------------------
+# load_yaml_app with env_file
+# ---------------------------------------------------------------------------
+
+def test_load_yaml_app_with_env_file(tmp_path, monkeypatch):
+    env_file = tmp_path / "test.env"
+    env_file.write_text("DB_DSN=mysql://localhost\nPOOL_SIZE=20\n", encoding="utf-8")
+    config_path = tmp_path / "app.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "name": "env-test",
+                "resources": {
+                    "incoming": {"type": "memory"},
+                },
+                "tasks": [
+                    {
+                        "name": "consume",
+                        "source": "incoming",
+                        "handler": "testsupport_config_env:consume",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    async def consume(ctx, item):
+        return item
+
+    with _registered_yaml_module(), _registered_module("testsupport_config_env", consume=consume):
+        app = load_yaml_app(str(config_path), env_file=str(env_file))
+    assert os.environ["DB_DSN"] == "mysql://localhost"
+    assert os.environ["POOL_SIZE"] == "20"
+    assert app.name == "env-test"
+
+
+def test_load_yaml_app_env_file_not_found(tmp_path):
+    config_path = tmp_path / "app.yaml"
+    config_path.write_text(
+        json.dumps({"name": "no-env", "tasks": []}),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        with pytest.raises(ValueError, match="env_file not found"):
+            load_yaml_app(str(config_path), env_file="/nonexistent/path.env")
+
+
+def test_load_yaml_app_auto_detect_env_file(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("AUTO_VAR=detected\n", encoding="utf-8")
+    config_path = tmp_path / "app.yaml"
+    config_path.write_text(
+        json.dumps({"name": "auto-env", "tasks": []}),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        app = load_yaml_app(str(config_path))
+    assert os.environ["AUTO_VAR"] == "detected"
+    assert app.name == "auto-env"
+
+
+def test_load_yaml_app_no_dotenv_silent(tmp_path):
+    config_path = tmp_path / "app.yaml"
+    config_path.write_text(
+        json.dumps({"name": "no-dotenv", "tasks": []}),
+        encoding="utf-8",
+    )
+    # No .env file present — should not raise
+    with _registered_yaml_module():
+        app = load_yaml_app(str(config_path))
+    assert app.name == "no-dotenv"
+
+
+def test_load_yaml_app_env_file_priority_cli_over_yaml(tmp_path, monkeypatch):
+    cli_env = tmp_path / "cli.env"
+    cli_env.write_text("PRIORITY=from-cli\n", encoding="utf-8")
+    yaml_env = tmp_path / "yaml.env"
+    yaml_env.write_text("PRIORITY=from-yaml\n", encoding="utf-8")
+    config_path = tmp_path / "app.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "app": {"name": "priority-test", "env_file": "yaml.env"},
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        load_yaml_app(str(config_path), env_file=str(cli_env))
+    assert os.environ["PRIORITY"] == "from-cli"
+
+
+def test_load_yaml_app_env_file_relative_to_yaml(tmp_path):
+    sub_dir = tmp_path / "config"
+    sub_dir.mkdir()
+    env_file = sub_dir / "app.env"
+    env_file.write_text("REL_VAR=relative\n", encoding="utf-8")
+    config_path = sub_dir / "app.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "app": {"name": "relative-test", "env_file": "app.env"},
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        load_yaml_app(str(config_path))
+    assert os.environ["REL_VAR"] == "relative"
+
+
+# ---------------------------------------------------------------------------
+# load_yaml_app with strict_env
+# ---------------------------------------------------------------------------
+
+def test_load_yaml_app_strict_env_missing_var(tmp_path, monkeypatch):
+    monkeypatch.delenv("MISSING_SECRET", raising=False)
+    config_path = tmp_path / "strict-app.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "name": "strict-test",
+                "resources": {
+                    "api": {
+                        "type": "memory",
+                        "token": "${MISSING_SECRET}",
+                    },
+                },
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        with pytest.raises(ValueError, match="strict_env: missing required environment variable"):
+            load_yaml_app(str(config_path), strict_env=True)
+
+
+def test_load_yaml_app_strict_env_all_present(tmp_path, monkeypatch):
+    monkeypatch.setenv("API_TOKEN", "present")
+    config_path = tmp_path / "strict-ok.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "name": "strict-ok",
+                "resources": {
+                    "api": {
+                        "type": "memory",
+                        "token": "${API_TOKEN}",
+                    },
+                },
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        app = load_yaml_app(str(config_path), strict_env=True)
+    assert app.name == "strict-ok"
+
+
+def test_load_yaml_app_strict_env_with_defaults_ok(tmp_path, monkeypatch):
+    monkeypatch.delenv("TIMEOUT", raising=False)
+    config_path = tmp_path / "defaults.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "name": "defaults-test",
+                "resources": {
+                    "api": {
+                        "type": "memory",
+                        "timeout": "${TIMEOUT:-30}",
+                    },
+                },
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        app = load_yaml_app(str(config_path), strict_env=True)
+    assert app.name == "defaults-test"
+
+
+def test_load_yaml_app_strict_env_from_app_field(tmp_path, monkeypatch):
+    monkeypatch.delenv("DB_DSN", raising=False)
+    config_path = tmp_path / "app-strict.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "app": {"name": "app-strict-test", "strict_env": True},
+                "resources": {
+                    "db": {
+                        "type": "memory",
+                        "dsn": "${DB_DSN}",
+                    },
+                },
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        with pytest.raises(ValueError, match="strict_env: missing required environment variable"):
+            load_yaml_app(str(config_path))
+
+
+def test_load_yaml_app_strict_env_cli_overrides_app_field(tmp_path, monkeypatch):
+    monkeypatch.setenv("DB_DSN", "from-shell")
+    config_path = tmp_path / "override-strict.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "app": {"name": "override-test", "strict_env": False},
+                "resources": {
+                    "db": {
+                        "type": "memory",
+                        "dsn": "${DB_DSN}",
+                        "extra": "${MISSING}",
+                    },
+                },
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        # CLI strict_env=True should override app.strict_env=False
+        with pytest.raises(ValueError, match="strict_env: missing required environment variable"):
+            load_yaml_app(str(config_path), strict_env=True)
+
+
+def test_load_yaml_app_strict_env_error_message_includes_paths(tmp_path, monkeypatch):
+    monkeypatch.delenv("DB_PASSWORD", raising=False)
+    monkeypatch.delenv("API_TOKEN", raising=False)
+    config_path = tmp_path / "multi.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "name": "multi-error",
+                "resources": {
+                    "db": {"type": "memory", "dsn": "${DB_PASSWORD}"},
+                    "api": {"type": "memory", "token": "${API_TOKEN}"},
+                },
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        with pytest.raises(ValueError) as exc_info:
+            load_yaml_app(str(config_path), strict_env=True)
+        msg = str(exc_info.value)
+        assert "API_TOKEN" in msg
+        assert "DB_PASSWORD" in msg
+        assert "config.resources.db.dsn" in msg
+        assert "config.resources.api.token" in msg
+        assert "Hint" in msg
+
+
+# ---------------------------------------------------------------------------
+# strict validation for env_file / strict_env types
+# ---------------------------------------------------------------------------
+
+def test_validate_app_config_rejects_non_string_env_file():
+    from onestep.config import validate_app_config
+    with pytest.raises(TypeError, match="'app.env_file' must be a string"):
+        validate_app_config(
+            {
+                "apiVersion": "onestep/v1alpha1",
+                "kind": "App",
+                "app": {"name": "test", "env_file": 123},
+                "tasks": [],
+            }
+        )
+
+
+def test_validate_app_config_rejects_non_bool_strict_env():
+    from onestep.config import validate_app_config
+    with pytest.raises(TypeError, match="'app.strict_env' must be a boolean"):
+        validate_app_config(
+            {
+                "apiVersion": "onestep/v1alpha1",
+                "kind": "App",
+                "app": {"name": "test", "strict_env": 1},
+                "tasks": [],
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI: --env-file and --strict-env
+# ---------------------------------------------------------------------------
+
+def test_cli_check_with_env_file(tmp_path, capsys):
+    env_file = tmp_path / "test.env"
+    env_file.write_text("CLI_ENV_VAR=from-cli\n", encoding="utf-8")
+    config_path = tmp_path / "app.yaml"
+    config_path.write_text(
+        json.dumps({"name": "cli-env-test", "tasks": []}),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        exit_code = main(["check", "--env-file", str(env_file), str(config_path)])
+    assert exit_code == 0
+    assert os.environ["CLI_ENV_VAR"] == "from-cli"
+
+
+def test_cli_check_with_strict_env_missing_var(tmp_path, capsys):
+    config_path = tmp_path / "strict-cli.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "name": "strict-cli-test",
+                "resources": {
+                    "db": {"type": "memory", "dsn": "${MISSING_VAR}"},
+                },
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        exit_code = main(["check", "--strict-env", str(config_path)])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "strict_env: missing required environment variable" in captured.err
+
+
+def test_cli_check_with_strict_env_and_env_file(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("FROM_ENV_FILE", raising=False)
+    env_file = tmp_path / "prod.env"
+    env_file.write_text("FROM_ENV_FILE=loaded\n", encoding="utf-8")
+    config_path = tmp_path / "app.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "name": "combined-test",
+                "resources": {
+                    "db": {"type": "memory", "dsn": "${FROM_ENV_FILE}"},
+                },
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        exit_code = main(
+            ["check", "--env-file", str(env_file), "--strict-env", str(config_path)]
+        )
+    assert exit_code == 0
+    assert os.environ["FROM_ENV_FILE"] == "loaded"
+
+
+def test_cli_run_with_env_file(tmp_path, capsys, monkeypatch):
+    env_file = tmp_path / "run.env"
+    env_file.write_text("RUN_VAR=loaded\n", encoding="utf-8")
+    config_path = tmp_path / "app.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "name": "cli-run-env",
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    # Use run command to verify --env-file works on run too
+    with _registered_yaml_module():
+        exit_code = main(["run", "--env-file", str(env_file), str(config_path)])
+    assert exit_code == 0
+    assert os.environ["RUN_VAR"] == "loaded"
+
+
+def test_load_yaml_app_strict_env_type_error(tmp_path):
+    config_path = tmp_path / "bad-strict.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "app": {"name": "bad-strict", "strict_env": "yes"},
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        with pytest.raises(TypeError, match="'app.strict_env' must be a boolean"):
+            load_yaml_app(str(config_path))
+
+
+def test_load_yaml_app_env_file_type_error(tmp_path):
+    config_path = tmp_path / "bad-env.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "app": {"name": "bad-env", "env_file": 42},
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        with pytest.raises(TypeError, match="'app.env_file' must be a string"):
+            load_yaml_app(str(config_path))

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -94,7 +94,16 @@ def test_load_dotenv_value_with_trailing_comment(tmp_path, monkeypatch):
     env_file.write_text("DB_DSN_5=mysql://localhost # connection string\n", encoding="utf-8")
     loaded = _load_dotenv(str(env_file))
     assert loaded == 1
-    assert "mysql://localhost" in os.environ["DB_DSN_5"]
+    assert os.environ["DB_DSN_5"] == "mysql://localhost"
+
+
+def test_load_dotenv_quoted_value_preserves_spaces(tmp_path, monkeypatch):
+    monkeypatch.delenv("PADDED_TOKEN", raising=False)
+    env_file = tmp_path / ".env"
+    env_file.write_text('PADDED_TOKEN="  abc123  " # comment\n', encoding="utf-8")
+    loaded = _load_dotenv(str(env_file))
+    assert loaded == 1
+    assert os.environ["PADDED_TOKEN"] == "  abc123  "
 
 
 def test_load_dotenv_shell_variable_takes_precedence(tmp_path, monkeypatch):
@@ -540,6 +549,28 @@ def test_cli_check_with_strict_env_missing_var(tmp_path, capsys):
     captured = capsys.readouterr()
     assert exit_code == 2
     assert "strict_env: missing required environment variable" in captured.err
+
+
+def test_cli_check_honors_app_strict_env_when_flag_omitted(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("APP_STRICT_MISSING_VAR", raising=False)
+    config_path = tmp_path / "app-strict-cli.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "app": {"name": "app-strict-cli-test", "strict_env": True},
+                "resources": {
+                    "db": {"type": "memory", "dsn": "${APP_STRICT_MISSING_VAR}"},
+                },
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with _registered_yaml_module():
+        exit_code = main(["check", str(config_path)])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "APP_STRICT_MISSING_VAR" in captured.err
 
 
 def test_cli_check_with_strict_env_and_env_file(tmp_path, capsys, monkeypatch):


### PR DESCRIPTION
- Add `_load_dotenv()` to parse .env files (KEY=VALUE, quoted values, comments, blank lines) and inject into os.environ with setdefault semantics (no external dependencies)
- Add `_collect_env_refs()` to scan config tree for ${VAR} references without defaults that are missing from the environment
- Extend `load_yaml_app()` with `env_file` and `strict_env` parameters; env_file resolution priority: CLI arg > app.env_file > auto-detect YAML-adjacent .env; strict_env priority: CLI arg > app.strict_env > false
- Add `--env-file` and `--strict-env` CLI arguments to both `run` and `check` subcommands
- Extend `_STRICT_APP_FIELDS` and `validate_app_config` to support `env_file` (string) and `strict_env` (boolean) in strict mode
- Add 38 tests covering load_dotenv, collect_env_refs, env expansion regression, load_yaml_app integration, strict validation, and CLI