### PR TITLE
feat: add postgres plugin

### DIFF
--- a/.github/workflows/plugin-postgres.yml
+++ b/.github/workflows/plugin-postgres.yml
@@ -1,0 +1,240 @@
+name: PostgreSQL Plugin
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/plugin-postgres.yml"
+      - "plugins/onestep-postgres/**"
+      - "src/**"
+      - "pyproject.toml"
+  pull_request:
+    paths:
+      - ".github/workflows/plugin-postgres.yml"
+      - "plugins/onestep-postgres/**"
+      - "src/**"
+      - "pyproject.toml"
+  workflow_dispatch:
+    inputs:
+      publish_pypi:
+        description: "Publish the current onestep-postgres version to PyPI"
+        required: false
+        default: false
+        type: boolean
+      version:
+        description: "Optional expected plugin version, for example 0.1.0"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: postgres-plugin-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PLUGIN_PACKAGE: onestep-postgres
+  PLUGIN_PATH: plugins/onestep-postgres
+  PLUGIN_PYPROJECT: plugins/onestep-postgres/pyproject.toml
+
+jobs:
+  test:
+    name: Test plugin (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install plugin test dependencies
+        run: uv sync --frozen --all-packages --extra test
+
+      - name: Run plugin tests
+        run: uv run --all-packages python -m pytest -q "$PLUGIN_PATH/tests"
+
+      - name: Build plugin distribution
+        run: uv build --package "$PLUGIN_PACKAGE" --out-dir dist/plugin --sdist --wheel --clear
+
+      - name: Check plugin metadata
+        run: uvx twine check dist/plugin/*
+
+  detect-version:
+    name: Detect plugin version change
+    runs-on: ubuntu-latest
+    outputs:
+      current_version: ${{ steps.detect.outputs.current_version }}
+      previous_version: ${{ steps.detect.outputs.previous_version }}
+      should_publish: ${{ steps.detect.outputs.should_publish }}
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Detect version change
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          INPUT_PUBLISH_PYPI: ${{ github.event.inputs.publish_pypi || 'false' }}
+          INPUT_VERSION: ${{ github.event.inputs.version || '' }}
+        run: |
+          set -euo pipefail
+
+          read_version() {
+            python3 -c 'import pathlib, re, sys; text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"); match = re.search(r"(?m)^version\s*=\s*\"([^\"]+)\"", text); print(match.group(1) if match else sys.exit(f"project.version not found in {sys.argv[1]}"))' "$1"
+          }
+
+          CURRENT_VERSION="$(read_version "$PLUGIN_PYPROJECT")"
+          PREVIOUS_VERSION=""
+          SHOULD_PUBLISH=false
+          PROJECT_EXISTS_ON_PYPI=false
+          VERSION_EXISTS_ON_PYPI=false
+          PYPI_STATUS=unknown
+
+          PYPI_STATUS="$(python3 - "$CURRENT_VERSION" "$PLUGIN_PACKAGE" <<'PY'
+          import json
+          import socket
+          import sys
+          import urllib.error
+          import urllib.request
+
+          version = sys.argv[1]
+          package = sys.argv[2]
+          try:
+              with urllib.request.urlopen(f"https://pypi.org/pypi/{package}/json", timeout=20) as response:
+                  releases = json.load(response).get("releases", {})
+          except urllib.error.HTTPError as exc:
+              if exc.code == 404:
+                  print("missing-project")
+                  raise SystemExit(0)
+              print("unknown")
+              raise SystemExit(0)
+          except (TimeoutError, socket.timeout, urllib.error.URLError):
+              print("unknown")
+              raise SystemExit(0)
+          print("version-exists" if releases.get(version) else "missing-version")
+          PY
+          )"
+
+          if [ "$PYPI_STATUS" = "version-exists" ]; then
+            PROJECT_EXISTS_ON_PYPI=true
+            VERSION_EXISTS_ON_PYPI=true
+          elif [ "$PYPI_STATUS" = "missing-version" ]; then
+            PROJECT_EXISTS_ON_PYPI=true
+          fi
+
+          if [ "$EVENT_NAME" = "push" ]; then
+            if [ "$PYPI_STATUS" = "unknown" ]; then
+              echo "::notice::Could not determine PyPI status for $PLUGIN_PACKAGE. Skipping automatic publish on push; use workflow_dispatch with publish_pypi=true when PyPI is healthy."
+            fi
+
+            if [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+              if git cat-file -e "$BEFORE_SHA:$PLUGIN_PYPROJECT" 2>/dev/null; then
+                git show "$BEFORE_SHA:$PLUGIN_PYPROJECT" > /tmp/previous-plugin-pyproject.toml
+                PREVIOUS_VERSION="$(read_version /tmp/previous-plugin-pyproject.toml)"
+              fi
+            fi
+
+            if [ "$PYPI_STATUS" = "unknown" ]; then
+              SHOULD_PUBLISH=false
+            elif [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
+              if [ "$PROJECT_EXISTS_ON_PYPI" = "true" ]; then
+                SHOULD_PUBLISH=true
+              else
+                echo "::notice::Package $PLUGIN_PACKAGE does not exist on PyPI yet. Use workflow_dispatch with publish_pypi=true after PyPI's new-project creation limit resets."
+              fi
+            elif [ "$PROJECT_EXISTS_ON_PYPI" = "true" ] && [ "$VERSION_EXISTS_ON_PYPI" != "true" ]; then
+              SHOULD_PUBLISH=true
+            fi
+          elif [ "$INPUT_PUBLISH_PYPI" = "true" ]; then
+            if [ -n "$INPUT_VERSION" ] && [ "$INPUT_VERSION" != "$CURRENT_VERSION" ]; then
+              echo "Requested plugin version '$INPUT_VERSION' does not match current version '$CURRENT_VERSION'." >&2
+              exit 1
+            fi
+            SHOULD_PUBLISH=true
+          fi
+
+          {
+            echo "current_version=$CURRENT_VERSION"
+            echo "previous_version=$PREVIOUS_VERSION"
+            echo "should_publish=$SHOULD_PUBLISH"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Current plugin version: $CURRENT_VERSION"
+          echo "Previous plugin version: ${PREVIOUS_VERSION:-<none>}"
+          echo "PyPI status: $PYPI_STATUS"
+          echo "Project exists on PyPI: $PROJECT_EXISTS_ON_PYPI"
+          echo "Version exists on PyPI: $VERSION_EXISTS_ON_PYPI"
+          echo "Publish plugin: $SHOULD_PUBLISH"
+
+  publish-pypi:
+    name: Publish plugin to PyPI
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - detect-version
+    if: >-
+      ${{
+        needs.test.result == 'success' &&
+        needs.detect-version.outputs.should_publish == 'true'
+      }}
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build plugin distribution
+        run: uv build --package "$PLUGIN_PACKAGE" --out-dir dist/plugin --sdist --wheel --clear
+
+      - name: Check plugin metadata
+        run: uvx twine check dist/plugin/*
+
+      - name: Verify onestep dependency is published
+        run: |
+          set -euo pipefail
+
+          REQUIRED_ONESTEP_VERSION="$(
+            python3 -c 'import pathlib, re, sys; text = pathlib.Path("plugins/onestep-postgres/pyproject.toml").read_text(encoding="utf-8"); match = re.search(r"onestep\s*>=\s*([0-9]+(?:\.[0-9]+)*(?:[A-Za-z0-9._+-]*)?)", text); print(match.group(1) if match else sys.exit("onestep dependency must be pinned as onestep>=<version>"))'
+          )"
+
+          python3 -c 'import json, sys, urllib.request; version = sys.argv[1]; releases = json.load(urllib.request.urlopen("https://pypi.org/pypi/onestep/json", timeout=20)).get("releases", {}); sys.exit(f"onestep=={version} is not published on PyPI yet; publish the core package before publishing the plugin.") if not releases.get(version) else print(f"onestep=={version} is available on PyPI.")' "$REQUIRED_ONESTEP_VERSION"
+
+      - name: Publish plugin to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/plugin
+          skip-existing: true
+          password: ${{ secrets.POSTGRES_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN || secrets.PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - Adds YAML conditional sink routing with `when` / `then` / `otherwise` emit entries while preserving legacy fan-out emit behavior.
 - Keeps CLI, app description, and control-plane topology output on the existing flattened `emit` sink list.
 
+## onestep-postgres 0.1.0
+
+- Adds the `onestep-postgres` plugin package with PostgreSQL table queues, incremental polling sources, table sinks, and SQLAlchemy-backed state/cursor stores.
+- Supports YAML resource registration for `postgres`, `postgres_state_store`, `postgres_cursor_store`, `postgres_table_queue`, `postgres_incremental`, and `postgres_table_sink`.
+- Adds focused unit tests and live PostgreSQL integration coverage gated by `ONESTEP_POSTGRES_DSN`.
+
 ## onestep-mysql 0.3.0
 
 - Adds the `mysql_binlog` source for row-based MySQL binlog CDC.

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -18,6 +18,8 @@ COPY plugins/onestep-redis/pyproject.toml plugins/onestep-redis/README.md /tmp/o
 COPY plugins/onestep-redis/src/onestep_redis /tmp/onestep/plugins/onestep-redis/src/onestep_redis
 COPY plugins/onestep-mysql/pyproject.toml plugins/onestep-mysql/README.md /tmp/onestep/plugins/onestep-mysql/
 COPY plugins/onestep-mysql/src/onestep_mysql /tmp/onestep/plugins/onestep-mysql/src/onestep_mysql
+COPY plugins/onestep-postgres/pyproject.toml plugins/onestep-postgres/README.md /tmp/onestep/plugins/onestep-postgres/
+COPY plugins/onestep-postgres/src/onestep_postgres /tmp/onestep/plugins/onestep-postgres/src/onestep_postgres
 COPY plugins/onestep-sqs/pyproject.toml plugins/onestep-sqs/README.md /tmp/onestep/plugins/onestep-sqs/
 COPY plugins/onestep-sqs/src/onestep_sqs /tmp/onestep/plugins/onestep-sqs/src/onestep_sqs
 
@@ -27,6 +29,7 @@ RUN python -m pip install --upgrade pip \
         /tmp/onestep/plugins/onestep-rabbitmq \
         /tmp/onestep/plugins/onestep-redis \
         /tmp/onestep/plugins/onestep-mysql \
+        /tmp/onestep/plugins/onestep-postgres \
         /tmp/onestep/plugins/onestep-sqs \
     && rm -rf /tmp/onestep
 

--- a/docs/superpowers/plans/2026-06-14-postgres-plugin.md
+++ b/docs/superpowers/plans/2026-06-14-postgres-plugin.md
@@ -1,0 +1,216 @@
+# PostgreSQL Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a first-version `onestep-postgres` plugin with PostgreSQL connector, table queue source, incremental source, table sink, SQLAlchemy state/cursor stores, YAML resource registration, and focused tests.
+
+**Architecture:** Add a repo-local plugin package parallel to `plugins/onestep-mysql`. Reuse the MySQL plugin's runtime contracts for table queue, incremental polling, and state stores, but omit binlog/CDC and use PostgreSQL dialect upsert for table sinks.
+
+**Tech Stack:** Python, onestep resource registry entry points, SQLAlchemy 2.x, psycopg 3, pytest, uv workspace.
+
+---
+
+## File Structure
+
+- Create `plugins/onestep-postgres/pyproject.toml`: package metadata, dependencies, and `onestep.resources` entry point.
+- Create `plugins/onestep-postgres/README.md`: minimal install and YAML usage docs.
+- Create `plugins/onestep-postgres/src/onestep_postgres/__init__.py`: public exports and `register` entry point alias.
+- Create `plugins/onestep-postgres/src/onestep_postgres/connector.py`: connector, table queue source, incremental source, and table sink.
+- Create `plugins/onestep-postgres/src/onestep_postgres/resources.py`: YAML build handlers for `postgres*` resource types.
+- Create `plugins/onestep-postgres/src/onestep_postgres/resilience.py`: SQLAlchemy error normalization with backend name `postgres`.
+- Create `plugins/onestep-postgres/src/onestep_postgres/state_sqlalchemy.py`: SQLAlchemy state/cursor store.
+- Create tests under `plugins/onestep-postgres/tests/`, mirroring the MySQL plugin's non-binlog tests.
+- Modify `pyproject.toml`: add the plugin to workspace members, optional extras, and uv sources.
+- Modify `uv.lock`: refresh lock metadata after adding the workspace package.
+
+### Task 1: Scaffold Package And Metadata
+
+**Files:**
+- Create: `plugins/onestep-postgres/pyproject.toml`
+- Create: `plugins/onestep-postgres/README.md`
+- Create: `plugins/onestep-postgres/src/onestep_postgres/__init__.py`
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Add package metadata**
+
+Create `plugins/onestep-postgres/pyproject.toml` with:
+
+```toml
+[project]
+name = "onestep-postgres"
+version = "0.1.0"
+description = "PostgreSQL connector plugin for onestep."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+dependencies = [
+    "onestep>=1.4.2",
+    "SQLAlchemy>=2.0.0",
+    "psycopg[binary]>=3.2.0",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=8.0.0"]
+dev = ["pytest>=8.0.0"]
+
+[project.entry-points."onestep.resources"]
+postgres = "onestep_postgres:register"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/onestep_postgres"]
+
+[tool.uv.sources]
+onestep = { workspace = true }
+```
+
+- [ ] **Step 2: Add public exports**
+
+Create `plugins/onestep-postgres/src/onestep_postgres/__init__.py` exporting `PostgresConnector`, sources, deliveries, sink, state stores, resilience helpers, and `register = register_resources`.
+
+- [ ] **Step 3: Add README**
+
+Create a short README with install command, YAML example, and note that CDC/logical replication is not part of v1.
+
+- [ ] **Step 4: Register workspace package**
+
+Update root `pyproject.toml`:
+
+```toml
+postgres = [
+    "onestep-postgres>=0.1.0",
+]
+```
+
+Also add `onestep-postgres>=0.1.0` to `integration`, `all`, and `dev`; add `plugins/onestep-postgres` to `[tool.uv.workspace].members`; add `onestep-postgres = { workspace = true }` to `[tool.uv.sources]`.
+
+- [ ] **Step 5: Validate metadata**
+
+Run: `uv lock`
+
+Expected: `uv.lock` updates successfully and includes `onestep-postgres`.
+
+### Task 2: Implement Runtime Code
+
+**Files:**
+- Create: `plugins/onestep-postgres/src/onestep_postgres/connector.py`
+- Create: `plugins/onestep-postgres/src/onestep_postgres/state_sqlalchemy.py`
+- Create: `plugins/onestep-postgres/src/onestep_postgres/resilience.py`
+
+- [ ] **Step 1: Copy the SQLAlchemy state store shape**
+
+Implement `SQLAlchemyStateStore` and `SQLAlchemyCursorStore` with async `load`, `save`, `delete`, and `close`, matching the MySQL plugin's behavior.
+
+- [ ] **Step 2: Add PostgreSQL connector**
+
+Implement `PostgresConnector(dsn, **engine_options)` with `state_store`, `cursor_store`, `table_queue`, `incremental`, `table_sink`, `_table`, and `close`.
+
+- [ ] **Step 3: Add table queue source**
+
+Implement `PostgresTableQueueSource` with `fetch_is_cancel_safe = False`, `FOR UPDATE SKIP LOCKED` claiming, and delivery methods `ack`, `retry`, `fail`, `release_unstarted`, and `update_current_row`.
+
+- [ ] **Step 4: Add incremental source**
+
+Implement `PostgresIncrementalSource` with cursor state loading, tuple cursor comparison, pending/acked cursor commit ordering, and default state key hashing for long `where` clauses.
+
+- [ ] **Step 5: Add table sink**
+
+Implement `PostgresTableSink` supporting `insert` and `upsert`. Use `sqlalchemy.dialects.postgresql.insert(...).on_conflict_do_update(...)` for PostgreSQL, keep SQLite support in tests, and require `keys` for upsert.
+
+- [ ] **Step 6: Add resilience helper**
+
+Implement `classify_sqlalchemy_error` and `as_postgres_connector_operation_error` with backend name `postgres`, following the MySQL plugin's error normalization contract.
+
+### Task 3: Implement YAML Resource Registration
+
+**Files:**
+- Create: `plugins/onestep-postgres/src/onestep_postgres/resources.py`
+
+- [ ] **Step 1: Register resource handlers**
+
+Register `postgres`, `postgres_state_store`, `postgres_cursor_store`, `postgres_table_queue`, `postgres_incremental`, and `postgres_table_sink`.
+
+- [ ] **Step 2: Build resources from specs**
+
+Implement builders using `ResourceBuildContext` helpers:
+
+```python
+connector = ctx.resolve_dependency(spec, "connector")
+table = ctx.require_string(spec, "table")
+cursor = tuple(ctx.string_list(spec.get("cursor"), field=f"{ctx.field}.cursor"))
+```
+
+- [ ] **Step 3: Keep strict field sets narrow**
+
+Allowed fields should match the implemented API: connector DSN plus `engine_options`; state/cursor store options; table queue claim fields; incremental state fields; table sink mode and keys.
+
+### Task 4: Add Tests
+
+**Files:**
+- Create: `plugins/onestep-postgres/tests/test_postgres_plugin.py`
+- Create: `plugins/onestep-postgres/tests/test_postgres_incremental.py`
+- Create: `plugins/onestep-postgres/tests/test_postgres_table_queue.py`
+- Create: `plugins/onestep-postgres/tests/test_postgres_runtime_contract.py`
+- Create: `plugins/onestep-postgres/tests/test_state_sqlalchemy.py`
+- Create: `plugins/onestep-postgres/tests/integration/test_postgres_live.py`
+
+- [ ] **Step 1: Add plugin/resource tests**
+
+Cover entry point discovery and strict YAML construction with `load_app_config`, asserting resource instances are `PostgresConnector`, `SQLAlchemyStateStore`, `SQLAlchemyCursorStore`, `PostgresIncrementalSource`, and `PostgresTableSink`.
+
+- [ ] **Step 2: Add incremental tests**
+
+Cover ordered cursor advancement, out-of-order ack gap behavior, key tie-breaker behavior, and default state key separation for distinct `where` clauses.
+
+- [ ] **Step 3: Add table queue tests**
+
+Cover a round trip through `OneStepApp`, `ctx.update_current_row`, `ack`, and `PostgresTableSink` upsert.
+
+- [ ] **Step 4: Add runtime cancellation contract tests**
+
+Cover drain, pause, and shutdown releasing claimed table queue rows when fetch is stopped before delivery starts.
+
+- [ ] **Step 5: Add live integration tests**
+
+Use `ONESTEP_POSTGRES_DSN`; skip at module level when unset. Cover table queue claim/ack/retry, incremental restart recovery, and PostgreSQL upsert.
+
+### Task 5: Validate And Commit
+
+**Files:**
+- Modify: `uv.lock`
+- Test all created plugin files.
+
+- [ ] **Step 1: Run focused tests**
+
+Run: `uv run --all-packages python -m pytest -q plugins/onestep-postgres/tests`
+
+Expected: all non-live plugin tests pass; live tests skip if `ONESTEP_POSTGRES_DSN` is unset.
+
+- [ ] **Step 2: Run lock check**
+
+Run: `uv lock --check`
+
+Expected: lockfile is current.
+
+- [ ] **Step 3: Review diff**
+
+Run: `git diff --stat` and `git diff --check`
+
+Expected: only PostgreSQL plugin, root metadata, lockfile, and plan/spec docs are changed; no whitespace errors.
+
+- [ ] **Step 4: Commit implementation**
+
+```bash
+git add pyproject.toml uv.lock plugins/onestep-postgres docs/superpowers/plans/2026-06-14-postgres-plugin.md
+git commit -m "feat: add postgres plugin"
+```
+
+## Self-Review
+
+- Spec coverage: package, resource registration, table queue, incremental source, table sink, state/cursor store, tests, workspace metadata, and lockfile are covered.
+- Explicit non-goals: no CDC/logical replication, no onestep-web changes, no control-plane protocol changes.
+- Placeholder scan: no TBD/TODO steps remain.
+- Type consistency: the public prefix is `Postgres*`, package import is `onestep_postgres`, resource type prefix is `postgres_*`.

--- a/docs/superpowers/specs/2026-06-14-postgres-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-14-postgres-plugin-design.md
@@ -1,0 +1,197 @@
+# PostgreSQL 插件设计
+
+## 背景
+
+onestep 已经通过 `onestep.resources` entry point 支持 repo-local 插件注册 YAML resource type。MySQL 插件也已经覆盖关系型数据库的常见 runtime 能力：连接资源、table queue、incremental source、table sink、SQLAlchemy state store 和 cursor store。
+
+PostgreSQL 第一版沿用这个插件边界，目标是支持稳定的表级轮询和写入，不引入 logical replication CDC。CDC 涉及 replication slot、publication、LSN 确认、delete payload、schema 变更等独立语义，放到后续设计中处理。
+
+## 目标
+
+- 新增 repo-local 插件包 `plugins/onestep-postgres`。
+- 插件包名为 `onestep-postgres`，Python import 包名为 `onestep_postgres`。
+- 注册 YAML resource type：
+  - `postgres`
+  - `postgres_state_store`
+  - `postgres_cursor_store`
+  - `postgres_table_queue`
+  - `postgres_incremental`
+  - `postgres_table_sink`
+- 支持 Python API 直接使用 connector、source、sink、state store 和 cursor store。
+- 支持 YAML worker 通过安装插件后直接使用 PostgreSQL resource type。
+- 提供 focused unit tests 和 PostgreSQL live integration tests。
+
+## 非目标
+
+- 不支持 logical replication、`pgoutput`、`wal2json` 或其它 CDC source。
+- 不修改 onestep-web 拖拽配置、credential schema 或 debug/sample data 流程。
+- 不改变 core `Source`、`Sink`、`Delivery`、`OneStepApp` API。
+- 不改变 control-plane protocol、reporter payload 字段或 remote-control 行为。
+- 不迁移或重构现有 MySQL 插件。
+
+## 包结构
+
+```text
+plugins/onestep-postgres/
+  pyproject.toml
+  README.md
+  src/onestep_postgres/
+    __init__.py
+    connector.py
+    resources.py
+    state_sqlalchemy.py
+  tests/
+    test_postgres_plugin.py
+    test_postgres_table_queue.py
+    test_postgres_incremental.py
+    test_postgres_table_sink.py
+    test_state_sqlalchemy.py
+    integration/
+      test_postgres_live.py
+```
+
+`connector.py` contains PostgreSQL runtime implementations. `resources.py` contains YAML build and strict validation handlers. `state_sqlalchemy.py` reuses the SQLAlchemy-backed state/cursor store shape from the MySQL plugin, with PostgreSQL-safe table creation and statements where needed.
+
+`__init__.py` exports the public Python API and the resource entry point target:
+
+```python
+from .resources import register_resources as register
+```
+
+## Dependencies
+
+The plugin depends on:
+
+- `onestep>=1.4.2`
+- `SQLAlchemy>=2.0.0`
+- `psycopg[binary]>=3.2.0`
+
+The root workspace adds `plugins/onestep-postgres` as a member and adds workspace source metadata for `onestep-postgres`. The core optional extras add:
+
+```toml
+postgres = [
+    "onestep-postgres>=0.1.0",
+]
+```
+
+The `all`, `dev`, and `integration` extras include the PostgreSQL plugin so repo-level development environments can run the plugin tests without manual package installation.
+
+## YAML Resource Types
+
+Example worker wiring:
+
+```yaml
+resources:
+  pg:
+    type: postgres
+    dsn: "${POSTGRES_DSN}"
+
+  cursor:
+    type: postgres_cursor_store
+    connector: pg
+
+  users_source:
+    type: postgres_incremental
+    connector: pg
+    table: users
+    key: id
+    cursor: [updated_at, id]
+    state: cursor
+
+  users_sink:
+    type: postgres_table_sink
+    connector: pg
+    table: dw_users
+    mode: upsert
+    keys: [id]
+```
+
+`postgres` accepts `dsn`, optional `name`, and connection pool options already supported by the MySQL connector where they map cleanly to SQLAlchemy.
+
+`postgres_state_store` and `postgres_cursor_store` accept `connector`, optional `table`, and optional `name`. Defaults should match the MySQL plugin naming style, using PostgreSQL-compatible DDL.
+
+`postgres_incremental` accepts `connector`, `table`, `key`, `cursor`, optional `state`, optional `batch_size`, optional `where`, optional `columns`, and optional `name`.
+
+`postgres_table_queue` accepts the same table queue fields as MySQL where the semantics are portable, including claim status fields, max attempts, visibility timeout, batch size, payload columns, and ordering. It uses PostgreSQL row locking for concurrency.
+
+`postgres_table_sink` accepts `connector`, `table`, `mode`, optional `keys`, optional `columns`, optional `name`, and insert/upsert options. `mode` supports `insert` and `upsert`.
+
+## Runtime Behavior
+
+`PostgresConnector` wraps a SQLAlchemy engine. It should expose small helpers for creating connections and executing transaction-scoped operations, following the MySQL connector style.
+
+`PostgresIncrementalSource` polls rows ordered by cursor fields. Cursor comparisons use tuple-style ordering semantics where PostgreSQL supports them, with deterministic tie-breaking through the configured `key` or final cursor component. The source persists cursor state only after the delivery is acknowledged.
+
+`PostgresTableQueueSource` claims available rows in a transaction using:
+
+```sql
+SELECT ...
+FOR UPDATE SKIP LOCKED
+```
+
+The claim updates status, attempt count, lock metadata, and visibility timestamp in the same transaction. `ack()`, `retry()`, and `fail()` update the claimed row according to the existing table queue contract.
+
+`PostgresTableSink` inserts mapped payload rows. In `upsert` mode it uses:
+
+```python
+sqlalchemy.dialects.postgresql.insert(table).on_conflict_do_update(...)
+```
+
+`keys` are required for upsert mode and map to `index_elements`. Non-key columns are updated from `excluded`.
+
+## Strict Validation
+
+YAML handlers should reject unknown fields in strict mode and keep errors tied to the resource path, such as `resources.users_sink`.
+
+Validation requirements:
+
+- `postgres.dsn` must be a non-empty string.
+- Source and sink resource references must resolve to a `PostgresConnector`.
+- State and cursor store references must expose the expected store capability.
+- `postgres_incremental.cursor` must be a non-empty string list.
+- `postgres_table_sink.mode` must be `insert` or `upsert`.
+- `postgres_table_sink.keys` is required and non-empty when `mode: upsert`.
+- Numeric limits such as `batch_size`, `max_attempts`, and visibility timeout must be positive where applicable.
+
+## Control Plane Impact
+
+No control-plane coordination is required for the first version. The plugin only adds runtime resource types and does not change reporter payload fields, task lifecycle events, WebSocket protocol behavior, runtime identity, or remote task-control behavior.
+
+Topology display can rely on existing generic source/sink descriptors. Friendly labels for `postgres_*` resource types can be added later as a web/control-plane enhancement if needed.
+
+## Testing
+
+Focused unit tests cover:
+
+- entry point registration and YAML resource construction
+- strict validation failures for missing and invalid fields
+- incremental cursor query construction and cursor persistence timing
+- table queue claim, ack, retry, fail, and skip-locked behavior shape
+- table sink insert and PostgreSQL upsert statement behavior
+- SQLAlchemy state and cursor store behavior
+
+Integration tests use Docker PostgreSQL and are marked `integration`. They cover:
+
+- connecting through a real PostgreSQL DSN
+- creating state/cursor tables
+- reading incremental rows across multiple polls
+- claiming table queue rows concurrently without duplicate deliveries
+- inserting and upserting sink rows into a real table
+
+Default validation for development:
+
+```bash
+uv run --all-packages python -m pytest -q plugins/onestep-postgres/tests
+```
+
+Live validation when PostgreSQL infrastructure is available:
+
+```bash
+uv run --all-packages python -m pytest -q -m integration plugins/onestep-postgres/tests/integration
+```
+
+## Release Impact
+
+The new plugin starts at version `0.1.0`. Adding the workspace member and optional extras requires updating `uv.lock`.
+
+Publishing `onestep-postgres` is independent from core unless the release also changes core package behavior. If the core package is released at the same time, follow the existing onestep release rules for core version, changelog, lockfile, and tag.

--- a/plugins/onestep-postgres/README.md
+++ b/plugins/onestep-postgres/README.md
@@ -1,0 +1,41 @@
+# onestep-postgres
+
+PostgreSQL connector plugin for onestep.
+
+Install it with:
+
+```bash
+pip install onestep-postgres
+```
+
+YAML resources are available after the plugin is installed:
+
+```yaml
+resources:
+  pg:
+    type: postgres
+    dsn: "${POSTGRES_DSN}"
+
+  cursor:
+    type: postgres_cursor_store
+    connector: pg
+
+  users:
+    type: postgres_incremental
+    connector: pg
+    table: users
+    key: id
+    cursor: [updated_at, id]
+    state: cursor
+
+  processed:
+    type: postgres_table_sink
+    connector: pg
+    table: processed_users
+    mode: upsert
+    keys: [id]
+```
+
+The first version supports table queues, incremental polling, table sinks, and
+SQLAlchemy-backed state/cursor stores. It does not support PostgreSQL logical
+replication or CDC.

--- a/plugins/onestep-postgres/pyproject.toml
+++ b/plugins/onestep-postgres/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "onestep-postgres"
+version = "0.1.0"
+description = "PostgreSQL connector plugin for onestep."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+dependencies = [
+    "onestep>=1.4.2",
+    "SQLAlchemy>=2.0.0",
+    "psycopg[binary]>=3.2.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0.0",
+]
+dev = [
+    "pytest>=8.0.0",
+]
+
+[project.entry-points."onestep.resources"]
+postgres = "onestep_postgres:register"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/onestep_postgres"]
+
+[tool.uv.sources]
+onestep = { workspace = true }

--- a/plugins/onestep-postgres/src/onestep_postgres/__init__.py
+++ b/plugins/onestep-postgres/src/onestep_postgres/__init__.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version as _package_version
+
+from .connector import (
+    IncrementalDelivery,
+    PostgresConnector,
+    PostgresIncrementalSource,
+    PostgresTableQueueDelivery,
+    PostgresTableQueueSource,
+    PostgresTableSink,
+)
+from .resources import register_resources
+from .resilience import classify_sqlalchemy_error
+from .state_sqlalchemy import SQLAlchemyCursorStore, SQLAlchemyStateStore
+
+try:
+    __version__ = _package_version("onestep-postgres")
+except PackageNotFoundError:  # pragma: no cover - local source tree before install
+    __version__ = "dev"
+
+register = register_resources
+
+__all__ = [
+    "IncrementalDelivery",
+    "PostgresConnector",
+    "PostgresIncrementalSource",
+    "PostgresTableQueueDelivery",
+    "PostgresTableQueueSource",
+    "PostgresTableSink",
+    "SQLAlchemyCursorStore",
+    "SQLAlchemyStateStore",
+    "__version__",
+    "classify_sqlalchemy_error",
+    "register",
+    "register_resources",
+]

--- a/plugins/onestep-postgres/src/onestep_postgres/connector.py
+++ b/plugins/onestep-postgres/src/onestep_postgres/connector.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from collections import deque
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from onestep.connectors.base import Delivery, Sink, Source
+from onestep.envelope import Envelope
+from onestep.resilience import ConnectorOperation
+from onestep.state import CursorStore, InMemoryCursorStore
+
+from .resilience import as_postgres_connector_operation_error
+from .state_sqlalchemy import SQLAlchemyCursorStore, SQLAlchemyStateStore
+
+try:
+    import sqlalchemy as sa
+    from sqlalchemy import create_engine
+except ImportError:  # pragma: no cover - exercised when optional deps are missing
+    sa = None
+    create_engine = None
+
+
+class PostgresConnector:
+    def __init__(self, dsn: str, **engine_options: Any) -> None:
+        if create_engine is None:
+            raise RuntimeError("PostgresConnector requires SQLAlchemy. Install onestep-postgres.")
+        self.dsn = dsn
+        self.engine = create_engine(dsn, future=True, pool_pre_ping=True, **engine_options)
+        self._tables: dict[str, Any] = {}
+
+    async def close(self) -> None:
+        await asyncio.to_thread(self.engine.dispose)
+
+    def state_store(
+        self,
+        *,
+        table: str = "onestep_state",
+        key_column: str = "state_key",
+        value_column: str = "state_value",
+        updated_at_column: str = "updated_at",
+        auto_create: bool = True,
+    ) -> SQLAlchemyStateStore:
+        return SQLAlchemyStateStore(
+            engine=self.engine,
+            table=table,
+            key_column=key_column,
+            value_column=value_column,
+            updated_at_column=updated_at_column,
+            auto_create=auto_create,
+        )
+
+    def cursor_store(
+        self,
+        *,
+        table: str = "onestep_cursor",
+        key_column: str = "cursor_key",
+        value_column: str = "cursor_value",
+        updated_at_column: str = "updated_at",
+        auto_create: bool = True,
+    ) -> SQLAlchemyCursorStore:
+        return SQLAlchemyCursorStore(
+            engine=self.engine,
+            table=table,
+            key_column=key_column,
+            value_column=value_column,
+            updated_at_column=updated_at_column,
+            auto_create=auto_create,
+        )
+
+    def table_queue(
+        self,
+        *,
+        table: str,
+        key: str,
+        where: str,
+        claim: Mapping[str, Any],
+        ack: Mapping[str, Any],
+        nack: Mapping[str, Any] | None = None,
+        batch_size: int = 100,
+        poll_interval_s: float = 1.0,
+    ) -> "PostgresTableQueueSource":
+        return PostgresTableQueueSource(
+            connector=self,
+            table=table,
+            key=key,
+            where=where,
+            claim=dict(claim),
+            ack=dict(ack),
+            nack=dict(nack or {}),
+            batch_size=batch_size,
+            poll_interval_s=poll_interval_s,
+        )
+
+    def incremental(
+        self,
+        *,
+        table: str,
+        key: str,
+        cursor: Sequence[str],
+        where: str | None = None,
+        batch_size: int = 1000,
+        poll_interval_s: float = 1.0,
+        state: CursorStore | None = None,
+        state_key: str | None = None,
+    ) -> "PostgresIncrementalSource":
+        if len(cursor) < 1:
+            raise ValueError("cursor must contain at least one column")
+        effective_cursor = tuple(cursor) if key in cursor else (*tuple(cursor), key)
+        return PostgresIncrementalSource(
+            connector=self,
+            table=table,
+            key=key,
+            cursor=effective_cursor,
+            where=where,
+            batch_size=batch_size,
+            poll_interval_s=poll_interval_s,
+            state=state or InMemoryCursorStore(),
+            state_key=state_key or _default_incremental_state_key(
+                table=table,
+                cursor=effective_cursor,
+                key=key,
+                where=where,
+            ),
+        )
+
+    def table_sink(
+        self,
+        *,
+        table: str,
+        mode: str = "insert",
+        keys: Sequence[str] = (),
+    ) -> "PostgresTableSink":
+        return PostgresTableSink(connector=self, table=table, mode=mode, keys=tuple(keys))
+
+    def _table(self, table_name: str):
+        table = self._tables.get(table_name)
+        if table is None:
+            metadata = sa.MetaData()
+            table = sa.Table(table_name, metadata, autoload_with=self.engine)
+            self._tables[table_name] = table
+        return table
+
+
+def _default_incremental_state_key(
+    *,
+    table: str,
+    cursor: Sequence[str],
+    key: str,
+    where: str | None,
+) -> str:
+    normalized_where = " ".join((where or "").split())
+    if normalized_where:
+        where_fragment = normalized_where
+        if len(where_fragment) > 64:
+            where_fragment = f"sha1:{hashlib.sha1(where_fragment.encode('utf-8')).hexdigest()}"
+    else:
+        where_fragment = "-"
+    return f"{table}:{','.join(cursor)}:key={key}:where={where_fragment}"
+
+
+@dataclass
+class _TableRowRef:
+    table: str
+    key: str
+    key_value: Any
+
+
+class PostgresTableQueueDelivery(Delivery):
+    def __init__(self, source: "PostgresTableQueueSource", envelope: Envelope, row_ref: _TableRowRef) -> None:
+        super().__init__(envelope)
+        self._source = source
+        self._row_ref = row_ref
+
+    async def update_current_row(self, values: Mapping[str, Any]) -> None:
+        payload = dict(values)
+        await self._source.update_row(self._row_ref, payload)
+        if isinstance(self.envelope.body, dict):
+            self.envelope.body.update(payload)
+
+    async def ack(self) -> None:
+        await self._source.ack_row(self._row_ref)
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        await self._source.retry_row(self._row_ref, delay_s=delay_s)
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        await self._source.fail_row(self._row_ref, exc=exc)
+
+    async def release_unstarted(self) -> None:
+        await self._source.release_row(self._row_ref)
+
+
+class PostgresTableQueueSource(Source):
+    fetch_is_cancel_safe = False
+
+    def __init__(
+        self,
+        *,
+        connector: PostgresConnector,
+        table: str,
+        key: str,
+        where: str,
+        claim: dict[str, Any],
+        ack: dict[str, Any],
+        nack: dict[str, Any],
+        batch_size: int,
+        poll_interval_s: float,
+    ) -> None:
+        super().__init__(f"postgres.table_queue:{table}")
+        self.connector = connector
+        self.table_name = table
+        self.key = key
+        self.where = where
+        self.claim = claim
+        self.ack = ack
+        self.nack = nack
+        self.batch_size = batch_size
+        self.poll_interval_s = poll_interval_s
+
+    async def fetch(self, limit: int) -> list[Delivery]:
+        try:
+            rows = await asyncio.to_thread(self._fetch_sync, max(1, min(limit, self.batch_size)))
+        except Exception as exc:
+            connector_error = as_postgres_connector_operation_error(
+                operation=ConnectorOperation.FETCH,
+                exc=exc,
+                source_name=self.name,
+                retry_delay_s=self.poll_interval_s,
+            )
+            if connector_error is None:
+                raise
+            raise connector_error from exc
+        deliveries: list[Delivery] = []
+        for row in rows:
+            key_value = row[self.key]
+            envelope = Envelope(body=row, meta={"table": self.table_name})
+            row_ref = _TableRowRef(self.table_name, self.key, key_value)
+            deliveries.append(PostgresTableQueueDelivery(self, envelope, row_ref))
+        return deliveries
+
+    def _fetch_sync(self, limit: int) -> list[dict[str, Any]]:
+        table = self.connector._table(self.table_name)
+        with self.connector.engine.begin() as conn:
+            stmt = sa.select(table).where(sa.text(self.where)).order_by(table.c[self.key]).limit(limit)
+            try:
+                stmt = stmt.with_for_update(skip_locked=True)
+            except TypeError:
+                stmt = stmt.with_for_update()
+            rows = [dict(row) for row in conn.execute(stmt).mappings().all()]
+            if not rows:
+                return []
+            ids = [row[self.key] for row in rows]
+            conn.execute(sa.update(table).where(table.c[self.key].in_(ids)).values(**self.claim))
+            refreshed = conn.execute(
+                sa.select(table).where(table.c[self.key].in_(ids)).order_by(table.c[self.key])
+            )
+            return [dict(row) for row in refreshed.mappings().all()]
+
+    async def ack_row(self, row_ref: _TableRowRef) -> None:
+        await self.update_row(row_ref, self.ack)
+
+    async def retry_row(self, row_ref: _TableRowRef, *, delay_s: float | None = None) -> None:
+        if delay_s:
+            await asyncio.sleep(delay_s)
+        await self.update_row(row_ref, self.nack)
+
+    async def fail_row(self, row_ref: _TableRowRef, exc: Exception | None = None) -> None:
+        await self.update_row(row_ref, self.nack)
+
+    async def release_row(self, row_ref: _TableRowRef) -> None:
+        await self.update_row(row_ref, self.nack)
+
+    async def update_row(self, row_ref: _TableRowRef, values: Mapping[str, Any]) -> None:
+        await asyncio.to_thread(self._update_row_sync, row_ref, dict(values))
+
+    def _update_row_sync(self, row_ref: _TableRowRef, values: Mapping[str, Any]) -> None:
+        if not values:
+            return
+        table = self.connector._table(row_ref.table)
+        with self.connector.engine.begin() as conn:
+            conn.execute(
+                sa.update(table)
+                .where(table.c[row_ref.key] == row_ref.key_value)
+                .values(**dict(values))
+            )
+
+
+@dataclass
+class _CursorToken:
+    value: tuple[Any, ...]
+
+
+class IncrementalDelivery(Delivery):
+    def __init__(self, source: "PostgresIncrementalSource", envelope: Envelope, token: _CursorToken) -> None:
+        super().__init__(envelope)
+        self._source = source
+        self._token = token
+
+    async def ack(self) -> None:
+        await self._source.ack_token(self._token)
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        if delay_s:
+            await asyncio.sleep(delay_s)
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        return None
+
+
+class PostgresIncrementalSource(Source):
+    def __init__(
+        self,
+        *,
+        connector: PostgresConnector,
+        table: str,
+        key: str,
+        cursor: tuple[str, ...],
+        where: str | None,
+        batch_size: int,
+        poll_interval_s: float,
+        state: CursorStore,
+        state_key: str,
+    ) -> None:
+        super().__init__(f"postgres.incremental:{table}")
+        self.connector = connector
+        self.table_name = table
+        self.key = key
+        self.configured_cursor = cursor
+        self.cursor = cursor if key in cursor else (*cursor, key)
+        self.where = where
+        self.batch_size = batch_size
+        self.poll_interval_s = poll_interval_s
+        self.state = state
+        self.state_key = state_key
+        self._pending: deque[tuple[Any, ...]] = deque()
+        self._acked: set[tuple[Any, ...]] = set()
+        self._commit_lock: asyncio.Lock | None = None
+        self._commit_loop: asyncio.AbstractEventLoop | None = None
+        self._loaded = False
+        self._committed_cursor: tuple[Any, ...] | None = None
+        self._fetched_cursor: tuple[Any, ...] | None = None
+
+    async def open(self) -> None:
+        if not self._loaded:
+            loaded = await self.state.load(self.state_key)
+            if loaded is not None and len(loaded) == len(self.cursor):
+                self._committed_cursor = tuple(loaded)
+                self._fetched_cursor = self._committed_cursor
+            self._loaded = True
+
+    async def fetch(self, limit: int) -> list[Delivery]:
+        await self.open()
+        try:
+            rows = await asyncio.to_thread(self._fetch_sync, max(1, min(limit, self.batch_size)))
+        except Exception as exc:
+            connector_error = as_postgres_connector_operation_error(
+                operation=ConnectorOperation.FETCH,
+                exc=exc,
+                source_name=self.name,
+                retry_delay_s=self.poll_interval_s,
+            )
+            if connector_error is None:
+                raise
+            raise connector_error from exc
+        deliveries: list[Delivery] = []
+        for row in rows:
+            token = _CursorToken(tuple(row[column] for column in self.cursor))
+            self._pending.append(token.value)
+            self._fetched_cursor = token.value
+            envelope = Envelope(body=row, meta={"table": self.table_name})
+            deliveries.append(IncrementalDelivery(self, envelope, token))
+        return deliveries
+
+    def _fetch_sync(self, limit: int) -> list[dict[str, Any]]:
+        table = self.connector._table(self.table_name)
+        stmt = sa.select(table)
+        predicates = []
+        if self.where:
+            predicates.append(sa.text(self.where))
+        read_cursor = self._fetched_cursor or self._committed_cursor
+        if read_cursor is not None:
+            cursor_columns = [table.c[name] for name in self.cursor]
+            predicates.append(sa.tuple_(*cursor_columns) > tuple(read_cursor))
+        if predicates:
+            stmt = stmt.where(*predicates)
+        order_columns = [table.c[name] for name in self.cursor]
+        stmt = stmt.order_by(*order_columns).limit(limit)
+        with self.connector.engine.begin() as conn:
+            rows = conn.execute(stmt).mappings().all()
+        return [dict(row) for row in rows]
+
+    async def ack_token(self, token: _CursorToken) -> None:
+        lock = self._runtime_commit_lock()
+        async with lock:
+            self._acked.add(token.value)
+            advanced: tuple[Any, ...] | None = None
+            while self._pending and self._pending[0] in self._acked:
+                advanced = self._pending.popleft()
+                self._acked.remove(advanced)
+            if advanced is not None:
+                self._committed_cursor = advanced
+                if not self._pending:
+                    self._fetched_cursor = advanced
+                await self.state.save(self.state_key, list(advanced))
+
+    def _runtime_commit_lock(self) -> asyncio.Lock:
+        current_loop = asyncio.get_running_loop()
+        if self._commit_lock is None or self._commit_loop is not current_loop:
+            self._commit_lock = asyncio.Lock()
+            self._commit_loop = current_loop
+        return self._commit_lock
+
+
+class PostgresTableSink(Sink):
+    def __init__(self, *, connector: PostgresConnector, table: str, mode: str, keys: tuple[str, ...]) -> None:
+        super().__init__(f"postgres.table_sink:{table}")
+        if mode not in {"insert", "upsert"}:
+            raise ValueError("mode must be either 'insert' or 'upsert'")
+        self.connector = connector
+        self.table_name = table
+        self.mode = mode
+        self.keys = keys
+
+    async def send(self, envelope: Envelope) -> None:
+        if not isinstance(envelope.body, Mapping):
+            raise TypeError("PostgresTableSink only accepts mapping payloads")
+        try:
+            await asyncio.to_thread(self._send_sync, dict(envelope.body))
+        except Exception as exc:
+            connector_error = as_postgres_connector_operation_error(
+                operation=ConnectorOperation.SEND,
+                exc=exc,
+                source_name=self.name,
+                retry_delay_s=1.0,
+            )
+            if connector_error is None:
+                raise
+            raise connector_error from exc
+
+    def _send_sync(self, payload: dict[str, Any]) -> None:
+        table = self.connector._table(self.table_name)
+        dialect = self.connector.engine.dialect.name
+        with self.connector.engine.begin() as conn:
+            if self.mode == "insert":
+                conn.execute(sa.insert(table).values(**payload))
+                return
+            if not self.keys:
+                raise ValueError("upsert mode requires keys")
+            update_payload = {key: value for key, value in payload.items() if key not in self.keys}
+            if dialect == "postgresql":
+                from sqlalchemy.dialects.postgresql import insert as postgres_insert
+
+                stmt = postgres_insert(table).values(**payload)
+                conn.execute(stmt.on_conflict_do_update(index_elements=list(self.keys), set_=update_payload))
+                return
+            if dialect == "sqlite":
+                from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+                stmt = sqlite_insert(table).values(**payload)
+                conn.execute(stmt.on_conflict_do_update(index_elements=list(self.keys), set_=update_payload))
+                return
+            conn.execute(sa.insert(table).values(**payload))

--- a/plugins/onestep-postgres/src/onestep_postgres/resilience.py
+++ b/plugins/onestep-postgres/src/onestep_postgres/resilience.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from onestep.resilience import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError
+
+try:  # pragma: no cover - optional dependency
+    import sqlalchemy as sa
+except ImportError:  # pragma: no cover - optional dependency
+    sa = None
+
+
+def classify_sqlalchemy_error(exc: BaseException) -> ConnectorErrorKind | None:
+    if sa is None:
+        return None
+    sql_exc = sa.exc
+    if isinstance(exc, getattr(sql_exc, "TimeoutError", ())):
+        return ConnectorErrorKind.TRANSIENT
+    if isinstance(exc, getattr(sql_exc, "InterfaceError", ())):
+        return ConnectorErrorKind.DISCONNECTED
+    if isinstance(exc, getattr(sql_exc, "ProgrammingError", ())):
+        return ConnectorErrorKind.PERMANENT
+    if isinstance(exc, getattr(sql_exc, "DBAPIError", ())):
+        if getattr(exc, "connection_invalidated", False):
+            return ConnectorErrorKind.DISCONNECTED
+        message = " ".join(
+            str(part).lower()
+            for part in (
+                getattr(exc, "orig", None),
+                exc,
+            )
+            if part is not None
+        )
+        if any(token in message for token in ("server closed the connection", "connection refused", "connection reset")):
+            return ConnectorErrorKind.DISCONNECTED
+        if any(token in message for token in ("deadlock detected", "lock timeout", "could not serialize access")):
+            return ConnectorErrorKind.TRANSIENT
+        if any(token in message for token in ("password authentication failed", "permission denied")):
+            return ConnectorErrorKind.MISCONFIGURED
+        if any(token in message for token in ("database", "role")) and "does not exist" in message:
+            return ConnectorErrorKind.MISCONFIGURED
+        if any(token in message for token in ("undefined table", "undefined column", "syntax error", "does not exist")):
+            return ConnectorErrorKind.PERMANENT
+        if isinstance(exc, getattr(sql_exc, "OperationalError", ())):
+            return ConnectorErrorKind.TRANSIENT
+    return None
+
+
+def as_postgres_connector_operation_error(
+    *,
+    operation: ConnectorOperation,
+    exc: BaseException,
+    source_name: str | None = None,
+    retry_delay_s: float | None = None,
+) -> ConnectorOperationError | None:
+    kind = classify_sqlalchemy_error(exc)
+    if kind is None:
+        return None
+    return ConnectorOperationError(
+        backend="postgres",
+        operation=operation,
+        kind=kind,
+        source_name=source_name,
+        retry_delay_s=retry_delay_s,
+        cause=exc,
+    )

--- a/plugins/onestep-postgres/src/onestep_postgres/resources.py
+++ b/plugins/onestep-postgres/src/onestep_postgres/resources.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from onestep.resource_registry import ResourceBuildContext, ResourceRegistry, ResourceSpecHandler
+
+from .connector import PostgresConnector
+
+_POSTGRES_FIELDS = frozenset({"type", "dsn", "engine_options"})
+_POSTGRES_STATE_STORE_FIELDS = frozenset(
+    {"type", "connector", "table", "key_column", "value_column", "updated_at_column", "auto_create"}
+)
+_POSTGRES_CURSOR_STORE_FIELDS = frozenset(
+    {"type", "connector", "table", "key_column", "value_column", "updated_at_column", "auto_create"}
+)
+_POSTGRES_TABLE_QUEUE_FIELDS = frozenset(
+    {"type", "connector", "table", "key", "where", "claim", "ack", "nack", "batch_size", "poll_interval_s"}
+)
+_POSTGRES_INCREMENTAL_FIELDS = frozenset(
+    {"type", "connector", "table", "key", "cursor", "where", "batch_size", "poll_interval_s", "state", "state_key"}
+)
+_POSTGRES_TABLE_SINK_FIELDS = frozenset({"type", "connector", "table", "mode", "keys"})
+
+
+def register_resources(registry: ResourceRegistry) -> None:
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="postgres",
+            allowed_fields=_POSTGRES_FIELDS,
+            build=_build_postgres,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="postgres_state_store",
+            allowed_fields=_POSTGRES_STATE_STORE_FIELDS,
+            build=_build_postgres_state_store,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="postgres_cursor_store",
+            allowed_fields=_POSTGRES_CURSOR_STORE_FIELDS,
+            build=_build_postgres_cursor_store,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="postgres_table_queue",
+            allowed_fields=_POSTGRES_TABLE_QUEUE_FIELDS,
+            build=_build_postgres_table_queue,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="postgres_incremental",
+            allowed_fields=_POSTGRES_INCREMENTAL_FIELDS,
+            build=_build_postgres_incremental,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="postgres_table_sink",
+            allowed_fields=_POSTGRES_TABLE_SINK_FIELDS,
+            build=_build_postgres_table_sink,
+        )
+    )
+
+
+def _build_postgres(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> PostgresConnector:
+    return PostgresConnector(
+        ctx.require_string(spec, "dsn"),
+        **ctx.mapping_value(spec.get("engine_options"), field=f"{ctx.field}.engine_options"),
+    )
+
+
+def _build_postgres_state_store(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
+    connector = ctx.resolve_dependency(spec, "connector")
+    if not hasattr(connector, "state_store"):
+        raise TypeError(f"resource {spec['connector']!r} cannot build postgres_state_store")
+    return connector.state_store(
+        table=spec.get("table", "onestep_state"),
+        key_column=spec.get("key_column", "state_key"),
+        value_column=spec.get("value_column", "state_value"),
+        updated_at_column=spec.get("updated_at_column", "updated_at"),
+        auto_create=spec.get("auto_create", True),
+    )
+
+
+def _build_postgres_cursor_store(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
+    connector = ctx.resolve_dependency(spec, "connector")
+    if not hasattr(connector, "cursor_store"):
+        raise TypeError(f"resource {spec['connector']!r} cannot build postgres_cursor_store")
+    return connector.cursor_store(
+        table=spec.get("table", "onestep_cursor"),
+        key_column=spec.get("key_column", "cursor_key"),
+        value_column=spec.get("value_column", "cursor_value"),
+        updated_at_column=spec.get("updated_at_column", "updated_at"),
+        auto_create=spec.get("auto_create", True),
+    )
+
+
+def _build_postgres_table_queue(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
+    connector = ctx.resolve_dependency(spec, "connector")
+    if not hasattr(connector, "table_queue"):
+        raise TypeError(f"resource {spec['connector']!r} cannot build postgres_table_queue")
+    return connector.table_queue(
+        table=ctx.require_string(spec, "table"),
+        key=ctx.require_string(spec, "key"),
+        where=ctx.require_string(spec, "where"),
+        claim=ctx.require_mapping(spec, "claim"),
+        ack=ctx.require_mapping(spec, "ack"),
+        nack=ctx.optional_mapping(spec.get("nack"), field=f"{ctx.field}.nack") or None,
+        batch_size=spec.get("batch_size", 100),
+        poll_interval_s=spec.get("poll_interval_s", 1.0),
+    )
+
+
+def _build_postgres_incremental(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
+    connector = ctx.resolve_dependency(spec, "connector")
+    if not hasattr(connector, "incremental"):
+        raise TypeError(f"resource {spec['connector']!r} cannot build postgres_incremental")
+    raw_state_name = spec.get("state")
+    state = None
+    if raw_state_name is not None:
+        state_name = ctx.string_value(raw_state_name, field=f"{ctx.field}.state")
+        state = ctx.resolve(state_name)
+        if not ctx.is_cursor_store(state):
+            raise TypeError(f"resource {state_name!r} cannot be used as incremental state")
+    return connector.incremental(
+        table=ctx.require_string(spec, "table"),
+        key=ctx.require_string(spec, "key"),
+        cursor=tuple(ctx.string_list(spec.get("cursor"), field=f"{ctx.field}.cursor")),
+        where=spec.get("where"),
+        batch_size=spec.get("batch_size", 1000),
+        poll_interval_s=spec.get("poll_interval_s", 1.0),
+        state=state,
+        state_key=spec.get("state_key"),
+    )
+
+
+def _build_postgres_table_sink(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
+    connector = ctx.resolve_dependency(spec, "connector")
+    if not hasattr(connector, "table_sink"):
+        raise TypeError(f"resource {spec['connector']!r} cannot build postgres_table_sink")
+    keys = spec.get("keys")
+    return connector.table_sink(
+        table=ctx.require_string(spec, "table"),
+        mode=spec.get("mode", "insert"),
+        keys=tuple(ctx.string_list(keys, field=f"{ctx.field}.keys")) if keys is not None else (),
+    )

--- a/plugins/onestep-postgres/src/onestep_postgres/state_sqlalchemy.py
+++ b/plugins/onestep-postgres/src/onestep_postgres/state_sqlalchemy.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from datetime import datetime, timezone
+from typing import Any
+
+try:
+    import sqlalchemy as sa
+    from sqlalchemy import create_engine
+except ImportError:  # pragma: no cover - exercised when optional deps are missing
+    sa = None
+    create_engine = None
+
+
+class SQLAlchemyStateStore:
+    def __init__(
+        self,
+        *,
+        dsn: str | None = None,
+        engine: Any | None = None,
+        table: str = "onestep_state",
+        key_column: str = "state_key",
+        value_column: str = "state_value",
+        updated_at_column: str = "updated_at",
+        auto_create: bool = True,
+        **engine_options: Any,
+    ) -> None:
+        if create_engine is None or sa is None:
+            raise RuntimeError("SQLAlchemyStateStore requires SQLAlchemy. Install onestep-postgres.")
+        if engine is None and dsn is None:
+            raise ValueError("dsn or engine is required")
+        if engine is not None and dsn is not None:
+            raise ValueError("pass either dsn or engine, not both")
+        self.engine = engine or create_engine(dsn, future=True, pool_pre_ping=True, **engine_options)
+        self._owns_engine = engine is None
+        self.table_name = table
+        self.key_column_name = key_column
+        self.value_column_name = value_column
+        self.updated_at_column_name = updated_at_column
+        self.auto_create = auto_create
+        self._metadata = sa.MetaData()
+        self._table = sa.Table(
+            table,
+            self._metadata,
+            sa.Column(key_column, sa.String(255), primary_key=True),
+            sa.Column(value_column, sa.Text(), nullable=False),
+            sa.Column(updated_at_column, sa.DateTime(timezone=True), nullable=False),
+        )
+        self._ready = False
+        self._ready_lock = threading.Lock()
+
+    async def load(self, key: str) -> Any | None:
+        return await asyncio.to_thread(self._load_sync, key)
+
+    async def save(self, key: str, value: Any) -> None:
+        await asyncio.to_thread(self._save_sync, key, value)
+
+    async def delete(self, key: str) -> None:
+        await asyncio.to_thread(self._delete_sync, key)
+
+    async def close(self) -> None:
+        if self._owns_engine:
+            await asyncio.to_thread(self.engine.dispose)
+
+    def _load_sync(self, key: str) -> Any | None:
+        self._ensure_ready_sync()
+        key_column = self._table.c[self.key_column_name]
+        value_column = self._table.c[self.value_column_name]
+        with self.engine.begin() as conn:
+            row = conn.execute(sa.select(value_column).where(key_column == key)).scalar_one_or_none()
+        if row is None:
+            return None
+        return json.loads(row)
+
+    def _save_sync(self, key: str, value: Any) -> None:
+        self._ensure_ready_sync()
+        key_column = self._table.c[self.key_column_name]
+        payload = {
+            self.key_column_name: key,
+            self.value_column_name: json.dumps(value, ensure_ascii=False),
+            self.updated_at_column_name: datetime.now(timezone.utc),
+        }
+        with self.engine.begin() as conn:
+            exists = conn.execute(sa.select(key_column).where(key_column == key)).scalar_one_or_none()
+            if exists is None:
+                conn.execute(sa.insert(self._table).values(**payload))
+                return
+            conn.execute(
+                sa.update(self._table)
+                .where(key_column == key)
+                .values(
+                    **{
+                        self.value_column_name: payload[self.value_column_name],
+                        self.updated_at_column_name: payload[self.updated_at_column_name],
+                    }
+                )
+            )
+
+    def _delete_sync(self, key: str) -> None:
+        self._ensure_ready_sync()
+        key_column = self._table.c[self.key_column_name]
+        with self.engine.begin() as conn:
+            conn.execute(sa.delete(self._table).where(key_column == key))
+
+    def _ensure_ready_sync(self) -> None:
+        if self._ready or not self.auto_create:
+            return
+        with self._ready_lock:
+            if self._ready:
+                return
+            self._metadata.create_all(self.engine, tables=[self._table], checkfirst=True)
+            self._ready = True
+
+
+class SQLAlchemyCursorStore(SQLAlchemyStateStore):
+    pass

--- a/plugins/onestep-postgres/tests/integration/test_postgres_live.py
+++ b/plugins/onestep-postgres/tests/integration/test_postgres_live.py
@@ -1,0 +1,185 @@
+import asyncio
+import os
+import uuid
+
+import pytest
+import sqlalchemy as sa
+
+from onestep_postgres import PostgresConnector
+
+
+if not os.getenv("ONESTEP_POSTGRES_DSN"):
+    pytest.skip("set ONESTEP_POSTGRES_DSN to run PostgreSQL integration tests", allow_module_level=True)
+
+
+def _engine():
+    return sa.create_engine(os.environ["ONESTEP_POSTGRES_DSN"], future=True)
+
+
+@pytest.mark.integration
+def test_postgres_table_queue_claim_ack_and_retry_live():
+    async def scenario():
+        suffix = uuid.uuid4().hex[:8]
+        table_name = f"orders_{suffix}"
+        engine = _engine()
+        metadata = sa.MetaData()
+        orders = sa.Table(
+            table_name,
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("payload", sa.String(255), nullable=False),
+            sa.Column("status", sa.Integer, nullable=False),
+        )
+        metadata.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(
+                sa.insert(orders),
+                [
+                    {"id": 1, "payload": "alpha", "status": 0},
+                    {"id": 2, "payload": "beta", "status": 0},
+                ],
+            )
+
+        db = PostgresConnector(os.environ["ONESTEP_POSTGRES_DSN"])
+        source = db.table_queue(
+            table=table_name,
+            key="id",
+            where="status = 0",
+            claim={"status": 9},
+            ack={"status": 1},
+            nack={"status": 0},
+            batch_size=10,
+            poll_interval_s=0.1,
+        )
+
+        batch = await source.fetch(10)
+        assert [item.payload["id"] for item in batch] == [1, 2]
+        assert [item.payload["status"] for item in batch] == [9, 9]
+
+        await batch[0].ack()
+        await batch[1].retry()
+
+        with db.engine.begin() as conn:
+            rows = conn.execute(sa.select(orders).order_by(orders.c.id)).mappings().all()
+        assert [dict(row)["status"] for row in rows] == [1, 0]
+
+        await db.close()
+        metadata.drop_all(engine)
+        engine.dispose()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.integration
+def test_postgres_incremental_cursor_recovers_after_restart_live():
+    async def scenario():
+        suffix = uuid.uuid4().hex[:8]
+        users_table_name = f"users_{suffix}"
+        cursor_table_name = f"cursor_{suffix}"
+        engine = _engine()
+        metadata = sa.MetaData()
+        users = sa.Table(
+            users_table_name,
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("name", sa.String(255), nullable=False),
+            sa.Column("updated_at", sa.Integer, nullable=False),
+            sa.Column("deleted", sa.Integer, nullable=False, default=0),
+        )
+        metadata.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(
+                sa.insert(users),
+                [
+                    {"id": 1, "name": "A", "updated_at": 10, "deleted": 0},
+                    {"id": 2, "name": "B", "updated_at": 10, "deleted": 0},
+                ],
+            )
+
+        db = PostgresConnector(os.environ["ONESTEP_POSTGRES_DSN"])
+        cursor = db.cursor_store(table=cursor_table_name)
+        source = db.incremental(
+            table=users_table_name,
+            key="id",
+            cursor=("updated_at", "id"),
+            where="deleted = 0",
+            batch_size=10,
+            poll_interval_s=0.1,
+            state=cursor,
+            state_key="users-sync",
+        )
+
+        first_batch = await source.fetch(10)
+        assert [item.payload["id"] for item in first_batch] == [1, 2]
+        await first_batch[1].ack()
+        assert await cursor.load("users-sync") is None
+        await first_batch[0].ack()
+        assert await cursor.load("users-sync") == [10, 2]
+        await db.close()
+
+        restarted = PostgresConnector(os.environ["ONESTEP_POSTGRES_DSN"])
+        restarted_cursor = restarted.cursor_store(table=cursor_table_name)
+        restarted_source = restarted.incremental(
+            table=users_table_name,
+            key="id",
+            cursor=("updated_at", "id"),
+            where="deleted = 0",
+            batch_size=10,
+            poll_interval_s=0.1,
+            state=restarted_cursor,
+            state_key="users-sync",
+        )
+
+        empty = await restarted_source.fetch(10)
+        assert empty == []
+
+        with restarted.engine.begin() as conn:
+            conn.execute(sa.insert(users), [{"id": 3, "name": "C", "updated_at": 11, "deleted": 0}])
+
+        next_batch = await restarted_source.fetch(10)
+        assert [item.payload["id"] for item in next_batch] == [3]
+        await next_batch[0].ack()
+        assert await restarted_cursor.load("users-sync") == [11, 3]
+
+        await restarted.close()
+        with engine.begin() as conn:
+            conn.execute(sa.text(f'DROP TABLE IF EXISTS "{cursor_table_name}"'))
+        metadata.drop_all(engine)
+        engine.dispose()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.integration
+def test_postgres_table_sink_upserts_live():
+    async def scenario():
+        suffix = uuid.uuid4().hex[:8]
+        table_name = f"processed_{suffix}"
+        engine = _engine()
+        metadata = sa.MetaData()
+        processed = sa.Table(
+            table_name,
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("payload", sa.String(255), nullable=False),
+            sa.Column("status", sa.String(255), nullable=False),
+        )
+        metadata.create_all(engine)
+
+        db = PostgresConnector(os.environ["ONESTEP_POSTGRES_DSN"])
+        sink = db.table_sink(table=table_name, mode="upsert", keys=("id",))
+
+        from onestep.envelope import Envelope
+
+        await sink.send(Envelope(body={"id": 1, "payload": "alpha", "status": "new"}))
+        await sink.send(Envelope(body={"id": 1, "payload": "alpha", "status": "done"}))
+
+        with db.engine.begin() as conn:
+            rows = conn.execute(sa.select(processed).order_by(processed.c.id)).mappings().all()
+        assert [dict(row) for row in rows] == [{"id": 1, "payload": "alpha", "status": "done"}]
+
+        await db.close()
+        metadata.drop_all(engine)
+        engine.dispose()
+
+    asyncio.run(scenario())

--- a/plugins/onestep-postgres/tests/test_postgres_incremental.py
+++ b/plugins/onestep-postgres/tests/test_postgres_incremental.py
@@ -1,0 +1,221 @@
+import asyncio
+from pathlib import Path
+
+import sqlalchemy as sa
+
+from onestep_postgres import PostgresConnector
+
+
+def test_postgres_incremental_cursor_advances_in_order(tmp_path: Path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'incremental.db'}"
+    engine, users = _build_users_db(db_url)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.insert(users),
+            [
+                {"id": 1, "name": "A", "updated_at": 10, "deleted": 0},
+                {"id": 2, "name": "B", "updated_at": 10, "deleted": 0},
+            ],
+        )
+    engine.dispose()
+
+    async def scenario() -> None:
+        db = PostgresConnector(db_url)
+        state = db.cursor_store(table="onestep_cursor")
+        source = db.incremental(
+            table="users",
+            key="id",
+            cursor=("updated_at", "id"),
+            where="deleted = 0",
+            batch_size=10,
+            poll_interval_s=0.01,
+            state=state,
+            state_key="users-sync",
+        )
+
+        batch = await source.fetch(10)
+        assert [item.payload["id"] for item in batch] == [1, 2]
+
+        await batch[1].ack()
+        assert await state.load("users-sync") is None
+
+        await batch[0].ack()
+        assert await state.load("users-sync") == [10, 2]
+        await db.close()
+
+        restarted_db = PostgresConnector(db_url)
+        restarted_state = restarted_db.cursor_store(table="onestep_cursor")
+        restarted_source = restarted_db.incremental(
+            table="users",
+            key="id",
+            cursor=("updated_at", "id"),
+            where="deleted = 0",
+            batch_size=10,
+            poll_interval_s=0.01,
+            state=restarted_state,
+            state_key="users-sync",
+        )
+
+        empty_batch = await restarted_source.fetch(10)
+        assert empty_batch == []
+
+        with restarted_db.engine.begin() as conn:
+            conn.execute(sa.insert(users), [{"id": 3, "name": "C", "updated_at": 11, "deleted": 0}])
+
+        next_batch = await restarted_source.fetch(10)
+        assert [item.payload["id"] for item in next_batch] == [3]
+        await next_batch[0].ack()
+        assert await restarted_state.load("users-sync") == [11, 3]
+        await restarted_db.close()
+
+    asyncio.run(scenario())
+
+
+def test_postgres_incremental_does_not_refetch_pending_gap_with_out_of_order_ack(tmp_path: Path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'incremental_gap.db'}"
+    engine, users = _build_users_db(db_url)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.insert(users),
+            [
+                {"id": 1, "name": "A", "updated_at": 10, "deleted": 0},
+                {"id": 2, "name": "B", "updated_at": 10, "deleted": 0},
+            ],
+        )
+    engine.dispose()
+
+    async def scenario() -> None:
+        db = PostgresConnector(db_url)
+        source = db.incremental(
+            table="users",
+            key="id",
+            cursor=("updated_at", "id"),
+            where="deleted = 0",
+            batch_size=10,
+            poll_interval_s=0.01,
+        )
+
+        batch = await source.fetch(10)
+        assert [item.payload["id"] for item in batch] == [1, 2]
+
+        await batch[1].ack()
+        next_batch = await source.fetch(1)
+        assert next_batch == []
+
+        await batch[0].ack()
+        await db.close()
+
+    asyncio.run(scenario())
+
+
+def test_postgres_incremental_uses_key_as_tie_breaker_when_cursor_is_not_unique(tmp_path: Path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'incremental_tiebreak.db'}"
+    engine, users = _build_users_db(db_url)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.insert(users),
+            [
+                {"id": 1, "name": "A", "updated_at": 10, "deleted": 0},
+                {"id": 2, "name": "B", "updated_at": 10, "deleted": 0},
+            ],
+        )
+    engine.dispose()
+
+    async def scenario() -> None:
+        db = PostgresConnector(db_url)
+        state = db.cursor_store(table="onestep_cursor")
+        source = db.incremental(
+            table="users",
+            key="id",
+            cursor=("updated_at",),
+            where="deleted = 0",
+            batch_size=10,
+            poll_interval_s=0.01,
+            state=state,
+            state_key="users-updated-at",
+        )
+
+        batch = await source.fetch(10)
+        assert [item.payload["id"] for item in batch] == [1, 2]
+        assert source.cursor == ("updated_at", "id")
+
+        await batch[0].ack()
+        await batch[1].ack()
+        assert await state.load("users-updated-at") == [10, 2]
+
+        with db.engine.begin() as conn:
+            conn.execute(sa.insert(users), [{"id": 3, "name": "C", "updated_at": 10, "deleted": 0}])
+
+        next_batch = await source.fetch(10)
+        assert [item.payload["id"] for item in next_batch] == [3]
+        await next_batch[0].ack()
+        await db.close()
+
+    asyncio.run(scenario())
+
+
+def test_postgres_incremental_default_state_key_separates_distinct_where_clauses(tmp_path: Path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'incremental_where_scope.db'}"
+    engine, users = _build_users_db(db_url)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.insert(users),
+            [
+                {"id": 1, "name": "A", "updated_at": 10, "deleted": 0},
+                {"id": 2, "name": "B", "updated_at": 11, "deleted": 0},
+                {"id": 3, "name": "C", "updated_at": 9, "deleted": 1},
+            ],
+        )
+    engine.dispose()
+
+    async def scenario() -> None:
+        db = PostgresConnector(db_url)
+        state = db.cursor_store(table="onestep_cursor")
+        active = db.incremental(
+            table="users",
+            key="id",
+            cursor=("updated_at",),
+            where="deleted = 0",
+            batch_size=10,
+            poll_interval_s=0.01,
+            state=state,
+        )
+        deleted = db.incremental(
+            table="users",
+            key="id",
+            cursor=("updated_at",),
+            where="deleted = 1",
+            batch_size=10,
+            poll_interval_s=0.01,
+            state=state,
+        )
+
+        assert active.state_key != deleted.state_key
+
+        active_batch = await active.fetch(10)
+        assert [item.payload["id"] for item in active_batch] == [1, 2]
+        await active_batch[0].ack()
+        await active_batch[1].ack()
+
+        deleted_batch = await deleted.fetch(10)
+        assert [item.payload["id"] for item in deleted_batch] == [3]
+        await deleted_batch[0].ack()
+
+        await db.close()
+
+    asyncio.run(scenario())
+
+
+def _build_users_db(db_url: str):
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    users = sa.Table(
+        "users",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String, nullable=False),
+        sa.Column("updated_at", sa.Integer, nullable=False),
+        sa.Column("deleted", sa.Integer, nullable=False, default=0),
+    )
+    metadata.create_all(engine)
+    return engine, users

--- a/plugins/onestep-postgres/tests/test_postgres_plugin.py
+++ b/plugins/onestep-postgres/tests/test_postgres_plugin.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib
+from importlib import metadata as importlib_metadata
+from typing import Any
+
+import pytest
+
+from onestep.config import load_app_config
+from onestep.resilience import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError
+from onestep_postgres import (
+    PostgresConnector,
+    PostgresIncrementalSource,
+    PostgresTableSink,
+    SQLAlchemyCursorStore,
+    SQLAlchemyStateStore,
+)
+from onestep_postgres.resilience import as_postgres_connector_operation_error, classify_sqlalchemy_error
+
+
+def test_package_exposes_onestep_resource_entry_point() -> None:
+    entry_points = _entry_points_for_group("onestep.resources")
+
+    assert any(
+        entry_point.name == "postgres"
+        and entry_point.value == "onestep_postgres:register"
+        for entry_point in entry_points
+    )
+
+
+def test_sqlalchemy_state_store_is_not_exposed_by_core() -> None:
+    import onestep
+
+    assert not hasattr(onestep, "SQLAlchemyStateStore")
+    assert not hasattr(onestep, "SQLAlchemyCursorStore")
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("onestep.state_sqlalchemy")
+
+
+def test_postgres_plugin_normalizes_sqlalchemy_errors() -> None:
+    assert classify_sqlalchemy_error(TimeoutError("timeout")) is None
+
+    from onestep_postgres.resilience import sa
+
+    assert sa is not None
+    sql_error = sa.exc.TimeoutError("timeout")
+    assert classify_sqlalchemy_error(sql_error) is ConnectorErrorKind.TRANSIENT
+
+    normalized = as_postgres_connector_operation_error(
+        operation=ConnectorOperation.FETCH,
+        exc=sql_error,
+        source_name="postgres.incremental:users",
+        retry_delay_s=2.0,
+    )
+
+    assert isinstance(normalized, ConnectorOperationError)
+    assert normalized.backend == "postgres"
+    assert normalized.operation is ConnectorOperation.FETCH
+    assert normalized.kind is ConnectorErrorKind.TRANSIENT
+    assert normalized.source_name == "postgres.incremental:users"
+    assert normalized.retry_delay_s == 2.0
+    assert normalized.cause is sql_error
+
+
+def test_yaml_builds_postgres_resources_via_plugin_entry_point(tmp_path) -> None:
+    dsn = f"sqlite:///{tmp_path / 'postgres-plugin.db'}"
+
+    app = load_app_config(
+        {
+            "apiVersion": "onestep/v1alpha1",
+            "kind": "App",
+            "app": {
+                "name": "postgres-plugin",
+                "state": "app_state",
+            },
+            "resources": {
+                "db": {
+                    "type": "postgres",
+                    "dsn": dsn,
+                },
+                "app_state": {
+                    "type": "postgres_state_store",
+                    "connector": "db",
+                },
+                "cursor": {
+                    "type": "postgres_cursor_store",
+                    "connector": "db",
+                },
+                "users": {
+                    "type": "postgres_incremental",
+                    "connector": "db",
+                    "table": "users",
+                    "key": "id",
+                    "cursor": ["updated_at", "id"],
+                    "state": "cursor",
+                },
+                "processed": {
+                    "type": "postgres_table_sink",
+                    "connector": "db",
+                    "table": "processed_users",
+                },
+            },
+            "tasks": [],
+        },
+        strict=True,
+    )
+
+    assert isinstance(app.resources["db"], PostgresConnector)
+    assert isinstance(app.resources["app_state"], SQLAlchemyStateStore)
+    assert isinstance(app.resources["cursor"], SQLAlchemyCursorStore)
+    assert isinstance(app.resources["users"], PostgresIncrementalSource)
+    assert app.resources["users"].state is app.resources["cursor"]
+    assert isinstance(app.resources["processed"], PostgresTableSink)
+    assert app.state is app.resources["app_state"]
+
+
+def _entry_points_for_group(group: str) -> tuple[Any, ...]:
+    entry_points = importlib_metadata.entry_points()
+    if hasattr(entry_points, "select"):
+        return tuple(entry_points.select(group=group))
+    return tuple(entry_points.get(group, ()))

--- a/plugins/onestep-postgres/tests/test_postgres_runtime_contract.py
+++ b/plugins/onestep-postgres/tests/test_postgres_runtime_contract.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+import sqlalchemy as sa
+
+from onestep import OneStepApp
+from onestep_postgres import PostgresConnector
+
+
+def _build_table_queue_db(tmp_path: Path) -> tuple[str, sa.Table]:
+    db_url = f"sqlite:///{tmp_path / 'queue.db'}"
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    orders = sa.Table(
+        "orders",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("payload", sa.String, nullable=False),
+        sa.Column("status", sa.Integer, nullable=False),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(sa.insert(orders), [{"id": 1, "payload": "A", "status": 0}])
+    engine.dispose()
+    return db_url, orders
+
+
+def _load_order_rows(db_url: str, orders: sa.Table) -> list[tuple[int, int]]:
+    engine = sa.create_engine(db_url, future=True)
+    with engine.begin() as conn:
+        rows = conn.execute(sa.select(orders.c.id, orders.c.status).order_by(orders.c.id)).all()
+    engine.dispose()
+    return list(rows)
+
+
+def test_table_queue_drain_releases_claimed_rows_when_fetch_is_stopped_contract(tmp_path: Path) -> None:
+    db_url, orders = _build_table_queue_db(tmp_path)
+
+    async def scenario() -> list[int]:
+        app = OneStepApp("table-queue-drain-contract", shutdown_timeout_s=1.0)
+        db = PostgresConnector(db_url)
+        source = _source(db)
+        original_fetch = source._fetch_sync
+
+        def slow_fetch(limit: int):
+            rows = original_fetch(limit)
+            time.sleep(0.2)
+            return rows
+
+        source._fetch_sync = slow_fetch
+        seen: list[int] = []
+
+        @app.task(source=source, concurrency=1)
+        async def consume(ctx, row):
+            seen.append(row["id"])
+
+        async def controller() -> None:
+            await asyncio.sleep(0.05)
+            app.request_drain()
+            await asyncio.wait_for(app.wait_for_drain(), timeout=1.0)
+            app.request_shutdown()
+
+        await asyncio.wait_for(asyncio.gather(app.serve(), controller()), timeout=2.0)
+        await db.close()
+        return seen
+
+    seen = asyncio.run(scenario())
+
+    assert seen == []
+    assert _load_order_rows(db_url, orders) == [(1, 0)]
+
+
+def test_table_queue_pause_releases_claimed_rows_when_fetch_is_stopped_contract(tmp_path: Path) -> None:
+    db_url, orders = _build_table_queue_db(tmp_path)
+
+    async def scenario() -> list[int]:
+        app = OneStepApp("table-queue-pause-contract", shutdown_timeout_s=1.0)
+        db = PostgresConnector(db_url)
+        source = _source(db)
+        original_fetch = source._fetch_sync
+
+        def slow_fetch(limit: int):
+            rows = original_fetch(limit)
+            time.sleep(0.2)
+            return rows
+
+        source._fetch_sync = slow_fetch
+        seen: list[int] = []
+
+        @app.task(source=source, concurrency=1)
+        async def consume(ctx, row):
+            seen.append(row["id"])
+
+        async def controller() -> None:
+            await asyncio.sleep(0.05)
+            app.request_task_pause("consume")
+            await asyncio.wait_for(app.wait_for_task_pause("consume"), timeout=1.0)
+            app.request_shutdown()
+
+        await asyncio.wait_for(asyncio.gather(app.serve(), controller()), timeout=2.0)
+        await db.close()
+        return seen
+
+    seen = asyncio.run(scenario())
+
+    assert seen == []
+    assert _load_order_rows(db_url, orders) == [(1, 0)]
+
+
+def test_table_queue_shutdown_releases_claimed_rows_when_fetch_is_stopped_contract(tmp_path: Path) -> None:
+    db_url, orders = _build_table_queue_db(tmp_path)
+
+    async def scenario() -> list[int]:
+        app = OneStepApp("table-queue-shutdown-contract", shutdown_timeout_s=1.0)
+        db = PostgresConnector(db_url)
+        source = _source(db)
+        original_fetch = source._fetch_sync
+
+        def slow_fetch(limit: int):
+            rows = original_fetch(limit)
+            time.sleep(0.2)
+            return rows
+
+        source._fetch_sync = slow_fetch
+        seen: list[int] = []
+
+        @app.task(source=source, concurrency=1)
+        async def consume(ctx, row):
+            seen.append(row["id"])
+
+        async def controller() -> None:
+            await asyncio.sleep(0.05)
+            app.request_shutdown()
+
+        await asyncio.wait_for(asyncio.gather(app.serve(), controller()), timeout=2.0)
+        await db.close()
+        return seen
+
+    seen = asyncio.run(scenario())
+
+    assert seen == []
+    assert _load_order_rows(db_url, orders) == [(1, 0)]
+
+
+def _source(db: PostgresConnector):
+    return db.table_queue(
+        table="orders",
+        key="id",
+        where="status = 0",
+        claim={"status": 9},
+        ack={"status": 1},
+        nack={"status": 0},
+        batch_size=1,
+        poll_interval_s=0.01,
+    )

--- a/plugins/onestep-postgres/tests/test_postgres_table_queue.py
+++ b/plugins/onestep-postgres/tests/test_postgres_table_queue.py
@@ -1,0 +1,82 @@
+import asyncio
+from pathlib import Path
+
+import sqlalchemy as sa
+
+from onestep import OneStepApp
+from onestep_postgres import PostgresConnector
+
+
+def test_postgres_table_queue_round_trip(tmp_path: Path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'queue.db'}"
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    orders = sa.Table(
+        "orders",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("payload", sa.String, nullable=False),
+        sa.Column("status", sa.Integer, nullable=False),
+        sa.Column("score", sa.Integer),
+    )
+    processed = sa.Table(
+        "processed_orders",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("payload", sa.String, nullable=False),
+        sa.Column("status", sa.String, nullable=False),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.insert(orders),
+            [
+                {"id": 1, "payload": "A", "status": 0, "score": None},
+                {"id": 2, "payload": "B", "status": 0, "score": None},
+            ],
+        )
+    engine.dispose()
+
+    seen_scores: list[tuple[int, int]] = []
+
+    async def scenario() -> None:
+        app = OneStepApp("table-queue")
+        db = PostgresConnector(db_url)
+        source = db.table_queue(
+            table="orders",
+            key="id",
+            where="status = 0",
+            claim={"status": 9},
+            ack={"status": 1},
+            nack={"status": 0},
+            batch_size=10,
+            poll_interval_s=0.01,
+        )
+        sink = db.table_sink(table="processed_orders", mode="upsert", keys=("id",))
+        seen: list[int] = []
+
+        @app.task(source=source, emit=sink, concurrency=2)
+        async def process(ctx, row):
+            await ctx.update_current_row({"score": row["id"] * 10})
+            seen.append(row["id"])
+            seen_scores.append((row["id"], row["score"]))
+            if len(seen) == 2:
+                ctx.app.request_shutdown()
+            return {"id": row["id"], "payload": row["payload"], "status": "done"}
+
+        await app.serve()
+        await db.close()
+
+    asyncio.run(scenario())
+
+    verify_engine = sa.create_engine(db_url, future=True)
+    with verify_engine.begin() as conn:
+        order_rows = conn.execute(sa.select(orders.c.id, orders.c.status, orders.c.score).order_by(orders.c.id)).all()
+        processed_rows = conn.execute(
+            sa.select(processed.c.id, processed.c.payload, processed.c.status).order_by(processed.c.id)
+        ).all()
+    verify_engine.dispose()
+
+    assert sorted(seen_scores) == [(1, 10), (2, 20)]
+    assert order_rows == [(1, 1, 10), (2, 1, 20)]
+    assert processed_rows == [(1, "A", "done"), (2, "B", "done")]

--- a/plugins/onestep-postgres/tests/test_state_sqlalchemy.py
+++ b/plugins/onestep-postgres/tests/test_state_sqlalchemy.py
@@ -1,0 +1,43 @@
+import asyncio
+from pathlib import Path
+
+from onestep_postgres import PostgresConnector, SQLAlchemyStateStore
+
+
+def test_sqlalchemy_state_store_persists_across_instances(tmp_path: Path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'state.db'}"
+
+    async def scenario() -> None:
+        store = SQLAlchemyStateStore(dsn=db_url)
+        await store.save("jobs:last-run", {"cursor": [10, 2], "status": "ok"})
+        assert await store.load("jobs:last-run") == {"cursor": [10, 2], "status": "ok"}
+        await store.close()
+
+        reloaded = SQLAlchemyStateStore(dsn=db_url)
+        assert await reloaded.load("jobs:last-run") == {"cursor": [10, 2], "status": "ok"}
+        await reloaded.delete("jobs:last-run")
+        assert await reloaded.load("jobs:last-run") is None
+        await reloaded.close()
+
+    asyncio.run(scenario())
+
+
+def test_postgres_connector_builds_shared_state_store(tmp_path: Path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'connector-state.db'}"
+
+    async def scenario() -> None:
+        db = PostgresConnector(db_url)
+        state = db.state_store(table="app_state")
+        cursor = db.cursor_store(table="app_cursor")
+
+        assert state.engine is db.engine
+        assert cursor.engine is db.engine
+
+        await state.save("service:mode", {"value": "active"})
+        await cursor.save("users", [10, 2])
+
+        assert await state.load("service:mode") == {"value": "active"}
+        assert await cursor.load("users") == [10, 2]
+        await db.close()
+
+    asyncio.run(scenario())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ yaml = [
 mysql = [
     "onestep-mysql>=0.3.0",
 ]
+postgres = [
+    "onestep-postgres>=0.1.0",
+]
 rabbitmq = [
     "onestep-mq>=0.2.0",
 ]
@@ -54,6 +57,7 @@ integration = [
     "onestep-mq>=0.2.0",
     "onestep-redis>=0.2.0",
     "onestep-mysql>=0.3.0",
+    "onestep-postgres>=0.1.0",
     "onestep-sqs>=0.2.0",
 ]
 all = [
@@ -62,6 +66,7 @@ all = [
     "onestep-mq>=0.2.0",
     "onestep-redis>=0.2.0",
     "onestep-mysql>=0.3.0",
+    "onestep-postgres>=0.1.0",
     "onestep-sqs>=0.2.0",
 ]
 dev = [
@@ -72,6 +77,7 @@ dev = [
     "onestep-mq>=0.2.0",
     "onestep-redis>=0.2.0",
     "onestep-mysql>=0.3.0",
+    "onestep-postgres>=0.1.0",
     "onestep-sqs>=0.2.0",
 ]
 
@@ -84,6 +90,7 @@ members = [
     "plugins/onestep-rabbitmq",
     "plugins/onestep-redis",
     "plugins/onestep-mysql",
+    "plugins/onestep-postgres",
     "plugins/onestep-sqs",
 ]
 
@@ -91,6 +98,7 @@ members = [
 onestep-mq = { workspace = true }
 onestep-redis = { workspace = true }
 onestep-mysql = { workspace = true }
+onestep-postgres = { workspace = true }
 onestep-sqs = { workspace = true }
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ members = [
     "onestep-feishu-bitable",
     "onestep-mq",
     "onestep-mysql",
+    "onestep-postgres",
     "onestep-redis",
     "onestep-sqs",
 ]
@@ -479,6 +480,7 @@ source = { editable = "." }
 all = [
     { name = "onestep-mq" },
     { name = "onestep-mysql" },
+    { name = "onestep-postgres" },
     { name = "onestep-redis" },
     { name = "onestep-sqs" },
     { name = "pyyaml" },
@@ -492,6 +494,7 @@ control-plane = [
 dev = [
     { name = "onestep-mq" },
     { name = "onestep-mysql" },
+    { name = "onestep-postgres" },
     { name = "onestep-redis" },
     { name = "onestep-sqs" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -505,6 +508,7 @@ dev = [
 integration = [
     { name = "onestep-mq" },
     { name = "onestep-mysql" },
+    { name = "onestep-postgres" },
     { name = "onestep-redis" },
     { name = "onestep-sqs" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -515,6 +519,9 @@ integration = [
 ]
 mysql = [
     { name = "onestep-mysql" },
+]
+postgres = [
+    { name = "onestep-postgres" },
 ]
 rabbitmq = [
     { name = "onestep-mq" },
@@ -546,6 +553,10 @@ requires-dist = [
     { name = "onestep-mysql", marker = "extra == 'dev'", editable = "plugins/onestep-mysql" },
     { name = "onestep-mysql", marker = "extra == 'integration'", editable = "plugins/onestep-mysql" },
     { name = "onestep-mysql", marker = "extra == 'mysql'", editable = "plugins/onestep-mysql" },
+    { name = "onestep-postgres", marker = "extra == 'all'", editable = "plugins/onestep-postgres" },
+    { name = "onestep-postgres", marker = "extra == 'dev'", editable = "plugins/onestep-postgres" },
+    { name = "onestep-postgres", marker = "extra == 'integration'", editable = "plugins/onestep-postgres" },
+    { name = "onestep-postgres", marker = "extra == 'postgres'", editable = "plugins/onestep-postgres" },
     { name = "onestep-redis", marker = "extra == 'all'", editable = "plugins/onestep-redis" },
     { name = "onestep-redis", marker = "extra == 'dev'", editable = "plugins/onestep-redis" },
     { name = "onestep-redis", marker = "extra == 'integration'", editable = "plugins/onestep-redis" },
@@ -569,7 +580,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'control-plane'", specifier = ">=12.0" },
     { name = "websockets", marker = "extra == 'dev'", specifier = ">=12.0" },
 ]
-provides-extras = ["control-plane", "yaml", "mysql", "rabbitmq", "redis", "sqs", "test", "integration", "all", "dev"]
+provides-extras = ["control-plane", "yaml", "mysql", "postgres", "rabbitmq", "redis", "sqs", "test", "integration", "all", "dev"]
 
 [[package]]
 name = "onestep-feishu-bitable"
@@ -652,6 +663,37 @@ requires-dist = [
     { name = "mysql-replication", specifier = ">=1.0.15" },
     { name = "onestep", editable = "." },
     { name = "pymysql", specifier = ">=1.1.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "sqlalchemy", specifier = ">=2.0.0" },
+]
+provides-extras = ["test", "dev"]
+
+[[package]]
+name = "onestep-postgres"
+version = "0.1.0"
+source = { editable = "plugins/onestep-postgres" }
+dependencies = [
+    { name = "onestep" },
+    { name = "psycopg", version = "3.2.13", source = { registry = "https://pypi.org/simple" }, extra = ["binary"], marker = "python_full_version < '3.10'" },
+    { name = "psycopg", version = "3.3.4", source = { registry = "https://pypi.org/simple" }, extra = ["binary"], marker = "python_full_version >= '3.10'" },
+    { name = "sqlalchemy" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+test = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "onestep", editable = "." },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
@@ -875,6 +917,177 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/45/d78d136c3a3d215677abb886785aae744da2c3005bcb99e58640c56529b1/propcache-0.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:948dab269721ae9a87fd16c514a0a2c2a1bdb23a9a61b969b0f9d9ee2968546f", size = 41912, upload-time = "2025-10-08T19:48:57.995Z" },
     { url = "https://files.pythonhosted.org/packages/fc/2a/b0632941f25139f4e58450b307242951f7c2717a5704977c6d5323a800af/propcache-0.4.1-cp39-cp39-win_arm64.whl", hash = "sha256:5fd37c406dd6dc85aa743e214cef35dc54bbdd1419baac4f6ae5e5b1a2976938", size = 38450, upload-time = "2025-10-08T19:48:59.349Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.2.13"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "tzdata", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/05/d4a05988f15fcf90e0088c735b1f2fc04a30b7fc65461d6ec278f5f2f17a/psycopg-3.2.13.tar.gz", hash = "sha256:309adaeda61d44556046ec9a83a93f42bbe5310120b1995f3af49ab6d9f13c1d", size = 160626, upload-time = "2025-11-21T22:34:32.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/14/f2724bd1986158a348316e86fdd0837a838b14a711df3f00e47fba597447/psycopg-3.2.13-py3-none-any.whl", hash = "sha256:a481374514f2da627157f767a9336705ebefe93ea7a0522a6cbacba165da179a", size = 206797, upload-time = "2025-11-21T22:29:39.733Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", version = "3.2.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "tzdata", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", version = "3.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.2.13"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/16/325f72b7ebdb906bd6cca6c0caea5b8fd7092c4686237c5669fe3f3cc7f2/psycopg_binary-3.2.13-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9e25eb65494955c0dabdcd7097b004cbd70b982cf3cbc7186c2e854f788677a9", size = 4013642, upload-time = "2025-11-21T22:29:43.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a6/f7616dfcab942d5ad6fb5ce8364148e22a4cd817340ac368b6a6bd17559d/psycopg_binary-3.2.13-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:732b25c2d932ca0655ea2588563eae831dc0842c93c69be4754a5b0e9760b38d", size = 4076666, upload-time = "2025-11-21T22:29:51.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f7/cddf75c43c967c9262afe6863275fdd2e5f877d98c379f5c3a21b6fa419d/psycopg_binary-3.2.13-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7350d9cc4e35529c4548ddda34a1c17f28d3f3a8f792c25cd67e8a04952ed415", size = 4639390, upload-time = "2025-11-21T22:29:57.614Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/f86f2e6413ac024b3a759fd446cc90c325a0d7403dce533bd419e1c41164/psycopg_binary-3.2.13-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:090c22795969ee1ace17322b1718769694607d942cef084c6fb4493adfa57da0", size = 4737745, upload-time = "2025-11-21T22:30:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/19/aa/1a17c7176875d7e0a848710d87f13fdd3cc08724fa6bfcc43c72846f22b9/psycopg_binary-3.2.13-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9ac329532f36342ff99fc1aefdbb531563bec03c7bc3ae934c8347a7a61339df", size = 4419762, upload-time = "2025-11-21T22:30:05.401Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9b/5c7f8c90a3504c45ceadffa1f1f4b2fc8ce9e04494cf67d27dfa265e5681/psycopg_binary-3.2.13-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1db11a7e618d58cfb937c409c7d279a84cbb31d32a7efc63f1e5f426f3613793", size = 3878529, upload-time = "2025-11-21T22:30:09.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/37/37e7152e6b0813e68361768d1baf0e40d8ed0ac8091471641c2c88e0cec6/psycopg_binary-3.2.13-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:5f5081b2cbb0358bb3625109d41b57411bf9d9c29762a867e38c06d974b245ee", size = 3560767, upload-time = "2025-11-21T22:30:13.88Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b2/929d8e15b8797486d160b797ce84a4d0251a9361f7f31e9b01b439608e3b/psycopg_binary-3.2.13-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5d466ac3a3738647ff2405397946870dc363e33282ced151e7ea74f622947c06", size = 3604456, upload-time = "2025-11-21T22:30:18.392Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/74/4d4e7481bc717bbe3de689c4d40439d4e1be07df989da2c38140298cbae5/psycopg_binary-3.2.13-cp310-cp310-win_amd64.whl", hash = "sha256:087acf2b24787ae206718136c1f51bc90cda68b02c3819b0556f418e3565f2c3", size = 2910871, upload-time = "2025-11-21T22:30:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/06/f5/fc70804a999167daf5b876107b99e8fe91c3f785a31753c0e3e7b93446ba/psycopg_binary-3.2.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9cfe87749d010dfd34534ba8c71aa0674db9a3fce65232c98989f77c742c9ce7", size = 4013844, upload-time = "2025-11-21T22:30:25.985Z" },
+    { url = "https://files.pythonhosted.org/packages/07/87/857639681f5dfcd567aaf199fe4e5b026a105b0462a604f4fb7eda0735d8/psycopg_binary-3.2.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8db77fac1dfe3f69c982db92a51fd78e1354fa8f523a6781a636123e5c7ffcde", size = 4077002, upload-time = "2025-11-21T22:30:29.539Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/1d/2cb7af6a31429b9022455c966d8408a2b5a19acd3de7610402381518e8f7/psycopg_binary-3.2.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cbbac4cd5b0e14b91ad8244268ca3fc2f527d1a337b489af57d7669c9d2e1a24", size = 4637181, upload-time = "2025-11-21T22:30:34.126Z" },
+    { url = "https://files.pythonhosted.org/packages/28/bd/ffde1ac7e6ab75646c253fbe0378772fb6f0229af8a05cd9862ee8aad0f0/psycopg_binary-3.2.13-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a146f0a59a7e3ca92996f8133b1d5e5922e668f7c656b4a9201e702f4cf25896", size = 4737775, upload-time = "2025-11-21T22:30:38.408Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/74/3702732d01639c97943d56ec26860357dfacda0b5a708e82e794d07f499c/psycopg_binary-3.2.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:27150515de5f709e4142429db6fd36a1d01f0b8b17d915b5f7bb095364465398", size = 4421537, upload-time = "2025-11-21T22:30:42.696Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/8c/915a899857c2211196aa7f1749ba85bed421afaf72f185a0eb91e64ba550/psycopg_binary-3.2.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9942255705255367d94368941e3a913b0daf74b47d191471dbe4dc0de9fbc769", size = 3877500, upload-time = "2025-11-21T22:30:47.064Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d9/46060c183413bf62d47df98d7e3b30ab561639bcb583c3796cca30dafa43/psycopg_binary-3.2.13-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:75ebc8335f48c339ec24f4c371595f6b7043147fe6d18e619c8564428ab8adaf", size = 3560186, upload-time = "2025-11-21T22:30:54.522Z" },
+    { url = "https://files.pythonhosted.org/packages/56/cf/2987689614632898e4861e4122cd41937ea9b5afcbe3c3061c7265bfa6de/psycopg_binary-3.2.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6fe2982a73b2ea473c9e2b91a35a21af3b03313bed188eccbcde4972483ac60a", size = 3601117, upload-time = "2025-11-21T22:31:01.218Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ef/df7fa8a47ef47d08af8a792343811a98bc7ab48f763560fc1d5acc1f28af/psycopg_binary-3.2.13-cp311-cp311-win_amd64.whl", hash = "sha256:6a50db4661fae78779d3cc38a0a68cabc997ca9d485ec27443b109ef8ac1672a", size = 2912873, upload-time = "2025-11-21T22:31:05.473Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9e/f90243b3d0d007a89989b013b0eb3e78ac929fed4eb40a2b317452abafe1/psycopg_binary-3.2.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:223fc610a80bbc4355ad3c9952d468a18bb5cd7065846a8c275f100d80cd4004", size = 3996285, upload-time = "2025-11-21T22:31:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/12/42/7d55f515ee3e2ced5ff9bc493fb2308f5187686b6d9583cd6a9c880d2053/psycopg_binary-3.2.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b67f06a68d68b4621b6a411f9e583df876977afa06b1ba270b1b347d40aa93fc", size = 4070567, upload-time = "2025-11-21T22:31:12.31Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a8/ead4de04d8cf5f35119a75a8dd92fa4a2ec8a309b1aa58855f64616c03d7/psycopg_binary-3.2.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:082579f2ae41bdabe20c82810810f3e290ac2206cccf0cb41cf36b3218f53b3c", size = 4616833, upload-time = "2025-11-21T22:31:16.614Z" },
+    { url = "https://files.pythonhosted.org/packages/26/2e/4af6ab69ade7d67d31296f88c79c322a3522564e30b3f1458f19e74d67c3/psycopg_binary-3.2.13-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:ff7df7bd8ec2c805f3a4896b8ade971139af0f9f8cf45d05014ac71fe54887be", size = 4711710, upload-time = "2025-11-21T22:31:22.007Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/31/bdbd6b2264bb7ae5fe8b775c5524da73329d8888c6137fd8b050ff9cabbc/psycopg_binary-3.2.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8f1189dc78553ef4b2e55d9e116fc74870191bc6a9a5f4442412a703c4cc6c3b", size = 4401656, upload-time = "2025-11-21T22:31:26.842Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c5/8fd8f96450e4ef242022c9a588305e3dc7309c34bc392a9b4c2da60854b1/psycopg_binary-3.2.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0ef8ed4a4e0f7bf5e941782478a43c14b2b585b031e2266dd3afb87be2775d95", size = 3851747, upload-time = "2025-11-21T22:31:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/47/406d102ae49d253f124644530f1e5b3fd2f92aea59d4f9b8dd1c71cf8e0f/psycopg_binary-3.2.13-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:de06fc9707a49f7c081b5c950974dd6de3dc33d681f7524f0b396471f5a4a480", size = 3524796, upload-time = "2025-11-21T22:31:34.377Z" },
+    { url = "https://files.pythonhosted.org/packages/45/6f/a89be8aee27a5522e97dbcb225fe429c489acdf0bb25fc0fadb329dfb39f/psycopg_binary-3.2.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:917ad1cd6e6ef8a9df2f28d7b29c7148f089be46ac56fe838f986c0227652d14", size = 3576536, upload-time = "2025-11-21T22:31:38.06Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f8/c924c7dc792c81bf6181d7d4eeb613c8b2151b3a208f95cedec3c1a25ba3/psycopg_binary-3.2.13-cp312-cp312-win_amd64.whl", hash = "sha256:b53b0d9499805b307017070492189e349256e0946f62c815e442baa01f2ea6c5", size = 2902172, upload-time = "2025-11-21T22:31:41.256Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ec/ef37bb44dc02fcc6c0a3eeb93f4baaac13bcb228633fe38ad3fb5a3f6449/psycopg_binary-3.2.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:dbae6ab1966e2b61d97e47220556c330c4608bb4cfb3a124aa0595c39995c068", size = 3995628, upload-time = "2025-11-21T22:31:45.921Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ad/4748f5f1a40248af16dba087dbec50bd335ee025cc1fb9bf64773378ceff/psycopg_binary-3.2.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fae933e4564386199fc54845d85413eedb49760e0bcd2b621fde2dd1825b99b3", size = 4069024, upload-time = "2025-11-21T22:31:50.202Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c2/f02ec6bbc30c7fcd3b39823d2d624b42fae480edeb6e50eb3276281d5635/psycopg_binary-3.2.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:13e2f8894d410678529ff9f1211f96c5a93ff142f992b302682b42d924428b61", size = 4615127, upload-time = "2025-11-21T22:31:56.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0d/a54fc2cdd672c84175d6869cc823d6ec2a8909318d491f3c24e6077983f2/psycopg_binary-3.2.13-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f26f7009375cf1e92180e5c517c52da1054f7e690dde90e0ed00fa8b5736bcd4", size = 4710267, upload-time = "2025-11-21T22:32:04.585Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/b7/067de1acaf3d312253351f3af4121f972584bd36cada6378d4b0cdcebd38/psycopg_binary-3.2.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea2fdbcc9142933a47c66970e0df8b363e3bd1ea4c5ce376f2f3d94a9aeec847", size = 4400795, upload-time = "2025-11-21T22:32:08.883Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b5/030e6b1ebfc4d3a8fca03adc5fc827982643bad0b01a1268538d17c08ed3/psycopg_binary-3.2.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac92d6bc1d4a41c7459953a9aa727b9966e937e94c9e072527317fd2a67d488b", size = 3851239, upload-time = "2025-11-21T22:32:12.333Z" },
+    { url = "https://files.pythonhosted.org/packages/79/6f/0541845364a7de9eae6807060da6a04b22a8eb2e803606d285d9250fbe93/psycopg_binary-3.2.13-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8b843c00478739e95c46d6d3472b13123b634685f107831a9bfc41503a06ecbd", size = 3525084, upload-time = "2025-11-21T22:32:15.946Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ae/6507890dc30a4bbd9d938d4ff3a4079d009a5ad8170af51c7f762438fdbf/psycopg_binary-3.2.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2f63868cc96bc18486cebec24445affbdd7f7debf28fac466ea935a8b5a4753b", size = 3576787, upload-time = "2025-11-21T22:32:19.922Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/64/3d1c2f1fd09b60cdfbe68b9a810b357ba505eff6e4bdb1a2d9f6729da64c/psycopg_binary-3.2.13-cp313-cp313-win_amd64.whl", hash = "sha256:594dfbca3326e997ae738d3d339004e8416b1f7390f52ce8dc2d692393e8fa96", size = 2905584, upload-time = "2025-11-21T22:32:23.399Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b4/7656b3d67bedff2b900c8c4671cb6eb5fb99c2fc36da33579cac89779c25/psycopg_binary-3.2.13-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:502a778c3e07c6b3aabfa56ee230e8c264d2debfab42d11535513a01bdfff0d6", size = 3997201, upload-time = "2025-11-21T22:32:28.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/2e/3b4afbd94d48df19c3931cedba464b109f89d81ac43178e6a3d654b4e8d5/psycopg_binary-3.2.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7561a71d764d6f74d66e8b7d844b0f27fa33de508f65c17b1d56a94c73644776", size = 4071631, upload-time = "2025-11-21T22:32:32.594Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8b/107d06d55992e2f13157eb705ba5a47d06c4cf1bed077dff0c567b10c187/psycopg_binary-3.2.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9caf14745a1930b4e03fe4072cd7154eaf6e1241d20c42130ed784408a26b24b", size = 4620918, upload-time = "2025-11-21T22:32:37.357Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/47/a925620f261b115f31e813a5bfe640f316413b1864094a60162f4a6e4d67/psycopg_binary-3.2.13-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a6cafabdc0bfa37e11c6f365020fd5916b62d6296df581f4dceaa43a2ce680c", size = 4714494, upload-time = "2025-11-21T22:32:42.138Z" },
+    { url = "https://files.pythonhosted.org/packages/46/33/bed384665356bb9ba17dd8e104884d87cc2343d16dffdfd9aaa9a159bd4d/psycopg_binary-3.2.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96cb5a27e68acac6d74b64fca38592a692de9c4b7827339190698d58027aa45", size = 4403046, upload-time = "2025-11-21T22:32:47.241Z" },
+    { url = "https://files.pythonhosted.org/packages/41/88/749d8e8102fb5df502e2ecb053b79e78e3358af01af652b5dbeb96ab7905/psycopg_binary-3.2.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:596176ae3dfbf56fc61108870bfe17c7205d33ac28d524909feb5335201daa0a", size = 3859046, upload-time = "2025-11-21T22:32:51.481Z" },
+    { url = "https://files.pythonhosted.org/packages/38/7c/f492e63b517d6dcd564e8c43bc15e11a4c712a848adf8938ce33bfd4c867/psycopg_binary-3.2.13-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:cc3a0408435dfbb77eeca5e8050df4b19a6e9b7e5e5583edf524c4a83d6293b2", size = 3531351, upload-time = "2025-11-21T22:32:55.571Z" },
+    { url = "https://files.pythonhosted.org/packages/07/5a/d8743eb23944e5cf2a0bbfa92935c140b5beaacdb872be641065ed70ab2c/psycopg_binary-3.2.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:65df0d459ffba14082d8ca4bb2f6ffbb2f8d02968f7d34a747e1031934b76b23", size = 3581034, upload-time = "2025-11-21T22:33:01.648Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b2/411d4180252144f7eff024894d2d2ebb98c012c944a282fc20250870e461/psycopg_binary-3.2.13-cp314-cp314-win_amd64.whl", hash = "sha256:5c77f156c7316529ed371b5f95a51139e531328ee39c37493a2afcbc1f79d5de", size = 3000162, upload-time = "2025-11-21T22:33:07.378Z" },
+    { url = "https://files.pythonhosted.org/packages/80/dc/3ea3fe5df19af323b4b78e0e98e073f8117b1336e5b6dc6978c067485019/psycopg_binary-3.2.13-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6d8d1b709509d0f8cb857acf740b5eccd5bd2fb208a5b20e895f250519a32459", size = 4015148, upload-time = "2025-11-21T22:33:47.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/28/a832b014974e7bda61b3c684afe5e47f70d5dc4471cbab90a41a7c2bdf6a/psycopg_binary-3.2.13-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2d45bc5f4335498d32a26c8f8c0bf9ce8c973c19e78a9ee77c031300fb361300", size = 4078197, upload-time = "2025-11-21T22:33:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/8c/5962c876a8bba4a6f8ff941998577e8359c928c700d092893e10f97aa94e/psycopg_binary-3.2.13-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f062d725898bf6fc5cfc6349a0d08ee09f129deb14d7fcd5c30f9f1b349f39dc", size = 4638520, upload-time = "2025-11-21T22:33:57.568Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b2/b557ac96752da8fd4b0ff7a128d148e6809ce576a2add6156c91d55abe0a/psycopg_binary-3.2.13-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:915647b5bbbcde2bd464dc293eec4f74710fa71edc4f85aa6f6c8494a179dc9e", size = 4737730, upload-time = "2025-11-21T22:34:02.969Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9a/af2d96c0e711e90cf340a5f607911cd6df593fe1aec9c46644162161af18/psycopg_binary-3.2.13-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d3aec6e2f1cf4deb1b9a3ac287c0591479f3bd851d0a911d628f8c2c71c14f4a", size = 4421382, upload-time = "2025-11-21T22:34:11.501Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f6/f8135198a2c70ca663b55d44c6fc3beb4e36025679b541a9d489814f2ddc/psycopg_binary-3.2.13-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a56a8b1794cbf27ca04012ac2890d58cfc82b3b310c1dac4fa78fbf6f57e7440", size = 3879259, upload-time = "2025-11-21T22:34:17.706Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8c/3f778fc954f0b691941073a1d8b78c07219594135831cad32a739e4eee97/psycopg_binary-3.2.13-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:4150a5e72f863be442d153829724109d83a76871d9bc801d6bb5b9c84b5b19b9", size = 3560475, upload-time = "2025-11-21T22:34:21.329Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d2/731d56c636155f210fbb00cdbb7498c0e04a21052415520da54ac96eca63/psycopg_binary-3.2.13-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:028b49eb465f5d263d250cfd4f168fdabb306d0bbd97fd66a8a1fd7b696a953c", size = 3605616, upload-time = "2025-11-21T22:34:25.229Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/22/2619870c9ed44b5eaeae4f7706126754ccadde6319483cd4c490f5d13fbb/psycopg_binary-3.2.13-cp39-cp39-win_amd64.whl", hash = "sha256:532ea34f673148d637be65a96251832252e278540b39fbd683ef37e58ec361c1", size = 2912739, upload-time = "2025-11-21T22:34:29.069Z" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/bf/70d8a60488f9955cbbcd538beae44d56bb2f1d19e673b72788f2d343ff55/psycopg_binary-3.3.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b7bfff1ca23732b488cbca3076fc11bc98d520ee122514fdb17a8e20d3338f5a", size = 4609750, upload-time = "2026-05-01T23:24:20.06Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b0/29e98ba210c9dbc75a6dc91e3f99b9e06ea901a62ca95804e02a1ae13e6b/psycopg_binary-3.3.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:32a6fbf8481e3a370d0d72b860d35948a693cb01281da217f7b2f307636e591a", size = 4676700, upload-time = "2026-05-01T23:25:21.727Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ab/3df087b3c12bf74e47c08204172b2fabb5a144679110d5c7ad12d9201323/psycopg_binary-3.3.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bdef84570ebbce1d42b4e7ea952d21c414c5f118ad02fee00c5625f35e134429", size = 5496319, upload-time = "2026-05-01T23:25:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9a/f088207b4cd6772f9e0d8a91807e79fa2458d4eb9eb1ae406c68415f2bec/psycopg_binary-3.3.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbc10768a796c96d3243656016bf4e337c81c71097270bb7b0ad6210d9765", size = 5171906, upload-time = "2026-05-01T23:25:34.004Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/4523a857f253871d75c22e1c2e79fd47e599e736bcba1bad58d83e24be02/psycopg_binary-3.3.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf7f73a4a792bc5db58a4b385d8a1467e8d468f7548702fb0ed1e9b7501b1c13", size = 6762621, upload-time = "2026-05-01T23:25:41.392Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d1/925bf776503345bef428e6c45fb017d0139ddbe0e211814b585c4253dca8/psycopg_binary-3.3.4-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d7b4d40c153fa352ab3cca530f3a0baedf7621b2ebcbd7f084009522c21788fc", size = 5006319, upload-time = "2026-05-01T23:25:51.419Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/aa/99727337206fbba357ca084bf4ea8b29dc986f61842a2685859af61416db/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f9b1c2533af01cd7648378599f82b0b8ae32f293296e6eec5753a625bc97ef28", size = 4535388, upload-time = "2026-05-01T23:25:57.957Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a4/567ba2c37d19d8c2f63d836385dfd2495aa5897bbee6cfab104d9ee58624/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ad3bc94054876155549fdaedf4a46d1ec69d39a5bcee377148afe498e84c4b8e", size = 4224544, upload-time = "2026-05-01T23:26:03.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/23/86457f5a82731685d7701de7bfaa5eb783dd1fecbf875321897d9d9ce33a/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:eb4eed2079c01a4850bf467deacfab56d356d4225040170af03dc9958321242d", size = 3956282, upload-time = "2026-05-01T23:26:09.983Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d8/249456df16d47de082abd9b73bce8ccdeb0293eb12e590f9150c7cbdb788/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f80e3f2b5331dbbf0901bcb658056c03eeb2c1ef31d774afb0d61598b242e744", size = 4261736, upload-time = "2026-05-01T23:26:16.798Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6b/c4abe228acafd8a385c1fb615d4f1e3c9b8ad7a4e4f0e84118ba3ffeed9c/psycopg_binary-3.3.4-cp310-cp310-win_amd64.whl", hash = "sha256:574ea21a9651958f1535c5a1c649c7409e9168bcbffa29a3f2f961f58b322949", size = 3570620, upload-time = "2026-05-01T23:26:22.655Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
 ]
 
 [[package]]
@@ -1236,6 +1449,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add the onestep-postgres plugin with table queue, incremental polling, table sink, and SQLAlchemy state/cursor stores
- add plugin release workflow for PyPI publishing
- document the release in CHANGELOG

## Verification
- uv run --all-packages python -m pytest -q plugins/onestep-postgres/tests
- uv lock --check
- uv build --package onestep-postgres --out-dir dist/plugin --sdist --wheel --clear
- uvx twine check dist/plugin/*