### PR TITLE
feat(sqs): expose delivery system metadata

### DIFF
--- a/plugins/onestep-sqs/README.md
+++ b/plugins/onestep-sqs/README.md
@@ -17,3 +17,31 @@ Python usage:
 ```python
 from onestep_sqs import SQSConnector
 ```
+
+## Delivery metadata
+
+Fetched messages keep the existing OneStep body decoding behavior and expose
+SQS system metadata under `delivery.envelope.meta["sqs"]`:
+
+```python
+{
+    "message_id": "00000000-0000-0000-0000-000000000000",
+    "attributes": {
+        "ApproximateReceiveCount": "2",
+        "SentTimestamp": "1720000000000",
+    },
+}
+```
+
+The current message's `MessageId` sets `message_id`. Its `Attributes` sets
+`attributes` to an isolated snapshot of the complete system attributes
+dictionary. When no existing SQS metadata or current system fields are
+available, `meta["sqs"]` is an empty dictionary.
+
+Existing envelope `meta` and `attempts` values are preserved. If the encoded
+envelope already contains a `meta["sqs"]` dictionary, its other keys are kept.
+The reserved `message_id` and `attributes` keys are populated only from the
+current SQS response, so missing fields do not inherit stale transport values.
+
+`ReceiptHandle` remains internal to acknowledgement and retry operations.
+Custom SQS `MessageAttributes` are not exposed in the envelope.

--- a/plugins/onestep-sqs/src/onestep_sqs/connector.py
+++ b/plugins/onestep-sqs/src/onestep_sqs/connector.py
@@ -20,7 +20,19 @@ except ImportError:  # pragma: no cover - optional dependency
 
 class SQSDelivery(Delivery):
     def __init__(self, queue: "SQSQueue", message: dict[str, Any]) -> None:
-        super().__init__(decode_envelope(message["Body"]))
+        envelope = decode_envelope(message["Body"])
+        existing_sqs_meta = envelope.meta.get("sqs")
+        sqs_meta = (
+            dict(existing_sqs_meta) if isinstance(existing_sqs_meta, dict) else {}
+        )
+        sqs_meta.pop("message_id", None)
+        sqs_meta.pop("attributes", None)
+        if "MessageId" in message:
+            sqs_meta["message_id"] = message["MessageId"]
+        if "Attributes" in message:
+            sqs_meta["attributes"] = dict(message["Attributes"])
+        envelope.meta["sqs"] = sqs_meta
+        super().__init__(envelope)
         self._queue = queue
         self._message = message
         self._heartbeat_task: asyncio.Task[None] | None = None

--- a/plugins/onestep-sqs/tests/test_sqs_connector.py
+++ b/plugins/onestep-sqs/tests/test_sqs_connector.py
@@ -57,6 +57,188 @@ class FakeSQSClient:
             self.inflight.pop(ReceiptHandle, None)
 
 
+def test_sqs_delivery_exposes_system_message_metadata():
+    async def scenario():
+        client = FakeSQSClient()
+        client.available.append(
+            {
+                "MessageId": "msg-123",
+                "ReceiptHandle": "secret-receipt-handle",
+                "Body": '{"value": 1}',
+                "Attributes": {
+                    "ApproximateReceiveCount": "3",
+                    "SentTimestamp": "1720000000000",
+                },
+                "MessageAttributes": {
+                    "tenant": {"DataType": "String", "StringValue": "acme"},
+                },
+            }
+        )
+        connector = SQSConnector(region_name="ap-southeast-1", client=client)
+        queue = connector.queue(
+            "https://sqs.ap-southeast-1.amazonaws.com/123456789/jobs",
+            wait_time_s=0,
+            delete_flush_interval_s=0,
+        )
+
+        delivery = (await queue.fetch(1))[0]
+
+        assert delivery.payload == {"value": 1}
+        assert delivery.envelope.meta["sqs"] == {
+            "message_id": "msg-123",
+            "attributes": {
+                "ApproximateReceiveCount": "3",
+                "SentTimestamp": "1720000000000",
+            },
+        }
+        assert "secret-receipt-handle" not in repr(delivery.envelope.meta)
+        assert "MessageAttributes" not in delivery.envelope.meta["sqs"]
+
+    asyncio.run(scenario())
+
+
+def test_sqs_delivery_snapshots_system_attributes():
+    async def scenario():
+        message = {
+            "MessageId": "msg-123",
+            "ReceiptHandle": "rh-msg-123",
+            "Body": '{"value": 1}',
+            "Attributes": {"ApproximateReceiveCount": "1"},
+        }
+        client = FakeSQSClient()
+        client.available.append(message)
+        connector = SQSConnector(region_name="ap-southeast-1", client=client)
+        queue = connector.queue(
+            "https://sqs.ap-southeast-1.amazonaws.com/123456789/jobs",
+            wait_time_s=0,
+            delete_flush_interval_s=0,
+        )
+
+        delivery = (await queue.fetch(1))[0]
+        public_attributes = delivery.envelope.meta["sqs"]["attributes"]
+
+        message["Attributes"]["SentTimestamp"] = "1720000000000"
+        assert public_attributes == {"ApproximateReceiveCount": "1"}
+
+        public_attributes["ApproximateReceiveCount"] = "2"
+        assert delivery._message["Attributes"] == {
+            "ApproximateReceiveCount": "1",
+            "SentTimestamp": "1720000000000",
+        }
+
+    asyncio.run(scenario())
+
+
+def test_sqs_delivery_preserves_encoded_envelope_and_merges_sqs_metadata():
+    async def scenario():
+        client = FakeSQSClient()
+        client.available.append(
+            {
+                "MessageId": "current-message-id",
+                "ReceiptHandle": "secret-receipt-handle",
+                "Body": (
+                    '{"body":{"value":2},"meta":{"source":"upstream",'
+                    '"sqs":{"trace_id":"trace-123","message_id":"old-message-id",'
+                    '"attributes":{"OldAttribute":"old"}}},"attempts":4}'
+                ),
+                "Attributes": {
+                    "ApproximateReceiveCount": "2",
+                    "MessageGroupId": "workers",
+                },
+            }
+        )
+        connector = SQSConnector(region_name="ap-southeast-1", client=client)
+        queue = connector.queue(
+            "https://sqs.ap-southeast-1.amazonaws.com/123456789/jobs",
+            wait_time_s=0,
+            delete_flush_interval_s=0,
+        )
+
+        delivery = (await queue.fetch(1))[0]
+
+        assert delivery.payload == {"value": 2}
+        assert delivery.envelope.attempts == 4
+        assert delivery.envelope.meta == {
+            "source": "upstream",
+            "sqs": {
+                "trace_id": "trace-123",
+                "message_id": "current-message-id",
+                "attributes": {
+                    "ApproximateReceiveCount": "2",
+                    "MessageGroupId": "workers",
+                },
+            },
+        }
+
+    asyncio.run(scenario())
+
+
+def test_sqs_delivery_drops_stale_transport_metadata_when_current_fields_are_missing():
+    async def scenario():
+        client = FakeSQSClient()
+        client.available.append(
+            {
+                "ReceiptHandle": "rh-current-message",
+                "Body": (
+                    '{"body":{"value":3},"meta":{"sqs":{"trace_id":"trace-123",'
+                    '"message_id":"stale-message-id","attributes":'
+                    '{"ApproximateReceiveCount":"9"}}},"attempts":2}'
+                ),
+            }
+        )
+        connector = SQSConnector(region_name="ap-southeast-1", client=client)
+        queue = connector.queue(
+            "https://sqs.ap-southeast-1.amazonaws.com/123456789/jobs",
+            wait_time_s=0,
+            delete_flush_interval_s=0,
+        )
+
+        delivery = (await queue.fetch(1))[0]
+
+        assert delivery.envelope.meta["sqs"] == {"trace_id": "trace-123"}
+
+    asyncio.run(scenario())
+
+
+def test_sqs_delivery_only_includes_available_system_metadata_fields():
+    async def scenario():
+        client = FakeSQSClient()
+        client.available.extend(
+            [
+                {
+                    "MessageId": "message-id-only",
+                    "ReceiptHandle": "rh-message-id-only",
+                    "Body": '{"value": 1}',
+                },
+                {
+                    "ReceiptHandle": "rh-attributes-only",
+                    "Body": '{"value": 2}',
+                    "Attributes": {"ApproximateReceiveCount": "1"},
+                },
+                {
+                    "ReceiptHandle": "rh-no-system-metadata",
+                    "Body": '{"value": 3}',
+                },
+            ]
+        )
+        connector = SQSConnector(region_name="ap-southeast-1", client=client)
+        queue = connector.queue(
+            "https://sqs.ap-southeast-1.amazonaws.com/123456789/jobs",
+            wait_time_s=0,
+            delete_flush_interval_s=0,
+        )
+
+        deliveries = await queue.fetch(3)
+
+        assert [delivery.envelope.meta["sqs"] for delivery in deliveries] == [
+            {"message_id": "message-id-only"},
+            {"attributes": {"ApproximateReceiveCount": "1"}},
+            {},
+        ]
+
+    asyncio.run(scenario())
+
+
 def test_sqs_queue_send_fetch_batch_delete_and_fail_delete():
     async def scenario():
         client = FakeSQSClient()
@@ -77,7 +259,10 @@ def test_sqs_queue_send_fetch_batch_delete_and_fail_delete():
         batch = await queue.fetch(2)
         assert len(batch) == 2
         assert batch[0].payload == {"value": 1}
-        assert batch[0].envelope.meta == {"source": "test"}
+        assert batch[0].envelope.meta == {
+            "source": "test",
+            "sqs": {"message_id": "msg-1"},
+        }
         assert batch[0].envelope.attempts == 3
 
         first_receipt = batch[0]._message["ReceiptHandle"]


### PR DESCRIPTION
## Summary

- expose the current SQS `MessageId` and complete system `Attributes` under `delivery.envelope.meta["sqs"]`
- preserve decoded envelope body, non-SQS metadata, attempts, and unknown keys in an existing `meta["sqs"]` mapping
- treat transport-owned `message_id` and `attributes` as current-message snapshots, removing stale values when the current response omits them
- keep `ReceiptHandle` internal and leave custom `MessageAttributes` out of this contract

## Contract

```python
delivery.envelope.meta["sqs"] == {
    "message_id": "...",
    "attributes": {
        "SentTimestamp": "...",
        "ApproximateReceiveCount": "...",
    },
}
```

The connector exposes transport facts only. It does not parse timestamps or add application-specific task/date behavior.

## Verification

- `12 passed, 1 skipped` for `plugins/onestep-sqs/tests`
- `ruff check` passed for plugin source and tests
- sdist and wheel build passed
- independent code review completed with no remaining findings

The skipped test is the existing live AWS integration test, which requires `ONESTEP_SQS_QUEUE_URL`; fake-client coverage exercises all new metadata behavior.

Fixes #77