### PR TITLE
fix(sqs): release messages received during cancelled long polls

### DIFF
--- a/plugins/onestep-sqs/README.md
+++ b/plugins/onestep-sqs/README.md
@@ -43,5 +43,13 @@ envelope already contains a `meta["sqs"]` dictionary, its other keys are kept.
 The reserved `message_id` and `attributes` keys are populated only from the
 current SQS response, so missing fields do not inherit stale transport values.
 
-`ReceiptHandle` remains internal to acknowledgement and retry operations.
-Custom SQS `MessageAttributes` are not exposed in the envelope.
+`ReceiptHandle` remains internal to acknowledgement, retry, and release
+operations. Custom SQS `MessageAttributes` are not exposed in the envelope.
+
+## Shutdown and pause behavior
+
+SQS receives use a blocking long poll, so shutdown, drain, and pause wait for
+the current poll to finish instead of cancelling it. Any deliveries returned
+after fetching has stopped are released immediately with a visibility timeout
+of zero when processing has not started, making them available to SQS consumers
+again without waiting for the configured visibility timeout.

--- a/plugins/onestep-sqs/pyproject.toml
+++ b/plugins/onestep-sqs/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "onestep-sqs"
-version = "0.2.0"
+version = "0.2.1"
 description = "Amazon SQS connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }
 dependencies = [
-    "onestep>=1.4.1",
+    "onestep>=1.4.4",
     "boto3>=1.34.0",
 ]
 

--- a/plugins/onestep-sqs/src/onestep_sqs/connector.py
+++ b/plugins/onestep-sqs/src/onestep_sqs/connector.py
@@ -60,6 +60,7 @@ class SQSDelivery(Delivery):
             await self._change_visibility(0)
 
     async def release_unstarted(self) -> None:
+        await self._stop_heartbeat()
         await self._change_visibility(0)
 
     async def _heartbeat_loop(self) -> None:

--- a/plugins/onestep-sqs/src/onestep_sqs/connector.py
+++ b/plugins/onestep-sqs/src/onestep_sqs/connector.py
@@ -49,12 +49,7 @@ class SQSDelivery(Delivery):
     async def retry(self, *, delay_s: float | None = None) -> None:
         await self._stop_heartbeat()
         timeout = 0 if delay_s is None else max(0, int(delay_s))
-        await asyncio.to_thread(
-            self._queue.client.change_message_visibility,
-            QueueUrl=self._queue.url,
-            ReceiptHandle=self._message["ReceiptHandle"],
-            VisibilityTimeout=timeout,
-        )
+        await self._change_visibility(timeout)
 
     async def fail(self, exc: Exception | None = None) -> None:
         await self._stop_heartbeat()
@@ -62,22 +57,23 @@ class SQSDelivery(Delivery):
             await self._queue.stage_delete(self._message)
             return
         if self._queue.on_fail == "release":
-            await asyncio.to_thread(
-                self._queue.client.change_message_visibility,
-                QueueUrl=self._queue.url,
-                ReceiptHandle=self._message["ReceiptHandle"],
-                VisibilityTimeout=0,
-            )
+            await self._change_visibility(0)
+
+    async def release_unstarted(self) -> None:
+        await self._change_visibility(0)
 
     async def _heartbeat_loop(self) -> None:
         while True:
             await asyncio.sleep(self._queue.heartbeat_interval_s)
-            await asyncio.to_thread(
-                self._queue.client.change_message_visibility,
-                QueueUrl=self._queue.url,
-                ReceiptHandle=self._message["ReceiptHandle"],
-                VisibilityTimeout=self._queue.heartbeat_visibility_timeout,
-            )
+            await self._change_visibility(self._queue.heartbeat_visibility_timeout)
+
+    async def _change_visibility(self, timeout: int) -> None:
+        await asyncio.to_thread(
+            self._queue.client.change_message_visibility,
+            QueueUrl=self._queue.url,
+            ReceiptHandle=self._message["ReceiptHandle"],
+            VisibilityTimeout=timeout,
+        )
 
     async def _stop_heartbeat(self) -> None:
         if self._heartbeat_task is None:
@@ -145,6 +141,8 @@ class SQSConnector:
 
 
 class SQSQueue(Source, Sink):
+    fetch_is_cancel_safe = False
+
     def __init__(
         self,
         *,

--- a/plugins/onestep-sqs/tests/test_sqs_connector.py
+++ b/plugins/onestep-sqs/tests/test_sqs_connector.py
@@ -92,6 +92,45 @@ def test_sqs_delivery_releases_unstarted_message_immediately():
     asyncio.run(scenario())
 
 
+def test_sqs_delivery_release_unstarted_stops_heartbeat():
+    async def scenario():
+        client = FakeSQSClient()
+        client.available.append(
+            {
+                "MessageId": "msg-heartbeat",
+                "ReceiptHandle": "rh-heartbeat",
+                "Body": '{"value": 1}',
+            }
+        )
+        connector = SQSConnector(region_name="ap-southeast-1", client=client)
+        queue = connector.queue(
+            "https://sqs.ap-southeast-1.amazonaws.com/123456789/jobs",
+            wait_time_s=0,
+            heartbeat_interval_s=0.01,
+            heartbeat_visibility_timeout=30,
+            delete_flush_interval_s=0,
+        )
+        delivery = (await queue.fetch(1))[0]
+        receipt = delivery._message["ReceiptHandle"]
+
+        await delivery.start_processing()
+        for _ in range(20):
+            if client.visibility_changes:
+                break
+            await asyncio.sleep(0.005)
+        assert client.visibility_changes[0] == (queue.url, receipt, 30)
+        client.visibility_changes.clear()
+
+        try:
+            await delivery.release_unstarted()
+            await asyncio.sleep(0.03)
+            assert client.visibility_changes == [(queue.url, receipt, 0)]
+        finally:
+            await delivery.retry()
+
+    asyncio.run(scenario())
+
+
 def test_sqs_delivery_exposes_system_message_metadata():
     async def scenario():
         client = FakeSQSClient()

--- a/plugins/onestep-sqs/tests/test_sqs_connector.py
+++ b/plugins/onestep-sqs/tests/test_sqs_connector.py
@@ -57,6 +57,41 @@ class FakeSQSClient:
             self.inflight.pop(ReceiptHandle, None)
 
 
+def test_sqs_queue_fetch_is_not_cancel_safe():
+    connector = SQSConnector(region_name="ap-southeast-1", client=FakeSQSClient())
+    queue = connector.queue(
+        "https://sqs.ap-southeast-1.amazonaws.com/123456789/jobs",
+        wait_time_s=20,
+    )
+
+    assert queue.fetch_is_cancel_safe is False
+
+
+def test_sqs_delivery_releases_unstarted_message_immediately():
+    async def scenario():
+        client = FakeSQSClient()
+        client.available.append(
+            {
+                "MessageId": "msg-unstarted",
+                "ReceiptHandle": "rh-unstarted",
+                "Body": '{"value": 1}',
+            }
+        )
+        connector = SQSConnector(region_name="ap-southeast-1", client=client)
+        queue = connector.queue(
+            "https://sqs.ap-southeast-1.amazonaws.com/123456789/jobs",
+            wait_time_s=0,
+            delete_flush_interval_s=0,
+        )
+
+        delivery = (await queue.fetch(1))[0]
+        await delivery.release_unstarted()
+
+        assert client.visibility_changes == [(queue.url, "rh-unstarted", 0)]
+
+    asyncio.run(scenario())
+
+
 def test_sqs_delivery_exposes_system_message_metadata():
     async def scenario():
         client = FakeSQSClient()

--- a/plugins/onestep-sqs/tests/test_sqs_runtime_contract.py
+++ b/plugins/onestep-sqs/tests/test_sqs_runtime_contract.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+
+from onestep import OneStepApp
+from onestep_sqs import SQSConnector
+
+
+class BlockingReceiveSQSClient:
+    def __init__(self) -> None:
+        self.receive_started = threading.Event()
+        self.release_receive = threading.Event()
+        self.visibility_changes: list[tuple[str, str, int]] = []
+
+    def receive_message(self, **kwargs):
+        self.receive_started.set()
+        if not self.release_receive.wait(timeout=1.0):
+            raise TimeoutError("test did not release the SQS long poll")
+        return {
+            "Messages": [
+                {
+                    "MessageId": "msg-long-poll",
+                    "ReceiptHandle": "rh-long-poll",
+                    "Body": '{"value": 1}',
+                }
+            ]
+        }
+
+    def change_message_visibility(self, QueueUrl, ReceiptHandle, VisibilityTimeout):
+        self.visibility_changes.append((QueueUrl, ReceiptHandle, VisibilityTimeout))
+
+
+def test_shutdown_waits_for_sqs_long_poll_and_releases_unstarted_delivery() -> None:
+    async def scenario() -> None:
+        client = BlockingReceiveSQSClient()
+        connector = SQSConnector(region_name="ap-southeast-1", client=client)
+        queue = connector.queue(
+            "https://sqs.ap-southeast-1.amazonaws.com/123456789/jobs",
+            wait_time_s=20,
+            delete_flush_interval_s=0,
+        )
+        app = OneStepApp("sqs-long-poll-shutdown", shutdown_timeout_s=1.0)
+        handled: list[dict[str, int]] = []
+
+        @app.task(source=queue, concurrency=1)
+        async def consume(ctx, item):
+            handled.append(item)
+
+        serve_task = asyncio.create_task(app.serve())
+        try:
+            await _wait_for_thread_event(client.receive_started)
+            app.request_shutdown()
+            await asyncio.sleep(0.02)
+            assert serve_task.done() is False
+
+            client.release_receive.set()
+            await asyncio.wait_for(serve_task, timeout=1.0)
+        finally:
+            client.release_receive.set()
+            if not serve_task.done():
+                app.request_shutdown()
+            await asyncio.gather(serve_task, return_exceptions=True)
+
+        assert handled == []
+        assert client.visibility_changes == [(queue.url, "rh-long-poll", 0)]
+
+    asyncio.run(scenario())
+
+
+async def _wait_for_thread_event(event: threading.Event) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 1.0
+    while not event.is_set():
+        if loop.time() >= deadline:
+            raise TimeoutError("SQS receive_message did not start")
+        await asyncio.sleep(0.001)

--- a/uv.lock
+++ b/uv.lock
@@ -737,7 +737,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-sqs"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "plugins/onestep-sqs" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## What changed

- marks `SQSQueue.fetch()` as non-cancel-safe so the runtime drains an in-flight blocking receive during shutdown
- releases deliveries fetched after cancellation before handler startup by setting their visibility to zero
- stops any heartbeat before releasing an unstarted delivery
- bumps `onestep-sqs` to `0.2.1` and requires `onestep>=1.4.4`
- documents the shutdown behavior and adds unit plus blocking long-poll regression coverage

## Why

`boto3` receives run in a worker thread. Cancelling the asyncio wrapper does not stop the underlying SQS long poll, so a message can arrive after the consumer has started shutting down and remain invisible until its visibility timeout expires.

This change builds directly on merged PR #78 (`9a97f256`) and preserves its SQS delivery metadata contract.

## Impact

Shutdown now waits for an active SQS receive to finish and immediately makes any fetched-but-unstarted message available to another consumer. Messages already handed to a handler keep their existing acknowledgement and retry behavior.

## Checks

- `uv run --all-packages python -m pytest -q plugins/onestep-sqs/tests` (`16 passed, 1 skipped`)
- `uvx ruff check plugins/onestep-sqs/src plugins/onestep-sqs/tests`
- `uv build --package onestep-sqs --out-dir /tmp/onestep-sqs-issue79-dist --sdist --wheel --clear`
- conflict simulation against current `origin/main` with `git merge-tree --write-tree origin/main HEAD`

Closes #79
