### PR TITLE
v1.7.2 feat: manage runtime logging from the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.7.2
+
+- Makes `onestep run` configure non-destructive INFO-level stdout logging and task lifecycle event logs by default.
+- Adds `--log-level` and `--no-task-events` while preserving application-installed handlers and structured event loggers.
+- Keeps direct `OneStepApp.run()` and `OneStepApp.serve()` embedding in full control of host process logging.
+
 ## 1.7.1
 
 - Adds the source/sink resource catalog contract with roles, fields, defaults, secret metadata, connector types, and topology display fields.

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ onestep check your_package.tasks:app   # validate the target before starting
 
 ### Logging
 
-`onestep run` writes framework logs and task lifecycle events to stdout at INFO
-level by default. Application code only needs a logger under the `onestep`
-namespace:
+`onestep run` writes application logs, framework logs, and task lifecycle events
+to stdout at INFO level by default. Application logger names do not need to use
+the `onestep` namespace:
 
 ```python
 import logging
 
-logger = logging.getLogger("onestep.billing_sync")
+logger = logging.getLogger("billing.kpi_sync")
 ```
 
 Use `--log-level DEBUG` to include fetched, started, and sink-success details.
@@ -76,8 +76,11 @@ onestep run your_package.tasks:app --no-task-events
 
 An explicit `--log-level` overrides a level configured by the loaded target,
 including YAML `app.logging.level`. Without the option, a target-configured level
-is preserved; otherwise the CLI uses INFO. Existing logging handlers and custom
-`StructuredEventLogger` instances are also preserved.
+is preserved; otherwise the CLI uses INFO. When the CLI installs the stdout
+handler, that resolved level applies to arbitrary application logger names and
+the `onestep` namespace. Existing logging handlers and custom
+`StructuredEventLogger` instances are preserved; when a host has configured its
+own handler, it also retains ownership of root logger levels.
 
 Direct `app.run()` and `app.serve()` calls do not modify host logging or install
 task event logging. Embedded applications retain full control of process logging.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ onestep run your_package.tasks:app
 onestep check your_package.tasks:app   # validate the target before starting
 ```
 
+### Logging
+
+`onestep run` writes framework logs and task lifecycle events to stdout at INFO
+level by default. Application code only needs a logger under the `onestep`
+namespace:
+
+```python
+import logging
+
+logger = logging.getLogger("onestep.billing_sync")
+```
+
+Use `--log-level DEBUG` to include fetched, started, and sink-success details.
+Use `--no-task-events` to disable the lifecycle logger installed by the CLI:
+
+```bash
+onestep run your_package.tasks:app --log-level DEBUG
+onestep run your_package.tasks:app --no-task-events
+```
+
+An explicit `--log-level` overrides a level configured by the loaded target,
+including YAML `app.logging.level`. Without the option, a target-configured level
+is preserved; otherwise the CLI uses INFO. Existing logging handlers and custom
+`StructuredEventLogger` instances are also preserved.
+
+Direct `app.run()` and `app.serve()` calls do not modify host logging or install
+task event logging. Embedded applications retain full control of process logging.
+
 ## What it does
 
 | Capability | Where |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,14 +54,14 @@ onestep check your_package.tasks:app   # 启动前校验目标
 
 ### 日志
 
-`onestep run` 默认以 INFO 级别将框架日志和任务生命周期事件写到 stdout。
-应用代码只需创建 `onestep` 命名空间下的业务 logger，不再需要调用
+`onestep run` 默认以 INFO 级别将应用日志、框架日志和任务生命周期事件写到
+stdout。业务 logger 名称不需要以 `onestep` 开头，应用也不再需要调用
 `logging.basicConfig(force=True)` 或注册标准 `StructuredEventLogger`：
 
 ```python
 import logging
 
-logger = logging.getLogger("onestep.billing_sync")
+logger = logging.getLogger("billing.kpi_sync")
 ```
 
 需要查看 fetched、started 和 sink 成功等细节时使用 `--log-level DEBUG`；
@@ -74,7 +74,9 @@ onestep run your_package.tasks:app --no-task-events
 
 显式 `--log-level` 的优先级高于目标加载时配置的级别，包括 YAML 的
 `app.logging.level`。未传该参数时保留目标已配置的级别，否则默认使用 INFO。
-已有 logging handler 和自定义 `StructuredEventLogger` 不会被覆盖或重复注册。
+CLI 自行安装 stdout handler 时，解析后的级别同时适用于任意名称的业务 logger
+和 `onestep` 命名空间。已有 logging handler 和自定义 `StructuredEventLogger`
+不会被覆盖或重复注册；宿主已配置 handler 时，也继续控制自己的 root level。
 
 直接调用 `app.run()` 或 `app.serve()` 不会修改宿主进程日志，也不会自动安装
 任务事件 logger；嵌入式应用仍完全控制自己的日志配置。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,6 +52,33 @@ onestep run your_package.tasks:app
 onestep check your_package.tasks:app   # 启动前校验目标
 ```
 
+### 日志
+
+`onestep run` 默认以 INFO 级别将框架日志和任务生命周期事件写到 stdout。
+应用代码只需创建 `onestep` 命名空间下的业务 logger，不再需要调用
+`logging.basicConfig(force=True)` 或注册标准 `StructuredEventLogger`：
+
+```python
+import logging
+
+logger = logging.getLogger("onestep.billing_sync")
+```
+
+需要查看 fetched、started 和 sink 成功等细节时使用 `--log-level DEBUG`；
+不需要 CLI 自动输出任务事件时使用 `--no-task-events`：
+
+```bash
+onestep run your_package.tasks:app --log-level DEBUG
+onestep run your_package.tasks:app --no-task-events
+```
+
+显式 `--log-level` 的优先级高于目标加载时配置的级别，包括 YAML 的
+`app.logging.level`。未传该参数时保留目标已配置的级别，否则默认使用 INFO。
+已有 logging handler 和自定义 `StructuredEventLogger` 不会被覆盖或重复注册。
+
+直接调用 `app.run()` 或 `app.serve()` 不会修改宿主进程日志，也不会自动安装
+任务事件 logger；嵌入式应用仍完全控制自己的日志配置。
+
 ## 能做什么
 
 | 能力 | 入口 |

--- a/docs/superpowers/plans/2026-07-27-cli-managed-logging.md
+++ b/docs/superpowers/plans/2026-07-27-cli-managed-logging.md
@@ -1,0 +1,570 @@
+# CLI-Managed Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `onestep run` configure non-destructive stdout logging and task lifecycle event logs so application modules no longer repeat logging bootstrap code.
+
+**Architecture:** Add an idempotent structured-event helper to `OneStepApp`, then keep process-level policy in `onestep.cli`. The CLI loads the target first, resolves `--log-level` against YAML state and the INFO default, installs a stdout handler only when the root logger is unconfigured, and enables the app helper unless task events are disabled. Direct runtime embedding remains untouched.
+
+**Tech Stack:** Python 3.9+, standard-library `argparse` and `logging`, pytest, uv workspace lockfile
+
+---
+
+## File Map
+
+- Modify `src/onestep/app.py`: expose idempotent `enable_structured_event_logging()` without changing normal app construction.
+- Modify `src/onestep/cli.py`: parse run-only logging options, resolve levels, install the CLI handler, and enable task events.
+- Modify `tests/contract/test_runtime_contract.py`: cover helper creation, reuse, and custom event logger preservation.
+- Modify `tests/test_cli.py`: cover CLI parsing, precedence, handler ownership, event registration, and check isolation.
+- Modify `example/cli_app.py`: demonstrate that CLI-run apps no longer bootstrap logging.
+- Modify `README.md` and `README.zh-CN.md`: document normal, debug, disabled-event, YAML, and embedded usage.
+- Modify `CHANGELOG.md`, `pyproject.toml`, and `uv.lock`: prepare core version `1.7.2` as required for shipping.
+
+### Task 1: Idempotent Structured Event Logging Helper
+
+**Files:**
+- Modify: `src/onestep/app.py`
+- Test: `tests/contract/test_runtime_contract.py`
+
+- [ ] **Step 1: Write failing helper contract tests**
+
+Add tests that verify a default logger is created once and a custom registered
+instance is returned unchanged:
+
+```python
+def test_enable_structured_event_logging_is_idempotent() -> None:
+    app = OneStepApp("structured-event-helper")
+
+    first = app.enable_structured_event_logging()
+    second = app.enable_structured_event_logging()
+
+    assert isinstance(first, StructuredEventLogger)
+    assert second is first
+    assert app.describe()["hooks"]["events"] == 1
+
+
+def test_enable_structured_event_logging_preserves_registered_logger() -> None:
+    app = OneStepApp("custom-structured-event-helper")
+    custom = StructuredEventLogger(logger=logging.getLogger("custom.events"))
+    app.on_event(custom)
+
+    resolved = app.enable_structured_event_logging()
+
+    assert resolved is custom
+    assert app.describe()["hooks"]["events"] == 1
+```
+
+- [ ] **Step 2: Run the focused tests and confirm the missing method failure**
+
+Run:
+
+```bash
+uv run pytest tests/contract/test_runtime_contract.py -k enable_structured_event_logging -v
+```
+
+Expected: both tests fail with `AttributeError: 'OneStepApp' object has no attribute 'enable_structured_event_logging'`.
+
+- [ ] **Step 3: Implement the helper**
+
+Import `StructuredEventLogger` next to `TaskEvent`, then add this public method near
+the event hook registration methods:
+
+```python
+def enable_structured_event_logging(self) -> StructuredEventLogger:
+    for handler in self._event_handlers:
+        if isinstance(handler, StructuredEventLogger):
+            return handler
+    handler = StructuredEventLogger()
+    self.on_event(handler)
+    return handler
+```
+
+The method intentionally checks only `StructuredEventLogger`; unrelated event hooks
+must continue to coexist with the default logger.
+
+- [ ] **Step 4: Run focused helper and existing event logger tests**
+
+Run:
+
+```bash
+uv run pytest tests/contract/test_runtime_contract.py -k 'enable_structured_event_logging or structured_event_logger' -v
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit the helper**
+
+```bash
+git add src/onestep/app.py tests/contract/test_runtime_contract.py
+git commit -m "feat: add structured event logging helper"
+```
+
+### Task 2: CLI Logging Bootstrap And Options
+
+**Files:**
+- Modify: `src/onestep/cli.py`
+- Test: `tests/test_cli.py`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Import `parse_args` and add tests for the run-only options:
+
+```python
+from onestep.cli import main, parse_args
+
+
+def test_cli_run_parses_logging_options() -> None:
+    args = parse_args(
+        ["run", "worker:app", "--log-level", "DEBUG", "--no-task-events"]
+    )
+
+    assert args.log_level == "DEBUG"
+    assert args.task_events is False
+
+
+def test_cli_run_enables_task_events_by_default() -> None:
+    args = parse_args(["run", "worker:app"])
+
+    assert args.log_level is None
+    assert args.task_events is True
+```
+
+- [ ] **Step 2: Run parser tests and confirm unknown-argument failures**
+
+Run:
+
+```bash
+uv run pytest tests/test_cli.py -k 'parses_logging_options or enables_task_events_by_default' -v
+```
+
+Expected: tests fail because `run` does not yet accept the options.
+
+- [ ] **Step 3: Add run-only arguments**
+
+Add these arguments to `run_parser`:
+
+```python
+run_parser.add_argument(
+    "--log-level",
+    choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
+    default=None,
+    help="Set the onestep logger level (default: YAML app.logging.level or INFO)",
+)
+run_parser.add_argument(
+    "--task-events",
+    action=argparse.BooleanOptionalAction,
+    default=True,
+    help="Emit task lifecycle events as logs (default: enabled)",
+)
+```
+
+Python 3.9 is the minimum supported version, so `BooleanOptionalAction` is available.
+
+- [ ] **Step 4: Run parser tests and CLI help coverage**
+
+Run:
+
+```bash
+uv run pytest tests/test_cli.py -k 'parses_logging_options or enables_task_events_by_default or cli_help' -v
+```
+
+Expected: all selected tests pass and existing help behavior remains valid.
+
+- [ ] **Step 5: Write failing runtime bootstrap tests**
+
+Add a context manager that snapshots and restores root/onestep logger state so tests
+cannot leak global logging mutations:
+
+```python
+@contextmanager
+def isolated_logging():
+    root = logging.getLogger()
+    framework = logging.getLogger("onestep")
+    root_handlers = list(root.handlers)
+    root_level = root.level
+    framework_level = framework.level
+    try:
+        root.handlers = []
+        root.setLevel(logging.WARNING)
+        framework.setLevel(logging.NOTSET)
+        yield root, framework
+    finally:
+        root.handlers = root_handlers
+        root.setLevel(root_level)
+        framework.setLevel(framework_level)
+```
+
+Use a stubbed `app.run` to inspect state immediately before execution:
+
+```python
+def test_cli_run_configures_info_stdout_logging_and_task_events(capsys) -> None:
+    app = OneStepApp("cli-logging-default")
+    observed = {}
+
+    def run() -> None:
+        observed["level"] = logging.getLogger("onestep").level
+        observed["event_hooks"] = app.describe()["hooks"]["events"]
+        logging.getLogger("onestep.cli-logging-default").info("business message")
+
+    app.run = run
+    with isolated_logging(), registered_module("testsupport_cli_logging", app=app):
+        assert main(["run", "testsupport_cli_logging:app"]) == 0
+
+    assert observed == {"level": logging.INFO, "event_hooks": 1}
+    assert "business message" in capsys.readouterr().out
+```
+
+Add companion tests for level selection and event registration:
+
+```python
+def test_cli_run_explicit_log_level_wins() -> None:
+    app = OneStepApp("cli-logging-debug")
+    observed = {}
+    app.run = lambda: observed.setdefault("level", logging.getLogger("onestep").level)
+
+    with isolated_logging(), registered_module("testsupport_cli_debug", app=app):
+        assert main(["run", "testsupport_cli_debug:app", "--log-level", "DEBUG"]) == 0
+
+    assert observed["level"] == logging.DEBUG
+
+
+def test_cli_run_can_disable_automatic_task_events() -> None:
+    app = OneStepApp("cli-no-task-events")
+    app.run = lambda: None
+
+    with isolated_logging(), registered_module("testsupport_cli_no_events", app=app):
+        assert main(["run", "testsupport_cli_no_events:app", "--no-task-events"]) == 0
+
+    assert app.describe()["hooks"]["events"] == 0
+
+
+@pytest.mark.parametrize("disable_automatic", [False, True])
+def test_cli_run_preserves_registered_structured_event_logger(
+    disable_automatic: bool,
+) -> None:
+    app = OneStepApp("cli-custom-task-events")
+    custom = StructuredEventLogger(logger=logging.getLogger("custom.events"))
+    app.on_event(custom)
+    app.run = lambda: None
+    argv = ["run", "testsupport_cli_custom_events:app"]
+    if disable_automatic:
+        argv.append("--no-task-events")
+
+    with isolated_logging(), registered_module(
+        "testsupport_cli_custom_events", app=app
+    ):
+        assert main(argv) == 0
+
+    assert app.describe()["hooks"]["events"] == 1
+
+
+def test_cli_run_preserves_existing_root_handler() -> None:
+    app = OneStepApp("cli-existing-handler")
+    app.run = lambda: None
+    existing = logging.StreamHandler()
+    formatter = logging.Formatter("CUSTOM %(message)s")
+    existing.setFormatter(formatter)
+
+    with isolated_logging() as (root, _), registered_module(
+        "testsupport_cli_existing_handler", app=app
+    ):
+        root.addHandler(existing)
+        assert main(["run", "testsupport_cli_existing_handler:app"]) == 0
+        assert root.handlers == [existing]
+        assert existing.formatter is formatter
+
+
+def test_cli_check_does_not_configure_logging_or_task_events() -> None:
+    app = OneStepApp("cli-check-logging")
+
+    with isolated_logging() as (root, framework), registered_module(
+        "testsupport_cli_check_logging", app=app
+    ):
+        assert main(["check", "testsupport_cli_check_logging:app"]) == 0
+        assert root.handlers == []
+        assert framework.level == logging.NOTSET
+
+    assert app.describe()["hooks"]["events"] == 0
+```
+
+Add YAML precedence tests using a temporary config, `registered_yaml_module()`, and a
+class-level `run` stub that records the loaded app's state:
+
+```python
+@pytest.mark.parametrize(
+    ("cli_level", "expected"),
+    [(None, logging.ERROR), ("DEBUG", logging.DEBUG)],
+)
+def test_cli_log_level_precedence_over_yaml(
+    monkeypatch, tmp_path, cli_level: str | None, expected: int
+) -> None:
+    config_path = tmp_path / "logging.yaml"
+    config_path.write_text(
+        json.dumps({"app": {"name": "yaml-logging", "logging": {"level": "ERROR"}}, "tasks": []}),
+        encoding="utf-8",
+    )
+    observed = {}
+    monkeypatch.setattr(
+        OneStepApp,
+        "run",
+        lambda self: observed.update(
+            level=logging.getLogger("onestep").level,
+            event_hooks=self.describe()["hooks"]["events"],
+        ),
+    )
+    argv = ["run", str(config_path)]
+    if cli_level is not None:
+        argv.extend(["--log-level", cli_level])
+
+    with isolated_logging(), registered_yaml_module():
+        assert main(argv) == 0
+
+    assert observed == {"level": expected, "event_hooks": 1}
+```
+
+- [ ] **Step 6: Run bootstrap tests and confirm failures**
+
+Run:
+
+```bash
+uv run pytest tests/test_cli.py -k 'cli_logging or log_level_precedence or task_events' -v
+```
+
+Expected: the new runtime tests fail because CLI logging setup and automatic event registration do not exist.
+
+- [ ] **Step 7: Implement logging resolution and setup**
+
+Add imports and private helpers in `src/onestep/cli.py`:
+
+```python
+import logging
+
+_CLI_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
+
+
+def _configure_run_logging(*, explicit_level: str | None) -> None:
+    framework_logger = logging.getLogger("onestep")
+    if explicit_level is not None:
+        framework_logger.setLevel(getattr(logging, explicit_level))
+    elif framework_logger.level == logging.NOTSET:
+        framework_logger.setLevel(logging.INFO)
+
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
+        return
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter(_CLI_LOG_FORMAT))
+    root_logger.addHandler(handler)
+```
+
+After loading the app and after the `check` early return, initialize `run`:
+
+```python
+try:
+    _configure_run_logging(explicit_level=args.log_level)
+    if args.task_events:
+        app.enable_structured_event_logging()
+    app.run()
+except Exception as exc:
+    print(f"onestep: {args.target} failed while running: {exc}", file=sys.stderr)
+    return 1
+```
+
+The `framework_logger.level == logging.NOTSET` check preserves a YAML-applied explicit
+level. An explicit CLI option always replaces it.
+
+- [ ] **Step 8: Run focused and full CLI tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_cli.py -k 'cli_logging or log_level_precedence or task_events' -v
+uv run pytest tests/test_cli.py -v
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 9: Commit CLI behavior**
+
+```bash
+git add src/onestep/cli.py tests/test_cli.py
+git commit -m "feat: manage runtime logging from the CLI"
+```
+
+### Task 3: Application Guidance And Examples
+
+**Files:**
+- Modify: `example/cli_app.py`
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+
+- [ ] **Step 1: Simplify the CLI application example**
+
+Remove `_build_logger()`, the `StructuredEventLogger` import, and
+`app.on_event(StructuredEventLogger(...))`. Keep a normal business logger:
+
+```python
+import json
+import logging
+import os
+
+from onestep import IntervalSource, OneStepApp
+
+logger = logging.getLogger("onestep.cli_app")
+```
+
+Replace the handler's `print(json.dumps(...))` call with:
+
+```python
+logger.info(
+    "synced users",
+    extra={"service_name": ctx.config["service_name"], "payload": payload},
+)
+```
+
+Do not simplify `example/runtime_showcase.py`; its JSON formatter is an intentional
+custom logging example.
+
+- [ ] **Step 2: Document CLI-managed logging in English**
+
+Add a concise section near the Python/YAML run instructions containing:
+
+```markdown
+### Logging
+
+`onestep run` writes framework and task lifecycle logs to stdout at INFO level by
+default. Application code only needs a logger under the `onestep` namespace:
+
+```python
+logger = logging.getLogger("onestep.billing_sync")
+```
+
+Use `--log-level DEBUG` for fetched/started and sink-success details, or
+`--no-task-events` to disable the CLI-installed lifecycle logger. Existing logging
+handlers are preserved. Direct `app.run()` / `app.serve()` embedding does not modify
+host logging.
+```
+
+Also state that an explicit CLI level overrides YAML `app.logging.level`.
+
+- [ ] **Step 3: Add equivalent Chinese guidance**
+
+Document the same commands and ownership boundary in `README.zh-CN.md`, including:
+
+```markdown
+`onestep run` 默认以 INFO 级别将框架日志和任务生命周期事件写到 stdout。
+应用代码只需创建 `onestep` 命名空间下的业务 logger，不再需要调用
+`logging.basicConfig(force=True)` 或注册标准 `StructuredEventLogger`。
+```
+
+- [ ] **Step 4: Verify documentation and example syntax**
+
+Run:
+
+```bash
+uv run python -m py_compile example/cli_app.py
+rg -n -- "--log-level|--no-task-events|basicConfig" README.md README.zh-CN.md example/cli_app.py
+git diff --check
+```
+
+Expected: compilation succeeds, both READMEs mention both options, the example has no
+`basicConfig`, and `git diff --check` produces no output.
+
+- [ ] **Step 5: Commit documentation and example updates**
+
+```bash
+git add example/cli_app.py README.md README.zh-CN.md
+git commit -m "docs: simplify CLI application logging"
+```
+
+### Task 4: Release Preparation And Verification
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add the 1.7.2 changelog entry**
+
+Insert at the top of `CHANGELOG.md`:
+
+```markdown
+## 1.7.2
+
+- Makes `onestep run` configure non-destructive INFO-level stdout logging and task lifecycle event logs by default.
+- Adds `--log-level` and `--no-task-events` while preserving application-installed handlers and structured event loggers.
+- Keeps direct `OneStepApp.run()` / `OneStepApp.serve()` embedding in full control of host process logging.
+```
+
+- [ ] **Step 2: Bump the core version and refresh the lockfile**
+
+Change the root project version:
+
+```toml
+version = "1.7.2"
+```
+
+Then run:
+
+```bash
+uv lock
+```
+
+Expected: the root `onestep` package entry in `uv.lock` changes from `1.7.1` to `1.7.2`; plugin versions remain unchanged.
+
+- [ ] **Step 3: Run focused tests**
+
+```bash
+uv run pytest tests/test_cli.py tests/contract/test_runtime_contract.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Run the complete core test suite**
+
+```bash
+uv run pytest -v
+```
+
+Expected: all core tests pass; live integration tests remain skipped unless their infrastructure is configured.
+
+- [ ] **Step 5: Run package and diff checks**
+
+```bash
+uv build
+git diff --check main...HEAD
+git status --short
+```
+
+Expected: wheel and sdist build successfully, diff check is clean, and only intended release files remain uncommitted.
+
+- [ ] **Step 6: Commit release preparation**
+
+```bash
+git add CHANGELOG.md pyproject.toml uv.lock
+git commit -m "chore: prepare onestep 1.7.2"
+```
+
+- [ ] **Step 7: Review the complete branch**
+
+```bash
+git log --oneline main..HEAD
+git diff --stat main...HEAD
+git diff --check main...HEAD
+```
+
+Expected: the branch contains the design, helper, CLI, docs, and release commits with no unrelated files.
+
+- [ ] **Step 8: Push and open the pull request**
+
+```bash
+git push -u origin feat/cli-logging
+gh pr create --base main --head feat/cli-logging \
+  --title "feat: manage runtime logging from the CLI" \
+  --body $'Closes #84\n\n## Summary\n- configure non-destructive stdout logging for `onestep run`\n- emit task lifecycle logs by default with opt-out and level controls\n- simplify application logging setup and document embedding boundaries\n\n## Verification\n- `uv run pytest -v`\n- `uv build`'
+```
+
+Expected: GitHub returns a pull request URL linked to the implementation issue.
+
+Do not create or push `v1.7.2` while opening the PR. The annotated tag belongs to the
+actual package release after the PR is merged.

--- a/docs/superpowers/specs/2026-07-27-cli-managed-logging-design.md
+++ b/docs/superpowers/specs/2026-07-27-cli-managed-logging-design.md
@@ -1,0 +1,295 @@
+# CLI-Managed Logging Design
+
+## Summary
+
+Make `onestep run` provide useful process logging and task lifecycle logs without
+requiring every application module to configure Python logging or register a
+`StructuredEventLogger`.
+
+The CLI will:
+
+- configure a standard stdout handler when the host process has not configured logging
+- resolve the framework log level from an explicit CLI option, YAML configuration, or an INFO default
+- register a `StructuredEventLogger` by default
+- avoid replacing existing logging handlers or duplicating an existing structured event logger
+- allow operators to disable task event logging
+
+Direct library usage such as `app.run()` or `await app.serve()` remains unchanged.
+
+## Problem
+
+Python applications currently repeat process bootstrap code similar to:
+
+```python
+import logging
+import sys
+
+from onestep import StructuredEventLogger
+
+event_logger = StructuredEventLogger(
+    logger=logging.getLogger("onestep.kpi_sync.events")
+)
+
+
+def configure_logging() -> None:
+    level = logging.getLogger("onestep").getEffectiveLevel()
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        stream=sys.stdout,
+        force=True,
+    )
+
+
+app.on_event(event_logger)
+```
+
+This mixes three responsibilities in every app:
+
+- business code obtains named loggers
+- the task runtime converts lifecycle events to log records
+- the process entrypoint configures handlers, formatting, level, and output stream
+
+The first responsibility belongs in application code. The second belongs to the
+runtime integration, and the third belongs to the CLI process entrypoint. Repeating
+the latter two makes apps noisy and encourages `force=True`, which can unexpectedly
+remove handlers installed by a host, test runner, or monitoring integration.
+
+## Goals
+
+- Make `onestep run package.module:app` produce useful logs without app-level bootstrap code.
+- Emit INFO-level task success events and WARNING/ERROR lifecycle events by default.
+- Make DEBUG framework and lifecycle records available through one CLI option.
+- Preserve logging configuration installed while importing the target application.
+- Keep custom event hooks and custom logging configurations supported.
+- Keep YAML `app.logging.level` behavior compatible.
+
+## Non-Goals
+
+- Do not create a general logging configuration DSL.
+- Do not add JSON logging, file logging, rotation, or per-task level controls.
+- Do not change `StructuredEventLogger` event fields or event level mappings.
+- Do not change reporter payloads, task event names, or control-plane behavior.
+- Do not configure logging for direct `OneStepApp.run()` or `OneStepApp.serve()` callers.
+- Do not automatically convert arbitrary application logger names into the `onestep` namespace.
+
+## User Experience
+
+### Minimal Python Application
+
+An application only creates a business logger and defines its runtime:
+
+```python
+import logging
+
+from onestep import OneStepApp
+
+app = OneStepApp("kpi-sync")
+logger = logging.getLogger("onestep.kpi_sync")
+
+
+@app.task(source=source)
+async def sync_kpi(ctx, item):
+    logger.info("starting KPI sync")
+```
+
+The standard command provides process and task event logging:
+
+```bash
+onestep run kpi_sync.app:app
+```
+
+The application no longer imports `sys`, constructs a `StructuredEventLogger`,
+calls `logging.basicConfig()`, or registers the standard event logger.
+
+Applications still import `TaskEvent` when they implement custom event behavior,
+such as sending a failure notification:
+
+```python
+from onestep import TaskEvent, TaskEventKind
+
+
+@app.on_event
+async def notify_failure(app, event: TaskEvent):
+    if event.kind is TaskEventKind.FAILED:
+        await send_alert(event)
+```
+
+### CLI Options
+
+`onestep run` adds:
+
+```text
+--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
+--task-events / --no-task-events
+```
+
+Examples:
+
+```bash
+onestep run kpi_sync.app:app --log-level DEBUG
+onestep run kpi_sync.app:app --no-task-events
+```
+
+`--task-events` is enabled by default. The positive form is accepted so generated
+commands can state the desired behavior explicitly.
+
+The options apply only to `run`. They are not accepted by `check`, because checking
+a target should not install runtime observers or process logging.
+
+## Log Level Resolution
+
+The effective `onestep` namespace level uses this precedence:
+
+1. an explicit `onestep run --log-level LEVEL`
+2. YAML `app.logging.level`
+3. the CLI default, `INFO`
+
+For a Python target, the second source does not exist, so the default is INFO unless
+the CLI option is present.
+
+The CLI must distinguish an omitted `--log-level` from an explicit value. It must
+not blindly apply INFO after loading a YAML app, because that would overwrite
+`app.logging.level`.
+
+The resolved level is applied to the `onestep` logger namespace. Applications that
+want their business logs governed by the same setting should use a descendant name,
+such as `onestep.kpi_sync` or `onestep.<app-name>.business`.
+
+## Process Logging Configuration
+
+Logging configuration occurs after the target is loaded and before `app.run()`.
+Loading first gives application modules a chance to install their own logging setup.
+
+If the root logger has no handlers, the CLI adds one `logging.StreamHandler` targeting
+`sys.stdout` with this format:
+
+```text
+%(asctime)s %(levelname)s %(name)s %(message)s
+```
+
+The CLI does not call `logging.basicConfig(force=True)`. It does not remove, replace,
+or reformat existing root or named logger handlers.
+
+When an existing handler is present, the CLI only applies the resolved level to the
+`onestep` namespace. Handler levels and formatters remain owned by the application or
+host process. This prevents the CLI from silently weakening an explicitly configured
+handler policy.
+
+The CLI-owned handler is marked internally so repeated in-process CLI invocations in
+tests do not add duplicate handlers. This marker is an implementation detail, not a
+public API.
+
+## Task Event Registration
+
+Before calling `app.run()`, the CLI registers `StructuredEventLogger()` when task
+events are enabled.
+
+If the application has already registered any `StructuredEventLogger`, the CLI does
+not add another one. The existing instance wins, including its logger name and custom
+`level_by_kind` mapping. Other event handlers do not suppress the default structured
+event logger.
+
+To avoid CLI code reaching into `OneStepApp._event_handlers`, `OneStepApp` will expose
+a small idempotent helper:
+
+```python
+app.enable_structured_event_logging() -> StructuredEventLogger
+```
+
+The helper returns the existing structured logger when present, otherwise creates,
+registers, and returns a default instance. Applications may use it directly, but the
+primary intended caller is `onestep run`.
+
+When `--no-task-events` is present, the CLI does not call the helper. It does not
+remove an event logger explicitly registered by application code; explicit app
+configuration remains authoritative.
+
+## Compatibility
+
+### Existing CLI Applications
+
+Existing apps with no logging setup gain INFO-level stdout logs and lifecycle events.
+This is the intended behavior change.
+
+Existing apps that configure root handlers keep those handlers and formatters. The CLI
+does not add a second root handler.
+
+Existing apps that register a custom `StructuredEventLogger` keep it without duplicate
+event output.
+
+### Direct Runtime Embedding
+
+Calling `app.run()` or `await app.serve()` directly does not configure handlers or add
+event observers. Host applications retain complete ownership of process logging.
+
+### YAML Applications
+
+YAML `app.logging.level` retains its current meaning. It controls the `onestep`
+namespace when no explicit CLI level is supplied. The CLI supplies stdout output and
+the standard task event observer for `run` just as it does for Python targets.
+
+### Custom Event Hooks
+
+Custom `@app.on_event` hooks continue to run alongside the CLI-managed structured
+logger. `--no-task-events` disables only the CLI's automatic registration; it does not
+disable application-defined hooks.
+
+## Failure Handling
+
+- `--log-level` is constrained by argparse choices, producing a standard usage error
+  for unsupported values.
+- Logging setup failures are treated as CLI startup failures and use the existing
+  `onestep: ... failed while running` error path where practical.
+- A logging handler or event hook failure during runtime retains existing Python
+  logging and `OneStepApp.emit_event()` behavior.
+- No payload data is added to standard log messages, avoiding accidental disclosure
+  of task bodies.
+
+## Documentation Changes
+
+- Document the new `run` options in the English and Chinese READMEs.
+- Explain that application modules should not call `basicConfig(force=True)` when run
+  through the CLI.
+- Update the CLI example to use the minimal application pattern.
+- Keep the runtime showcase's custom JSON formatter because it demonstrates an
+  intentional custom logging setup rather than required boilerplate.
+- Add a changelog entry under the new core package version prepared for shipping.
+
+## Testing
+
+Focused CLI tests will cover:
+
+- parsing valid and invalid `--log-level` values
+- default INFO level for Python targets
+- explicit CLI level override
+- YAML logging level preservation when the option is omitted
+- explicit CLI level precedence over YAML
+- stdout handler and standard formatter installation when no handler exists
+- preservation of existing root handlers and formatters
+- default structured event logger registration
+- `--no-task-events`
+- no duplicate registration when the app already has a `StructuredEventLogger`
+- no removal of an app-registered logger when `--no-task-events` is used
+- no logging mutation for `check`
+
+Runtime contract tests will cover the idempotent
+`OneStepApp.enable_structured_event_logging()` helper.
+
+The full core test suite and package checks will run before the pull request is opened.
+
+## Release And Coordination
+
+This is a core package feature, so shipping it requires:
+
+- bumping the root `pyproject.toml` core version
+- updating `uv.lock`
+- updating `CHANGELOG.md`
+- creating the matching annotated `v<version>` tag only when the package is actually released
+
+Opening the implementation pull request does not itself publish the package or create
+the release tag.
+
+No control-plane coordination is required. The change does not alter reporter payloads,
+task lifecycle event names or semantics, WebSocket behavior, runtime identity, or
+remote task control.

--- a/docs/superpowers/specs/2026-07-27-cli-managed-logging-design.md
+++ b/docs/superpowers/specs/2026-07-27-cli-managed-logging-design.md
@@ -153,9 +153,10 @@ The CLI must distinguish an omitted `--log-level` from an explicit value. It mus
 not blindly apply INFO after loading an app, because that would overwrite YAML or
 Python target logging configuration.
 
-The resolved level is applied to the `onestep` logger namespace. Applications that
-want their business logs governed by the same setting should use a descendant name,
-such as `onestep.kpi_sync` or `onestep.<app-name>.business`.
+The resolved level is applied to the `onestep` logger namespace. When the CLI installs
+its own root handler, it also applies that level to the root logger for the duration
+of the run, so application logger names do not need an `onestep` prefix. The previous
+root level is restored when the run finishes.
 
 ## Process Logging Configuration
 
@@ -163,7 +164,8 @@ Logging configuration occurs after the target is loaded and before `app.run()`.
 Loading first gives application modules a chance to install their own logging setup.
 
 If the root logger has no handlers, the CLI adds one `logging.StreamHandler` targeting
-`sys.stdout` with this format:
+`sys.stdout`, temporarily sets the root level to the resolved level, and uses this
+format:
 
 ```text
 %(asctime)s %(levelname)s %(name)s %(message)s
@@ -173,14 +175,15 @@ The CLI does not call `logging.basicConfig(force=True)`. It does not remove, rep
 or reformat existing root or named logger handlers.
 
 When an existing handler is present, the CLI only applies the resolved level to the
-`onestep` namespace. Handler levels and formatters remain owned by the application or
-host process. This prevents the CLI from silently weakening an explicitly configured
-handler policy.
+`onestep` namespace. Root and handler levels and formatters remain owned by the
+application or host process. This prevents the CLI from silently weakening an
+explicitly configured handler policy.
 
 The CLI removes and closes a handler it installed after `app.run()` returns. This
 does not affect normal worker output because the handler remains active for the full
 runtime, and it keeps repeated in-process CLI invocations from retaining duplicate or
-stale stream handlers. Handlers owned by the application or host are never removed.
+stale stream handlers. The previous root level is restored at the same time. Handlers
+owned by the application or host are never removed.
 
 ## Task Event Registration
 

--- a/docs/superpowers/specs/2026-07-27-cli-managed-logging-design.md
+++ b/docs/superpowers/specs/2026-07-27-cli-managed-logging-design.md
@@ -142,15 +142,16 @@ a target should not install runtime observers or process logging.
 The effective `onestep` namespace level uses this precedence:
 
 1. an explicit `onestep run --log-level LEVEL`
-2. YAML `app.logging.level`
+2. a level explicitly configured while loading the target, including YAML `app.logging.level`
 3. the CLI default, `INFO`
 
-For a Python target, the second source does not exist, so the default is INFO unless
-the CLI option is present.
+For a Python target that does not set an `onestep` logger level, the default is INFO
+unless the CLI option is present. A Python target that deliberately sets the namespace
+level during import keeps that value, just as a YAML target does.
 
 The CLI must distinguish an omitted `--log-level` from an explicit value. It must
-not blindly apply INFO after loading a YAML app, because that would overwrite
-`app.logging.level`.
+not blindly apply INFO after loading an app, because that would overwrite YAML or
+Python target logging configuration.
 
 The resolved level is applied to the `onestep` logger namespace. Applications that
 want their business logs governed by the same setting should use a descendant name,

--- a/docs/superpowers/specs/2026-07-27-cli-managed-logging-design.md
+++ b/docs/superpowers/specs/2026-07-27-cli-managed-logging-design.md
@@ -177,9 +177,10 @@ When an existing handler is present, the CLI only applies the resolved level to 
 host process. This prevents the CLI from silently weakening an explicitly configured
 handler policy.
 
-The CLI-owned handler is marked internally so repeated in-process CLI invocations in
-tests do not add duplicate handlers. This marker is an implementation detail, not a
-public API.
+The CLI removes and closes a handler it installed after `app.run()` returns. This
+does not affect normal worker output because the handler remains active for the full
+runtime, and it keeps repeated in-process CLI invocations from retaining duplicate or
+stale stream handlers. Handlers owned by the application or host are never removed.
 
 ## Task Event Registration
 

--- a/docs/yaml-task-definition.md
+++ b/docs/yaml-task-definition.md
@@ -59,6 +59,8 @@ Notes:
 - this only sets the `onestep` logger namespace
 - it does not configure the root logger, handlers, or formatters
 - `DEBUG` enables low-level framework logs such as successful sink sends
+- `onestep run --log-level LEVEL` overrides this value when explicitly provided
+- without a CLI override, `onestep run` preserves this value and supplies stdout output
 
 For long-lived configs, prefer adding:
 

--- a/example/cli_app.py
+++ b/example/cli_app.py
@@ -1,28 +1,12 @@
-import json
 import logging
 import os
 
-from onestep import IntervalSource, OneStepApp, StructuredEventLogger
-
-
-def _build_logger() -> logging.Logger:
-    logger = logging.getLogger("cli-app.events")
-    if logger.handlers:
-        return logger
-    handler = logging.StreamHandler()
-    handler.setFormatter(
-        logging.Formatter(
-            "%(asctime)s %(levelname)s %(event_kind)s app=%(app_name)s task=%(task_name)s message=%(message)s"
-        )
-    )
-    logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
-    logger.propagate = False
-    return logger
+from onestep import IntervalSource, OneStepApp
 
 
 SYNC_INTERVAL_SECONDS = int(os.getenv("SYNC_INTERVAL_SECONDS", "3600"))
 SERVICE_NAME = os.getenv("SERVICE_NAME", "demo-sync")
+logger = logging.getLogger("onestep.cli_app")
 
 app = OneStepApp(
     "cli-demo",
@@ -30,7 +14,6 @@ app = OneStepApp(
         "service_name": SERVICE_NAME,
     },
 )
-app.on_event(StructuredEventLogger(logger=_build_logger()))
 
 
 @app.task(
@@ -42,13 +25,8 @@ app.on_event(StructuredEventLogger(logger=_build_logger()))
     )
 )
 async def sync_users(ctx, payload):
-    print(
-        json.dumps(
-            {
-                "service": ctx.config["service_name"],
-                "task": "sync_users",
-                "payload": payload,
-            },
-            ensure_ascii=False,
-        )
+    logger.info(
+        "synced users service=%s payload=%r",
+        ctx.config["service_name"],
+        payload,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep"
-version = "1.7.1"
+version = "1.7.2"
 description = "Async task runtime for queue, polling, schedule, and webhook workloads."
 authors = [
     { name = "miclon", email = "jcnd@163.com" }

--- a/src/onestep/app.py
+++ b/src/onestep/app.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from .connectors.base import Sink, Source
 from .envelope import Envelope
-from .events import TaskEvent
+from .events import StructuredEventLogger, TaskEvent
 from .invoke import invoke_callback
 from .metrics import CustomMetricsRegistry
 from .retry import RetryPolicy
@@ -629,6 +629,14 @@ class OneStepApp:
 
     def on_event(self, func: Callable[..., Any] | None = None):
         return self._register_hook(self._event_handlers, func)
+
+    def enable_structured_event_logging(self) -> StructuredEventLogger:
+        for handler in self._event_handlers:
+            if isinstance(handler, StructuredEventLogger):
+                return handler
+        handler = StructuredEventLogger()
+        self.on_event(handler)
+        return handler
 
     def task(
         self,

--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import sys
 from importlib.metadata import PackageNotFoundError, version
@@ -12,6 +13,7 @@ from .config import is_yaml_target, load_resource_catalog, load_yaml_app
 from .init_project import init_project
 
 _PROJECT_MARKERS = ("pyproject.toml", "setup.py", "setup.cfg")
+_CLI_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -37,6 +39,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         dest="strict_env",
         default=None,
         help="Check that all ${VAR} references resolve to environment variables (YAML targets only)",
+    )
+    run_parser.add_argument(
+        "--log-level",
+        type=str.upper,
+        choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
+        default=None,
+        help="Set the onestep logger level (default: target configuration or INFO)",
+    )
+    run_parser.add_argument(
+        "--task-events",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Emit task lifecycle events as logs (default: enabled)",
     )
 
     check_parser = subparsers.add_parser("check", help="Load a target or YAML config and print its task summary")
@@ -204,12 +219,37 @@ def main(argv: list[str] | None = None) -> int:
         _print_summary(args.target, app, as_json=getattr(args, "as_json", False))
         return 0
 
+    cli_handler: logging.Handler | None = None
     try:
+        cli_handler = _configure_run_logging(explicit_level=args.log_level)
+        if args.task_events:
+            app.enable_structured_event_logging()
         app.run()
     except Exception as exc:
         print(f"onestep: {args.target} failed while running: {exc}", file=sys.stderr)
         return 1
+    finally:
+        if cli_handler is not None:
+            root_logger = logging.getLogger()
+            root_logger.removeHandler(cli_handler)
+            cli_handler.close()
     return 0
+
+
+def _configure_run_logging(*, explicit_level: str | None) -> logging.Handler | None:
+    framework_logger = logging.getLogger("onestep")
+    if explicit_level is not None:
+        framework_logger.setLevel(getattr(logging, explicit_level))
+    elif framework_logger.level == logging.NOTSET:
+        framework_logger.setLevel(logging.INFO)
+
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
+        return None
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter(_CLI_LOG_FORMAT))
+    root_logger.addHandler(handler)
+    return handler
 
 
 def _ensure_local_import_paths(target: str | None = None) -> None:

--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -219,9 +219,9 @@ def main(argv: list[str] | None = None) -> int:
         _print_summary(args.target, app, as_json=getattr(args, "as_json", False))
         return 0
 
-    cli_handler: logging.Handler | None = None
+    cli_logging_state: tuple[logging.Handler, int] | None = None
     try:
-        cli_handler = _configure_run_logging(explicit_level=args.log_level)
+        cli_logging_state = _configure_run_logging(explicit_level=args.log_level)
         if args.task_events:
             app.enable_structured_event_logging()
         app.run()
@@ -229,14 +229,18 @@ def main(argv: list[str] | None = None) -> int:
         print(f"onestep: {args.target} failed while running: {exc}", file=sys.stderr)
         return 1
     finally:
-        if cli_handler is not None:
+        if cli_logging_state is not None:
+            cli_handler, previous_root_level = cli_logging_state
             root_logger = logging.getLogger()
             root_logger.removeHandler(cli_handler)
+            root_logger.setLevel(previous_root_level)
             cli_handler.close()
     return 0
 
 
-def _configure_run_logging(*, explicit_level: str | None) -> logging.Handler | None:
+def _configure_run_logging(
+    *, explicit_level: str | None
+) -> tuple[logging.Handler, int] | None:
     framework_logger = logging.getLogger("onestep")
     if explicit_level is not None:
         framework_logger.setLevel(getattr(logging, explicit_level))
@@ -248,8 +252,10 @@ def _configure_run_logging(*, explicit_level: str | None) -> logging.Handler | N
         return None
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(logging.Formatter(_CLI_LOG_FORMAT))
+    previous_root_level = root_logger.level
+    root_logger.setLevel(framework_logger.level)
     root_logger.addHandler(handler)
-    return handler
+    return handler, previous_root_level
 
 
 def _ensure_local_import_paths(target: str | None = None) -> None:

--- a/tests/contract/test_runtime_contract.py
+++ b/tests/contract/test_runtime_contract.py
@@ -1487,6 +1487,17 @@ def test_enable_structured_event_logging_preserves_registered_logger() -> None:
     assert app.describe()["hooks"]["events"] == 1
 
 
+def test_enable_structured_event_logging_keeps_other_event_handlers() -> None:
+    app = OneStepApp("structured-event-helper-with-observer")
+    observer = lambda event: None
+    app.on_event(observer)
+
+    resolved = app.enable_structured_event_logging()
+
+    assert isinstance(resolved, StructuredEventLogger)
+    assert app.describe()["hooks"]["events"] == 2
+
+
 def test_structured_event_logger_includes_failure_fields() -> None:
     class ListHandler(logging.Handler):
         def __init__(self) -> None:

--- a/tests/contract/test_runtime_contract.py
+++ b/tests/contract/test_runtime_contract.py
@@ -1465,6 +1465,28 @@ def test_structured_event_logger_emits_uniform_log_fields() -> None:
     asyncio.run(scenario())
 
 
+def test_enable_structured_event_logging_is_idempotent() -> None:
+    app = OneStepApp("structured-event-helper")
+
+    first = app.enable_structured_event_logging()
+    second = app.enable_structured_event_logging()
+
+    assert isinstance(first, StructuredEventLogger)
+    assert second is first
+    assert app.describe()["hooks"]["events"] == 1
+
+
+def test_enable_structured_event_logging_preserves_registered_logger() -> None:
+    app = OneStepApp("custom-structured-event-helper")
+    custom = StructuredEventLogger(logger=logging.getLogger("custom.events"))
+    app.on_event(custom)
+
+    resolved = app.enable_structured_event_logging()
+
+    assert resolved is custom
+    assert app.describe()["hooks"]["events"] == 1
+
+
 def test_structured_event_logger_includes_failure_fields() -> None:
     class ListHandler(logging.Handler):
         def __init__(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -319,6 +319,24 @@ def test_cli_run_preserves_existing_root_handler() -> None:
         assert existing.formatter is formatter
 
 
+def test_cli_run_cleans_up_stdout_handler_after_failure(capsys) -> None:
+    app = OneStepApp("cli-run-failure")
+
+    def fail() -> None:
+        raise RuntimeError("boom")
+
+    app.run = fail
+    with isolated_logging() as (root, _), registered_module(
+        "testsupport_cli_run_failure", app=app
+    ):
+        assert main(["run", "testsupport_cli_run_failure:app"]) == 1
+        assert root.handlers == []
+
+    assert "testsupport_cli_run_failure:app failed while running: boom" in (
+        capsys.readouterr().err
+    )
+
+
 def test_cli_check_does_not_configure_logging_or_task_events() -> None:
     app = OneStepApp("cli-check-logging")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,8 +9,8 @@ from contextlib import contextmanager
 import pytest
 
 import onestep.config as config_module
-from onestep import MemoryQueue, OneStepApp, load_app_config
-from onestep.cli import main
+from onestep import MemoryQueue, OneStepApp, StructuredEventLogger, load_app_config
+from onestep.cli import main, parse_args
 
 
 @contextmanager
@@ -36,6 +36,24 @@ def registered_yaml_module():
 
     with registered_module("yaml", safe_load=safe_load) as module:
         yield module
+
+
+@contextmanager
+def isolated_logging():
+    root = logging.getLogger()
+    framework = logging.getLogger("onestep")
+    root_handlers = list(root.handlers)
+    root_level = root.level
+    framework_level = framework.level
+    try:
+        root.handlers = []
+        root.setLevel(logging.WARNING)
+        framework.setLevel(logging.NOTSET)
+        yield root, framework
+    finally:
+        root.handlers = root_handlers
+        root.setLevel(root_level)
+        framework.setLevel(framework_level)
 
 
 def clear_modules(monkeypatch, *names: str) -> None:
@@ -166,6 +184,152 @@ def test_cli_run_shorthand_executes_target(capsys) -> None:
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "cli target started" in captured.out
+
+
+def test_cli_run_parses_logging_options() -> None:
+    args = parse_args(
+        ["run", "worker:app", "--log-level", "debug", "--no-task-events"]
+    )
+
+    assert args.log_level == "DEBUG"
+    assert args.task_events is False
+
+
+def test_cli_run_enables_task_events_by_default() -> None:
+    args = parse_args(["run", "worker:app"])
+
+    assert args.log_level is None
+    assert args.task_events is True
+
+
+def test_cli_run_configures_info_stdout_logging_and_task_events(capsys) -> None:
+    app = OneStepApp("cli-logging-default")
+    observed = {}
+
+    def run() -> None:
+        observed["level"] = logging.getLogger("onestep").level
+        observed["event_hooks"] = app.describe()["hooks"]["events"]
+        logging.getLogger("onestep.cli-logging-default").info("business message")
+
+    app.run = run
+    with isolated_logging() as (root, _), registered_module(
+        "testsupport_cli_logging", app=app
+    ):
+        assert main(["run", "testsupport_cli_logging:app"]) == 0
+        assert root.handlers == []
+
+    assert observed == {"level": logging.INFO, "event_hooks": 1}
+    assert "business message" in capsys.readouterr().out
+
+
+def test_cli_run_explicit_log_level_wins() -> None:
+    app = OneStepApp("cli-logging-debug")
+    observed = {}
+    app.run = lambda: observed.setdefault(
+        "level", logging.getLogger("onestep").level
+    )
+
+    with isolated_logging(), registered_module("testsupport_cli_debug", app=app):
+        assert (
+            main(
+                [
+                    "run",
+                    "testsupport_cli_debug:app",
+                    "--log-level",
+                    "DEBUG",
+                ]
+            )
+            == 0
+        )
+
+    assert observed["level"] == logging.DEBUG
+
+
+def test_cli_run_preserves_target_log_level() -> None:
+    app = OneStepApp("cli-target-log-level")
+    observed = {}
+    app.run = lambda: observed.setdefault(
+        "level", logging.getLogger("onestep").level
+    )
+
+    with isolated_logging() as (_, framework), registered_module(
+        "testsupport_cli_target_level", app=app
+    ):
+        framework.setLevel(logging.ERROR)
+        assert main(["run", "testsupport_cli_target_level:app"]) == 0
+
+    assert observed["level"] == logging.ERROR
+
+
+def test_cli_run_can_disable_automatic_task_events() -> None:
+    app = OneStepApp("cli-no-task-events")
+    app.run = lambda: None
+
+    with isolated_logging(), registered_module(
+        "testsupport_cli_no_events", app=app
+    ):
+        assert (
+            main(
+                [
+                    "run",
+                    "testsupport_cli_no_events:app",
+                    "--no-task-events",
+                ]
+            )
+            == 0
+        )
+
+    assert app.describe()["hooks"]["events"] == 0
+
+
+@pytest.mark.parametrize("disable_automatic", [False, True])
+def test_cli_run_preserves_registered_structured_event_logger(
+    disable_automatic: bool,
+) -> None:
+    app = OneStepApp("cli-custom-task-events")
+    custom = StructuredEventLogger(logger=logging.getLogger("custom.events"))
+    app.on_event(custom)
+    app.run = lambda: None
+    argv = ["run", "testsupport_cli_custom_events:app"]
+    if disable_automatic:
+        argv.append("--no-task-events")
+
+    with isolated_logging(), registered_module(
+        "testsupport_cli_custom_events", app=app
+    ):
+        assert main(argv) == 0
+
+    assert app.enable_structured_event_logging() is custom
+    assert app.describe()["hooks"]["events"] == 1
+
+
+def test_cli_run_preserves_existing_root_handler() -> None:
+    app = OneStepApp("cli-existing-handler")
+    app.run = lambda: None
+    existing = logging.StreamHandler()
+    formatter = logging.Formatter("CUSTOM %(message)s")
+    existing.setFormatter(formatter)
+
+    with isolated_logging() as (root, _), registered_module(
+        "testsupport_cli_existing_handler", app=app
+    ):
+        root.addHandler(existing)
+        assert main(["run", "testsupport_cli_existing_handler:app"]) == 0
+        assert root.handlers == [existing]
+        assert existing.formatter is formatter
+
+
+def test_cli_check_does_not_configure_logging_or_task_events() -> None:
+    app = OneStepApp("cli-check-logging")
+
+    with isolated_logging() as (root, framework), registered_module(
+        "testsupport_cli_check_logging", app=app
+    ):
+        assert main(["check", "testsupport_cli_check_logging:app"]) == 0
+        assert root.handlers == []
+        assert framework.level == logging.NOTSET
+
+    assert app.describe()["hooks"]["events"] == 0
 
 
 def test_cli_invalid_target_returns_non_zero(capsys) -> None:
@@ -668,6 +832,48 @@ def test_load_app_config_strict_applies_yaml_logging_level() -> None:
         assert logger.level == logging.DEBUG
     finally:
         logger.setLevel(previous_level)
+
+
+@pytest.mark.parametrize(
+    ("cli_level", "expected"),
+    [(None, logging.ERROR), ("DEBUG", logging.DEBUG)],
+)
+def test_cli_log_level_precedence_over_yaml(
+    monkeypatch,
+    tmp_path,
+    cli_level: str | None,
+    expected: int,
+) -> None:
+    config_path = tmp_path / "logging.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "app": {
+                    "name": "yaml-logging",
+                    "logging": {"level": "ERROR"},
+                },
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    observed = {}
+    monkeypatch.setattr(
+        OneStepApp,
+        "run",
+        lambda self: observed.update(
+            level=logging.getLogger("onestep").level,
+            event_hooks=self.describe()["hooks"]["events"],
+        ),
+    )
+    argv = ["run", str(config_path)]
+    if cli_level is not None:
+        argv.extend(["--log-level", cli_level])
+
+    with isolated_logging(), registered_yaml_module():
+        assert main(argv) == 0
+
+    assert observed == {"level": expected, "event_hooks": 1}
 
 
 def test_load_app_config_strict_rejects_invalid_yaml_logging_level_type() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import os
 import sys
 import types
 from contextlib import contextmanager
+from typing import Optional
 
 import pytest
 
@@ -859,7 +860,7 @@ def test_load_app_config_strict_applies_yaml_logging_level() -> None:
 def test_cli_log_level_precedence_over_yaml(
     monkeypatch,
     tmp_path,
-    cli_level: str | None,
+    cli_level: Optional[str],
     expected: int,
 ) -> None:
     config_path = tmp_path / "logging.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -209,8 +209,9 @@ def test_cli_run_configures_info_stdout_logging_and_task_events(capsys) -> None:
 
     def run() -> None:
         observed["level"] = logging.getLogger("onestep").level
+        observed["root_level"] = logging.getLogger().level
         observed["event_hooks"] = app.describe()["hooks"]["events"]
-        logging.getLogger("onestep.cli-logging-default").info("business message")
+        logging.getLogger("xxxx.kpi_sync").info("business message")
 
     app.run = run
     with isolated_logging() as (root, _), registered_module(
@@ -218,16 +219,22 @@ def test_cli_run_configures_info_stdout_logging_and_task_events(capsys) -> None:
     ):
         assert main(["run", "testsupport_cli_logging:app"]) == 0
         assert root.handlers == []
+        assert root.level == logging.WARNING
 
-    assert observed == {"level": logging.INFO, "event_hooks": 1}
+    assert observed == {
+        "level": logging.INFO,
+        "root_level": logging.INFO,
+        "event_hooks": 1,
+    }
     assert "business message" in capsys.readouterr().out
 
 
 def test_cli_run_explicit_log_level_wins() -> None:
     app = OneStepApp("cli-logging-debug")
     observed = {}
-    app.run = lambda: observed.setdefault(
-        "level", logging.getLogger("onestep").level
+    app.run = lambda: observed.update(
+        framework_level=logging.getLogger("onestep").level,
+        root_level=logging.getLogger().level,
     )
 
     with isolated_logging(), registered_module("testsupport_cli_debug", app=app):
@@ -243,14 +250,18 @@ def test_cli_run_explicit_log_level_wins() -> None:
             == 0
         )
 
-    assert observed["level"] == logging.DEBUG
+    assert observed == {
+        "framework_level": logging.DEBUG,
+        "root_level": logging.DEBUG,
+    }
 
 
 def test_cli_run_preserves_target_log_level() -> None:
     app = OneStepApp("cli-target-log-level")
     observed = {}
-    app.run = lambda: observed.setdefault(
-        "level", logging.getLogger("onestep").level
+    app.run = lambda: observed.update(
+        framework_level=logging.getLogger("onestep").level,
+        root_level=logging.getLogger().level,
     )
 
     with isolated_logging() as (_, framework), registered_module(
@@ -259,7 +270,10 @@ def test_cli_run_preserves_target_log_level() -> None:
         framework.setLevel(logging.ERROR)
         assert main(["run", "testsupport_cli_target_level:app"]) == 0
 
-    assert observed["level"] == logging.ERROR
+    assert observed == {
+        "framework_level": logging.ERROR,
+        "root_level": logging.ERROR,
+    }
 
 
 def test_cli_run_can_disable_automatic_task_events() -> None:
@@ -317,6 +331,7 @@ def test_cli_run_preserves_existing_root_handler() -> None:
         root.addHandler(existing)
         assert main(["run", "testsupport_cli_existing_handler:app"]) == 0
         assert root.handlers == [existing]
+        assert root.level == logging.WARNING
         assert existing.formatter is formatter
 
 
@@ -332,6 +347,7 @@ def test_cli_run_cleans_up_stdout_handler_after_failure(capsys) -> None:
     ):
         assert main(["run", "testsupport_cli_run_failure:app"]) == 1
         assert root.handlers == []
+        assert root.level == logging.WARNING
 
     assert "testsupport_cli_run_failure:app failed while running: boom" in (
         capsys.readouterr().err
@@ -882,6 +898,7 @@ def test_cli_log_level_precedence_over_yaml(
         "run",
         lambda self: observed.update(
             level=logging.getLogger("onestep").level,
+            root_level=logging.getLogger().level,
             event_hooks=self.describe()["hooks"]["events"],
         ),
     )
@@ -892,7 +909,11 @@ def test_cli_log_level_precedence_over_yaml(
     with isolated_logging(), registered_yaml_module():
         assert main(argv) == 0
 
-    assert observed == {"level": expected, "event_hooks": 1}
+    assert observed == {
+        "level": expected,
+        "root_level": expected,
+        "event_hooks": 1,
+    }
 
 
 def test_load_app_config_strict_rejects_invalid_yaml_logging_level_type() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -517,7 +517,7 @@ wheels = [
 
 [[package]]
 name = "onestep"
-version = "1.7.1"
+version = "1.7.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #84

## Summary

- Make `onestep run` configure INFO-level stdout logging for arbitrary application logger names without replacing application-installed handlers.
- Emit task lifecycle logs by default, with `--log-level` and `--no-task-events` controls.
- Reuse existing `StructuredEventLogger` instances and keep direct `app.run()` / `app.serve()` embedding unchanged.
- Simplify the Python application example and document the behavior in English, Chinese, and YAML guidance.
- Prepare the core package as version `1.7.2`.

## Test Coverage

All new code paths have test coverage:

- CLI level: explicit option, target/YAML configuration, INFO fallback, and arbitrary non-`onestep` logger names
- root handler: install, preserve existing, success cleanup, and failure cleanup
- task events: default enable, opt-out, existing structured logger reuse, and unrelated hook coexistence
- command isolation: `check` and direct runtime embedding remain unchanged

Tests: 21 test files before and after; focused coverage was added to existing CLI and runtime contract suites.

## Pre-Landing Review

No issues found.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Plan Completion

All implementation, compatibility, documentation, release metadata, and verification items in `docs/superpowers/plans/2026-07-27-cli-managed-logging.md` are complete. The final push and PR creation are completed by this ship run.

## Verification Results

- `uv run pytest -q`: 193 passed
- `uv build`: built `dist/onestep-1.7.2.tar.gz` and `dist/onestep-1.7.2-py3-none-any.whl`
- `uv run python -m onestep.cli run --help`: new options rendered correctly
- `git diff --check main...HEAD`: clean
- GitHub Actions: core Python 3.9-3.12, integration, worker image smoke, control-plane contract, and all plugin matrices passed

## Documentation

- Updated `README.md` and `README.zh-CN.md` with CLI logging usage and ownership boundaries.
- Updated `docs/yaml-task-definition.md` with CLI/YAML level precedence.
- Simplified `example/cli_app.py` to use only a normal business logger.
