### PR TITLE
feat(clickhouse): add onestep-clickhouse database connector plugin

### DIFF
--- a/plugins/onestep-clickhouse/README.md
+++ b/plugins/onestep-clickhouse/README.md
@@ -1,0 +1,3 @@
+# onestep-clickhouse
+
+ClickHouse connector plugin for onestep.

--- a/plugins/onestep-clickhouse/README.md
+++ b/plugins/onestep-clickhouse/README.md
@@ -1,3 +1,141 @@
 # onestep-clickhouse
 
-ClickHouse connector plugin for onestep.
+`onestep-clickhouse` provides an acknowledged asynchronous ClickHouse table sink
+for [onestep](https://github.com/mic1on/onestep). It inserts rows into an existing
+table; it does not create or migrate ClickHouse schema.
+
+## Installation
+
+```bash
+pip install onestep-clickhouse
+```
+
+Python 3.9 or newer and `onestep>=1.7.1` are required.
+
+## Python usage
+
+```python
+from onestep_clickhouse import ClickHouseConnector
+
+clickhouse = ClickHouseConnector(
+    dsn="https://writer:secret@clickhouse:8443/analytics",
+    client_options={
+        "connect_timeout": 10,
+        "send_receive_timeout": 30,
+    },
+)
+
+sink = clickhouse.table_sink(
+    table="events",
+    columns=("event_id", "occurred_at", "kind", "payload"),
+    batch_size=1000,
+    settings={"async_insert": 0},
+)
+```
+
+The connector creates its async client lazily on the first insert. A connector
+closes a client it created, while a client injected by an application remains
+owned by the caller. Closing a connector is idempotent.
+
+## Strict YAML usage
+
+```yaml
+apiVersion: onestep/v1alpha1
+kind: App
+
+app:
+  name: clickhouse-writer
+
+resources:
+  analytics:
+    type: clickhouse
+    dsn: "${CLICKHOUSE_DSN}"
+    client_options:
+      connect_timeout: 10
+      send_receive_timeout: 30
+
+  events:
+    type: clickhouse_table_sink
+    connector: analytics
+    table: events
+    columns: [event_id, occurred_at, kind, payload]
+    batch_size: 1000
+    settings:
+      async_insert: 0
+
+tasks: []
+```
+
+Validate long-lived configuration with `onestep check --strict worker.yaml`.
+The `dsn` and `client_options` catalog fields are secret metadata and are not
+included in topology descriptors.
+
+## Rows and columns
+
+Each sink send accepts one mapping or an explicitly non-empty sequence of
+mappings. Strings, empty sequences, mixed sequences, and non-mapping items are
+rejected before the first network call.
+
+When `columns` is configured, every row must contain exactly those keys. Values
+are ordered according to the configured column sequence. When `columns` is
+omitted, the first mapping's insertion order fixes the columns for that logical
+send, and every later mapping must have exactly the same key set. The plugin does
+not infer database schema or coerce values.
+
+`batch_size` defaults to 1000 rows. A larger logical batch is split into chunks,
+and each chunk is inserted and awaited sequentially. The sink has no timer,
+hidden flush queue, or cross-send batching, so task concurrency and the
+ClickHouse client pool provide the concurrency controls. Tune task concurrency
+and client pool limits together for the server's capacity.
+
+## Acknowledged async inserts
+
+A successful send means every chunk received an acknowledged server response.
+Fire-and-forget async inserts are rejected. If `async_insert` is enabled, the
+settings must also include `wait_for_async_insert: 1`:
+
+```yaml
+settings:
+  async_insert: 1
+  wait_for_async_insert: 1
+```
+
+This awaited contract applies direct backpressure: onestep does not acknowledge
+the source delivery until the selected sink finishes.
+
+## Delivery and duplicate semantics
+
+The sink awaits every ClickHouse insert chunk and has no hidden queue. A crash after
+ClickHouse acknowledges a chunk but before onestep acknowledges the source can
+duplicate rows. A later chunk failure is reported as uncertain because earlier
+chunks remain committed. Idempotency depends on table design; use stable event keys
+and a dedup-aware engine such as `ReplacingMergeTree` when duplicates matter.
+
+Multi-sink fan-out is not transactional. If a later sink fails, ClickHouse writes
+from an earlier successful sink call are not rolled back. An explicit task retry
+may repeat already committed rows or chunks.
+
+For example, a table can retain a stable event key and version for eventual
+replacement:
+
+```sql
+CREATE TABLE events
+(
+    event_id String,
+    version DateTime64(3),
+    payload String
+)
+ENGINE = ReplacingMergeTree(version)
+ORDER BY event_id;
+```
+
+This is deployment guidance only. The plugin does not execute DDL or generate a
+deduplication token, and ClickHouse replacement behavior depends on the chosen
+engine and query strategy.
+
+## Deferred features
+
+The first release does not include automatic timed coalescing, DDL or migrations,
+query sources, streaming formats, Arrow or DataFrame APIs, schema inference or
+coercion, distributed-table routing, plugin-generated deduplication tokens,
+mutations, or upserts.

--- a/plugins/onestep-clickhouse/pyproject.toml
+++ b/plugins/onestep-clickhouse/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "onestep-clickhouse"
+version = "0.1.0"
+description = "ClickHouse connector plugin for onestep."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+dependencies = ["onestep>=1.7.1", "clickhouse-connect>=0.8"]
+
+[project.optional-dependencies]
+test = ["pytest>=8.0.0", "pytest-asyncio>=0.23.0"]
+dev = ["pytest>=8.0.0", "pytest-asyncio>=0.23.0"]
+
+[project.entry-points."onestep.resources"]
+clickhouse = "onestep_clickhouse:register"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/onestep_clickhouse"]
+
+[tool.uv.sources]
+onestep = { path = "../..", editable = true }
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+markers = ["integration: live external service tests"]

--- a/plugins/onestep-clickhouse/src/onestep_clickhouse/__init__.py
+++ b/plugins/onestep-clickhouse/src/onestep_clickhouse/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version as _package_version
+
+from .connector import (
+    ClickHouseConnector,
+    ClickHousePayloadError,
+    ClickHouseTableSink,
+)
+from .resources import register_resources
+
+try:
+    __version__ = _package_version("onestep-clickhouse")
+except PackageNotFoundError:
+    __version__ = "dev"
+
+register = register_resources
+
+__all__ = [
+    "ClickHouseConnector",
+    "ClickHousePayloadError",
+    "ClickHouseTableSink",
+    "__version__",
+    "register",
+    "register_resources",
+]

--- a/plugins/onestep-clickhouse/src/onestep_clickhouse/connector.py
+++ b/plugins/onestep-clickhouse/src/onestep_clickhouse/connector.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+from onestep import Sink
+
+
+class ClickHousePayloadError(ValueError):
+    pass
+
+
+class ClickHouseConnector:
+    def __init__(
+        self,
+        dsn: str,
+        *,
+        client_options: dict[str, Any] | None = None,
+        client: Any | None = None,
+    ) -> None:
+        self.dsn = dsn
+        self.client_options = dict(client_options or {})
+        self._client = client
+
+    def table_sink(self, *, table: str, **options: Any) -> "ClickHouseTableSink":
+        return ClickHouseTableSink(connector=self, table=table, **options)
+
+
+class ClickHouseTableSink(Sink):
+    def __init__(
+        self, *, connector: ClickHouseConnector, table: str, **options: Any
+    ) -> None:
+        super().__init__(f"clickhouse.table:{table}")
+        self.connector = connector
+        self.table = table
+        self.options = dict(options)
+
+    async def send(self, envelope) -> None:
+        raise NotImplementedError("table insert is introduced by Task 3")

--- a/plugins/onestep-clickhouse/src/onestep_clickhouse/connector.py
+++ b/plugins/onestep-clickhouse/src/onestep_clickhouse/connector.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from onestep import Sink
+from onestep import (
+    ConnectorErrorKind,
+    ConnectorOperation,
+    ConnectorOperationError,
+    Envelope,
+    Sink,
+)
 
 
 class ClickHousePayloadError(ValueError):
@@ -15,15 +21,37 @@ class ClickHouseConnector:
         self,
         dsn: str,
         *,
-        client_options: dict[str, Any] | None = None,
+        client_options: Mapping[str, Any] | None = None,
         client: Any | None = None,
     ) -> None:
+        if not dsn:
+            raise ValueError("dsn must not be empty")
         self.dsn = dsn
         self.client_options = dict(client_options or {})
         self._client = client
+        self._owns_client = client is None
+        self._closed = False
+
+    async def _get_client(self):
+        if self._client is None:
+            import clickhouse_connect
+
+            self._client = await clickhouse_connect.get_async_client(
+                dsn=self.dsn, **self.client_options
+            )
+        return self._client
 
     def table_sink(self, *, table: str, **options: Any) -> "ClickHouseTableSink":
         return ClickHouseTableSink(connector=self, table=table, **options)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._owns_client and self._client is not None:
+            result = self._client.close()
+            if hasattr(result, "__await__"):
+                await result
 
 
 class ClickHouseTableSink(Sink):
@@ -86,5 +114,41 @@ class ClickHouseTableSink(Sink):
             rows.append([document[column] for column in columns])
         return columns, rows
 
-    async def send(self, envelope) -> None:
-        raise NotImplementedError("table insert is introduced by Task 3")
+    async def send(self, envelope: Envelope) -> None:
+        try:
+            columns, rows = self._normalize(envelope.body)
+        except ClickHousePayloadError as exc:
+            raise ConnectorOperationError(
+                backend="clickhouse",
+                operation=ConnectorOperation.SEND,
+                kind=ConnectorErrorKind.PERMANENT,
+                source_name=self.name,
+                cause=exc,
+            ) from exc
+        client = await self.connector._get_client()
+        committed = 0
+        try:
+            for start in range(0, len(rows), self.batch_size):
+                chunk = rows[start : start + self.batch_size]
+                await client.insert(
+                    self.table,
+                    chunk,
+                    column_names=columns,
+                    settings=self.settings,
+                )
+                committed += 1
+        except Exception as exc:
+            from .resilience import classify_clickhouse_error
+
+            kind = classify_clickhouse_error(exc)
+            if kind is None:
+                raise
+            if committed:
+                kind = ConnectorErrorKind.UNCERTAIN
+            raise ConnectorOperationError(
+                backend="clickhouse",
+                operation=ConnectorOperation.SEND,
+                kind=kind,
+                source_name=self.name,
+                cause=exc,
+            ) from exc

--- a/plugins/onestep-clickhouse/src/onestep_clickhouse/connector.py
+++ b/plugins/onestep-clickhouse/src/onestep_clickhouse/connector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -24,21 +25,25 @@ class ClickHouseConnector:
         client_options: Mapping[str, Any] | None = None,
         client: Any | None = None,
     ) -> None:
-        if not dsn:
+        if not isinstance(dsn, str) or not dsn.strip():
             raise ValueError("dsn must not be empty")
         self.dsn = dsn
         self.client_options = dict(client_options or {})
         self._client = client
         self._owns_client = client is None
         self._closed = False
+        self._client_lock = asyncio.Lock()
 
     async def _get_client(self):
-        if self._client is None:
-            import clickhouse_connect
+        if self._client is not None:
+            return self._client
+        async with self._client_lock:
+            if self._client is None:
+                import clickhouse_connect
 
-            self._client = await clickhouse_connect.get_async_client(
-                dsn=self.dsn, **self.client_options
-            )
+                self._client = await clickhouse_connect.get_async_client(
+                    dsn=self.dsn, **self.client_options
+                )
         return self._client
 
     def table_sink(self, *, table: str, **options: Any) -> "ClickHouseTableSink":
@@ -65,14 +70,21 @@ class ClickHouseTableSink(Sink):
         settings: Mapping[str, Any] | None = None,
     ) -> None:
         super().__init__(f"clickhouse.table:{table}")
-        if not table:
+        if not isinstance(table, str) or not table.strip():
             raise ValueError("table must not be empty")
         if columns is not None and (
-            not columns or len(set(columns)) != len(columns)
+            isinstance(columns, (str, bytes, bytearray))
+            or not columns
+            or any(not isinstance(column, str) or not column.strip() for column in columns)
+            or len(set(columns)) != len(columns)
         ):
             raise ValueError("columns must be a non-empty unique sequence")
+        if isinstance(batch_size, bool) or not isinstance(batch_size, int):
+            raise TypeError("batch_size must be an integer")
         if batch_size <= 0:
             raise ValueError("batch_size must be positive")
+        if settings is not None and not isinstance(settings, Mapping):
+            raise TypeError("settings must be a mapping")
         self.connector = connector
         self.table = table
         self.columns = tuple(columns) if columns is not None else None
@@ -101,6 +113,10 @@ class ClickHouseTableSink(Sink):
     def _normalize(self, body: Any) -> tuple[tuple[str, ...], list[list[Any]]]:
         documents = self._documents(body)
         columns = self.columns or tuple(documents[0].keys())
+        if not columns:
+            raise ClickHousePayloadError(
+                "cannot infer columns from an empty mapping"
+            )
         expected = set(columns)
         rows: list[list[Any]] = []
         for index, document in enumerate(documents):
@@ -125,9 +141,9 @@ class ClickHouseTableSink(Sink):
                 source_name=self.name,
                 cause=exc,
             ) from exc
-        client = await self.connector._get_client()
         committed = 0
         try:
+            client = await self.connector._get_client()
             for start in range(0, len(rows), self.batch_size):
                 chunk = rows[start : start + self.batch_size]
                 await client.insert(

--- a/plugins/onestep-clickhouse/src/onestep_clickhouse/connector.py
+++ b/plugins/onestep-clickhouse/src/onestep_clickhouse/connector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from onestep import Sink
@@ -27,12 +28,63 @@ class ClickHouseConnector:
 
 class ClickHouseTableSink(Sink):
     def __init__(
-        self, *, connector: ClickHouseConnector, table: str, **options: Any
+        self,
+        *,
+        connector: ClickHouseConnector,
+        table: str,
+        columns: Sequence[str] | None = None,
+        batch_size: int = 1000,
+        settings: Mapping[str, Any] | None = None,
     ) -> None:
         super().__init__(f"clickhouse.table:{table}")
+        if not table:
+            raise ValueError("table must not be empty")
+        if columns is not None and (
+            not columns or len(set(columns)) != len(columns)
+        ):
+            raise ValueError("columns must be a non-empty unique sequence")
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
         self.connector = connector
         self.table = table
-        self.options = dict(options)
+        self.columns = tuple(columns) if columns is not None else None
+        self.batch_size = batch_size
+        self.settings = dict(settings or {})
+        if self.settings.get("async_insert") in {1, True, "1"} and self.settings.get(
+            "wait_for_async_insert"
+        ) not in {1, True, "1"}:
+            raise ValueError("async_insert requires wait_for_async_insert=1")
+
+    def _documents(self, body: Any) -> list[dict[str, Any]]:
+        if isinstance(body, Mapping):
+            return [dict(body)]
+        if not isinstance(body, Sequence) or isinstance(
+            body, (str, bytes, bytearray)
+        ):
+            raise ClickHousePayloadError(
+                "payload must be a mapping or non-empty sequence of mappings"
+            )
+        if not body:
+            raise ClickHousePayloadError("payload sequence must not be empty")
+        if any(not isinstance(item, Mapping) for item in body):
+            raise ClickHousePayloadError("every payload item must be a mapping")
+        return [dict(item) for item in body]
+
+    def _normalize(self, body: Any) -> tuple[tuple[str, ...], list[list[Any]]]:
+        documents = self._documents(body)
+        columns = self.columns or tuple(documents[0].keys())
+        expected = set(columns)
+        rows: list[list[Any]] = []
+        for index, document in enumerate(documents):
+            actual = set(document)
+            if actual != expected:
+                missing = sorted(expected - actual)
+                extra = sorted(actual - expected)
+                raise ClickHousePayloadError(
+                    f"row {index} column mismatch: missing={missing}, extra={extra}"
+                )
+            rows.append([document[column] for column in columns])
+        return columns, rows
 
     async def send(self, envelope) -> None:
         raise NotImplementedError("table insert is introduced by Task 3")

--- a/plugins/onestep-clickhouse/src/onestep_clickhouse/connector.py
+++ b/plugins/onestep-clickhouse/src/onestep_clickhouse/connector.py
@@ -138,7 +138,10 @@ class ClickHouseTableSink(Sink):
                 )
                 committed += 1
         except Exception as exc:
-            from .resilience import classify_clickhouse_error
+            from .resilience import (
+                classify_clickhouse_error,
+                redacted_clickhouse_cause,
+            )
 
             kind = classify_clickhouse_error(exc)
             if kind is None:
@@ -150,5 +153,5 @@ class ClickHouseTableSink(Sink):
                 operation=ConnectorOperation.SEND,
                 kind=kind,
                 source_name=self.name,
-                cause=exc,
+                cause=redacted_clickhouse_cause(exc),
             ) from exc

--- a/plugins/onestep-clickhouse/src/onestep_clickhouse/resilience.py
+++ b/plugins/onestep-clickhouse/src/onestep_clickhouse/resilience.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from onestep import ConnectorErrorKind
+
+
+def classify_clickhouse_error(exc: BaseException) -> ConnectorErrorKind | None:
+    if isinstance(exc, (ConnectionError, OSError)):
+        return ConnectorErrorKind.DISCONNECTED
+    return None

--- a/plugins/onestep-clickhouse/src/onestep_clickhouse/resilience.py
+++ b/plugins/onestep-clickhouse/src/onestep_clickhouse/resilience.py
@@ -1,9 +1,37 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from onestep import ConnectorErrorKind
 
 
+@dataclass(frozen=True)
+class ClickHouseErrorCause(Exception):
+    code: int | None
+    message: str
+
+    def __str__(self) -> str:
+        return f"ClickHouse error code={self.code}: {self.message}"
+
+
+def redacted_clickhouse_cause(exc: BaseException) -> ClickHouseErrorCause:
+    return ClickHouseErrorCause(getattr(exc, "code", None), str(exc)[:500])
+
+
 def classify_clickhouse_error(exc: BaseException) -> ConnectorErrorKind | None:
+    if isinstance(exc, TimeoutError):
+        return ConnectorErrorKind.UNCERTAIN
     if isinstance(exc, (ConnectionError, OSError)):
         return ConnectorErrorKind.DISCONNECTED
+    code = getattr(exc, "code", None)
+    if code in {202, 203, 209, 210}:
+        return ConnectorErrorKind.DISCONNECTED
+    if code in {159, 164, 241, 252}:
+        return ConnectorErrorKind.THROTTLED
+    if code in {60, 62, 81, 516}:
+        return ConnectorErrorKind.MISCONFIGURED
+    if code in {6, 27, 53, 117, 386}:
+        return ConnectorErrorKind.PERMANENT
+    if code is not None:
+        return ConnectorErrorKind.TRANSIENT
     return None

--- a/plugins/onestep-clickhouse/src/onestep_clickhouse/resources.py
+++ b/plugins/onestep-clickhouse/src/onestep_clickhouse/resources.py
@@ -1,7 +1,125 @@
 from __future__ import annotations
 
-from onestep import ResourceRegistry
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import urlparse
+
+from onestep import (
+    ResourceBuildContext,
+    ResourceCatalogEntry,
+    ResourceCatalogField,
+    ResourceRegistry,
+    ResourceSpecHandler,
+    ResourceValidationContext,
+)
+
+from .connector import ClickHouseConnector
+
+CONNECTOR_FIELDS = frozenset({"type", "dsn", "client_options"})
+SINK_FIELDS = frozenset(
+    {"type", "connector", "table", "columns", "batch_size", "settings"}
+)
+CONNECTOR_CATALOG = ResourceCatalogEntry(
+    type="clickhouse",
+    roles=("connector",),
+    label="ClickHouse",
+    fields=(
+        ResourceCatalogField("dsn", "string", required=True, secret=True),
+        ResourceCatalogField("client_options", "mapping", secret=True),
+    ),
+)
+SINK_CATALOG = ResourceCatalogEntry(
+    type="clickhouse_table_sink",
+    roles=("sink",),
+    label="ClickHouse Table Sink",
+    connector_types=("clickhouse",),
+    fields=(
+        ResourceCatalogField("connector", "ref", required=True),
+        ResourceCatalogField("table", "string", required=True),
+        ResourceCatalogField("columns", "string_list"),
+        ResourceCatalogField("batch_size", "integer", default=1000),
+        ResourceCatalogField("settings", "mapping"),
+    ),
+    topology_fields=("table", "columns", "batch_size"),
+)
+
+
+def _validate_connector(
+    ctx: ResourceValidationContext, spec: Mapping[str, Any]
+) -> None:
+    dsn = ctx.require_string(spec, "dsn")
+    parsed = urlparse(dsn)
+    if parsed.scheme not in {"clickhouse", "clickhouses", "http", "https"} or not parsed.netloc:
+        raise ValueError(f"'{ctx.field}.dsn' must be a ClickHouse or HTTP(S) DSN")
+    if "client_options" in spec and not isinstance(spec.get("client_options"), Mapping):
+        raise TypeError(f"'{ctx.field}.client_options' must be a mapping")
+
+
+def _validate_sink(ctx: ResourceValidationContext, spec: Mapping[str, Any]) -> None:
+    ctx.require_string(spec, "connector")
+    ctx.require_string(spec, "table")
+    if "columns" in spec:
+        ctx.require_non_empty_string_list(
+            spec, "columns", field=f"{ctx.field}.columns"
+        )
+    ctx.validate_positive_integer(
+        spec.get("batch_size"), field=f"{ctx.field}.batch_size"
+    )
+    settings = spec.get("settings", {})
+    if not isinstance(settings, Mapping):
+        raise TypeError(f"'{ctx.field}.settings' must be a mapping")
+    if settings.get("async_insert") in {1, True, "1"} and settings.get(
+        "wait_for_async_insert"
+    ) not in {1, True, "1"}:
+        raise ValueError(
+            f"'{ctx.field}.settings.wait_for_async_insert' must be 1 when async_insert is enabled"
+        )
+
+
+def _build_connector(
+    ctx: ResourceBuildContext, spec: Mapping[str, Any]
+) -> ClickHouseConnector:
+    return ClickHouseConnector(
+        ctx.require_string(spec, "dsn"),
+        client_options=ctx.mapping_value(
+            spec.get("client_options"), field=f"{ctx.field}.client_options"
+        ),
+    )
+
+
+def _build_sink(ctx: ResourceBuildContext, spec: Mapping[str, Any]):
+    connector = ctx.resolve_dependency(spec, "connector")
+    if not isinstance(connector, ClickHouseConnector):
+        raise TypeError(f"resource {spec['connector']!r} is not a ClickHouseConnector")
+    columns = (
+        tuple(ctx.string_list(spec.get("columns"), field=f"{ctx.field}.columns"))
+        if spec.get("columns") is not None
+        else None
+    )
+    return connector.table_sink(
+        table=ctx.require_string(spec, "table"),
+        columns=columns,
+        batch_size=spec.get("batch_size", 1000),
+        settings=ctx.mapping_value(spec.get("settings"), field=f"{ctx.field}.settings"),
+    )
 
 
 def register_resources(registry: ResourceRegistry) -> None:
-    return None
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="clickhouse",
+            catalog=CONNECTOR_CATALOG,
+            allowed_fields=CONNECTOR_FIELDS,
+            build=_build_connector,
+            validate=_validate_connector,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="clickhouse_table_sink",
+            catalog=SINK_CATALOG,
+            allowed_fields=SINK_FIELDS,
+            build=_build_sink,
+            validate=_validate_sink,
+        )
+    )

--- a/plugins/onestep-clickhouse/src/onestep_clickhouse/resources.py
+++ b/plugins/onestep-clickhouse/src/onestep_clickhouse/resources.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from onestep import ResourceRegistry
+
+
+def register_resources(registry: ResourceRegistry) -> None:
+    return None

--- a/plugins/onestep-clickhouse/tests/integration/test_clickhouse_live.py
+++ b/plugins/onestep-clickhouse/tests/integration/test_clickhouse_live.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+import uuid
+
+import clickhouse_connect
+import pytest
+
+from onestep import Envelope
+from onestep_clickhouse import ClickHouseConnector
+
+DSN = os.getenv("ONESTEP_CLICKHOUSE_DSN")
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not DSN, reason="ONESTEP_CLICKHOUSE_DSN is not configured"
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_live_mapping_sequence_chunking_and_visibility() -> None:
+    table = f"onestep_{uuid.uuid4().hex}"
+    admin = await clickhouse_connect.get_async_client(dsn=DSN)
+    await admin.command(
+        f"CREATE TABLE {table} (id UInt64, note Nullable(String)) "
+        "ENGINE = MergeTree ORDER BY id"
+    )
+    connector = ClickHouseConnector(DSN)
+    sink = connector.table_sink(
+        table=table, columns=("id", "note"), batch_size=2
+    )
+    try:
+        await sink.send(Envelope(body={"id": 1, "note": None}))
+        await sink.send(
+            Envelope(
+                body=[
+                    {"id": 2, "note": "two"},
+                    {"id": 3, "note": "three"},
+                    {"id": 4, "note": None},
+                ]
+            )
+        )
+        rows = await admin.query(f"SELECT id, note FROM {table} ORDER BY id")
+        assert rows.result_rows == [
+            (1, None),
+            (2, "two"),
+            (3, "three"),
+            (4, None),
+        ]
+    finally:
+        await admin.command(f"DROP TABLE IF EXISTS {table}")
+        await connector.close()
+        await admin.close()

--- a/plugins/onestep-clickhouse/tests/test_clickhouse_connector.py
+++ b/plugins/onestep-clickhouse/tests/test_clickhouse_connector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from onestep import ConnectorErrorKind, ConnectorOperationError, Envelope
 from onestep_clickhouse import ClickHouseConnector, ClickHousePayloadError
 
 
@@ -43,3 +44,92 @@ def test_invalid_payloads_fail_before_insert(body) -> None:
     )
     with pytest.raises(ClickHousePayloadError):
         sink._normalize(body)
+
+
+class FakeAsyncClient:
+    def __init__(self, *, fail_call: int | None = None) -> None:
+        self.calls: list[dict] = []
+        self.fail_call = fail_call
+        self.closed = False
+
+    async def insert(self, table, rows, *, column_names, settings):
+        self.calls.append(
+            {
+                "table": table,
+                "rows": rows,
+                "column_names": column_names,
+                "settings": settings,
+            }
+        )
+        if self.fail_call == len(self.calls):
+            raise TimeoutError("response timed out after submission")
+        return object()
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_send_awaits_each_chunk_in_order() -> None:
+    client = FakeAsyncClient()
+    connector = ClickHouseConnector(
+        "http://clickhouse:8123/default", client=client
+    )
+    sink = connector.table_sink(table="events", columns=("id",), batch_size=2)
+    await sink.send(Envelope(body=[{"id": 1}, {"id": 2}, {"id": 3}]))
+    assert [call["rows"] for call in client.calls] == [[[1], [2]], [[3]]]
+
+
+@pytest.mark.asyncio
+async def test_later_chunk_timeout_is_uncertain_and_stops() -> None:
+    client = FakeAsyncClient(fail_call=2)
+    sink = ClickHouseConnector(
+        "http://clickhouse:8123/default", client=client
+    ).table_sink(table="events", columns=("id",), batch_size=1)
+    with pytest.raises(ConnectorOperationError) as captured:
+        await sink.send(Envelope(body=[{"id": 1}, {"id": 2}, {"id": 3}]))
+    assert captured.value.kind is ConnectorErrorKind.UNCERTAIN
+    assert len(client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_injected_client_is_not_closed() -> None:
+    client = FakeAsyncClient()
+    connector = ClickHouseConnector(
+        "http://clickhouse:8123/default", client=client
+    )
+    await connector.close()
+    await connector.close()
+    assert client.closed is False
+
+
+@pytest.mark.asyncio
+async def test_owned_client_is_lazy_and_closes_once(monkeypatch) -> None:
+    import clickhouse_connect
+
+    client = FakeAsyncClient()
+    close_calls = 0
+
+    async def close_once():
+        nonlocal close_calls
+        close_calls += 1
+        client.closed = True
+
+    client.close = close_once
+    factory_calls = []
+
+    async def build_client(**options):
+        factory_calls.append(options)
+        return client
+
+    monkeypatch.setattr(clickhouse_connect, "get_async_client", build_client)
+    connector = ClickHouseConnector("http://clickhouse:8123/default")
+    assert factory_calls == []
+    await connector.table_sink(table="events", columns=("id",)).send(
+        Envelope(body={"id": 1})
+    )
+    assert factory_calls == [{"dsn": "http://clickhouse:8123/default"}]
+    await connector.close()
+    await connector.close()
+    assert client.closed is True
+    assert close_calls == 1

--- a/plugins/onestep-clickhouse/tests/test_clickhouse_connector.py
+++ b/plugins/onestep-clickhouse/tests/test_clickhouse_connector.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import pytest
 
-from onestep import ConnectorErrorKind, ConnectorOperationError, Envelope
+from onestep import (
+    ConnectorErrorKind,
+    ConnectorOperationError,
+    Delivery,
+    Envelope,
+    OneStepApp,
+    Source,
+)
 from onestep_clickhouse import ClickHouseConnector, ClickHousePayloadError
 
 
@@ -46,6 +53,32 @@ def test_invalid_payloads_fail_before_insert(body) -> None:
         sink._normalize(body)
 
 
+def test_empty_mapping_cannot_safely_infer_columns() -> None:
+    sink = ClickHouseConnector("http://clickhouse:8123/default").table_sink(
+        table="events"
+    )
+    with pytest.raises(ClickHousePayloadError, match="infer columns"):
+        sink._normalize({})
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"table": ""},
+        {"table": "events", "columns": "id"},
+        {"table": "events", "columns": ("id", "")},
+        {"table": "events", "batch_size": 1.5},
+        {"table": "events", "batch_size": True},
+        {"table": "events", "settings": "not-a-mapping"},
+        {"table": "events", "settings": {"async_insert": 1}},
+    ],
+)
+def test_invalid_sink_configuration_is_rejected(options) -> None:
+    connector = ClickHouseConnector("http://clickhouse:8123/default")
+    with pytest.raises((TypeError, ValueError)):
+        connector.table_sink(**options)
+
+
 class FakeAsyncClient:
     def __init__(self, *, fail_call: int | None = None) -> None:
         self.calls: list[dict] = []
@@ -78,6 +111,19 @@ async def test_send_awaits_each_chunk_in_order() -> None:
     sink = connector.table_sink(table="events", columns=("id",), batch_size=2)
     await sink.send(Envelope(body=[{"id": 1}, {"id": 2}, {"id": 3}]))
     assert [call["rows"] for call in client.calls] == [[[1], [2]], [[3]]]
+
+
+@pytest.mark.asyncio
+async def test_invalid_send_is_permanent_before_first_network_call() -> None:
+    client = FakeAsyncClient()
+    sink = ClickHouseConnector(
+        "http://clickhouse:8123/default", client=client
+    ).table_sink(table="events", columns=("id",))
+    with pytest.raises(ConnectorOperationError) as captured:
+        await sink.send(Envelope(body=[{"other": "secret-row-value"}]))
+    assert captured.value.kind is ConnectorErrorKind.PERMANENT
+    assert client.calls == []
+    assert "secret-row-value" not in str(captured.value.cause)
 
 
 @pytest.mark.asyncio
@@ -133,3 +179,114 @@ async def test_owned_client_is_lazy_and_closes_once(monkeypatch) -> None:
     await connector.close()
     assert client.closed is True
     assert close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_sends_share_one_lazy_client(monkeypatch) -> None:
+    import asyncio
+    import clickhouse_connect
+
+    client = FakeAsyncClient()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    factory_calls = 0
+
+    async def build_client(**options):
+        nonlocal factory_calls
+        factory_calls += 1
+        entered.set()
+        await release.wait()
+        return client
+
+    monkeypatch.setattr(clickhouse_connect, "get_async_client", build_client)
+    connector = ClickHouseConnector("http://clickhouse:8123/default")
+    sink = connector.table_sink(table="events", columns=("id",))
+    first = asyncio.create_task(sink.send(Envelope(body={"id": 1})))
+    await entered.wait()
+    second = asyncio.create_task(sink.send(Envelope(body={"id": 2})))
+    await asyncio.sleep(0)
+    assert factory_calls == 1
+    release.set()
+    await asyncio.gather(first, second)
+    assert factory_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_client_construction_error_uses_connector_error_contract(monkeypatch) -> None:
+    import clickhouse_connect
+
+    async def fail_client(**options):
+        raise ConnectionError("cannot connect")
+
+    monkeypatch.setattr(clickhouse_connect, "get_async_client", fail_client)
+    sink = ClickHouseConnector("http://clickhouse:8123/default").table_sink(
+        table="events", columns=("id",)
+    )
+    with pytest.raises(ConnectorOperationError) as captured:
+        await sink.send(Envelope(body={"id": 1}))
+    assert captured.value.kind is ConnectorErrorKind.DISCONNECTED
+
+
+class _AckRecordingDelivery(Delivery):
+    def __init__(self, envelope: Envelope) -> None:
+        super().__init__(envelope)
+        self.acked = False
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        raise AssertionError("runtime ordering test must not retry")
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        raise AssertionError(f"runtime ordering test failed: {exc}")
+
+
+class _OneShotSource(Source):
+    poll_interval_s = 0.01
+
+    def __init__(self, delivery: _AckRecordingDelivery) -> None:
+        super().__init__("one-shot")
+        self.delivery = delivery
+        self.sent = False
+
+    async def fetch(self, limit: int) -> list[Delivery]:
+        if self.sent:
+            return []
+        self.sent = True
+        return [self.delivery]
+
+
+@pytest.mark.asyncio
+async def test_runtime_ack_follows_clickhouse_insert_acknowledgement() -> None:
+    import asyncio
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    class BlockingClient(FakeAsyncClient):
+        async def insert(self, table, rows, *, column_names, settings):
+            entered.set()
+            await release.wait()
+            return await super().insert(
+                table, rows, column_names=column_names, settings=settings
+            )
+
+    sink = ClickHouseConnector(
+        "http://clickhouse:8123/default", client=BlockingClient()
+    ).table_sink(table="events", columns=("id",))
+    delivery = _AckRecordingDelivery(Envelope(body={"id": 1}))
+    source = _OneShotSource(delivery)
+    app = OneStepApp("clickhouse-runtime-order", shutdown_timeout_s=1.0)
+
+    @app.task(source=source, emit=sink, concurrency=1)
+    async def forward(ctx, item):
+        ctx.app.request_shutdown()
+        return item
+
+    serving = asyncio.create_task(app.serve())
+    await entered.wait()
+    assert delivery.acked is False
+    release.set()
+    await asyncio.wait_for(serving, timeout=2.0)
+    assert delivery.acked is True

--- a/plugins/onestep-clickhouse/tests/test_clickhouse_connector.py
+++ b/plugins/onestep-clickhouse/tests/test_clickhouse_connector.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from onestep_clickhouse import ClickHouseConnector, ClickHousePayloadError
+
+
+def test_configured_columns_produce_ordered_rows() -> None:
+    sink = ClickHouseConnector("http://clickhouse:8123/default").table_sink(
+        table="events", columns=("id", "kind")
+    )
+    columns, rows = sink._normalize(
+        [{"kind": "a", "id": 1}, {"id": 2, "kind": "b"}]
+    )
+    assert columns == ("id", "kind")
+    assert rows == [[1, "a"], [2, "b"]]
+
+
+def test_first_mapping_infers_deterministic_column_order() -> None:
+    sink = ClickHouseConnector("http://clickhouse:8123/default").table_sink(
+        table="events"
+    )
+    columns, rows = sink._normalize(
+        [{"id": 1, "kind": "a"}, {"kind": "b", "id": 2}]
+    )
+    assert columns == ("id", "kind")
+    assert rows == [[1, "a"], [2, "b"]]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        [],
+        "text",
+        [1],
+        [{"id": 1}, {"id": 2, "extra": True}],
+        [{"id": 1}, {"other": 2}],
+    ],
+)
+def test_invalid_payloads_fail_before_insert(body) -> None:
+    sink = ClickHouseConnector("http://clickhouse:8123/default").table_sink(
+        table="events", columns=("id",)
+    )
+    with pytest.raises(ClickHousePayloadError):
+        sink._normalize(body)

--- a/plugins/onestep-clickhouse/tests/test_clickhouse_plugin.py
+++ b/plugins/onestep-clickhouse/tests/test_clickhouse_plugin.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from importlib import metadata as importlib_metadata
+
+from onestep_clickhouse import (
+    ClickHouseConnector,
+    ClickHousePayloadError,
+    ClickHouseTableSink,
+    register,
+    register_resources,
+)
+
+
+def test_public_surface_and_entry_point() -> None:
+    assert register is register_resources
+    assert ClickHouseConnector.__name__ == "ClickHouseConnector"
+    assert ClickHouseTableSink.__name__ == "ClickHouseTableSink"
+    assert ClickHousePayloadError.__name__ == "ClickHousePayloadError"
+    entry_points = importlib_metadata.entry_points()
+    selected = (
+        entry_points.select(group="onestep.resources")
+        if hasattr(entry_points, "select")
+        else entry_points.get("onestep.resources", ())
+    )
+    assert any(
+        item.name == "clickhouse" and item.value == "onestep_clickhouse:register"
+        for item in selected
+    )

--- a/plugins/onestep-clickhouse/tests/test_clickhouse_plugin.py
+++ b/plugins/onestep-clickhouse/tests/test_clickhouse_plugin.py
@@ -99,3 +99,133 @@ def test_strict_yaml_rejects_unacknowledged_async_insert() -> None:
             ),
             strict=True,
         )
+
+
+@pytest.mark.parametrize(
+    "resource, error_type, message",
+    [
+        ({"type": "clickhouse"}, ValueError, "dsn"),
+        ({"type": "clickhouse", "dsn": "postgres://db"}, ValueError, "DSN"),
+        (
+            {
+                "type": "clickhouse",
+                "dsn": "http://clickhouse:8123/default",
+                "client_options": [],
+            },
+            TypeError,
+            "client_options",
+        ),
+        (
+            {
+                "type": "clickhouse",
+                "dsn": "http://clickhouse:8123/default",
+                "unknown": True,
+            },
+            ValueError,
+            "unsupported fields",
+        ),
+    ],
+)
+def test_strict_connector_validation(resource, error_type, message) -> None:
+    with pytest.raises(error_type, match=message):
+        load_app_config(_config({"db": resource}), strict=True)
+
+
+@pytest.mark.parametrize(
+    "sink, error_type, message",
+    [
+        (
+            {"type": "clickhouse_table_sink", "table": "events"},
+            ValueError,
+            "connector",
+        ),
+        (
+            {
+                "type": "clickhouse_table_sink",
+                "connector": "missing",
+                "table": "events",
+            },
+            KeyError,
+            "missing",
+        ),
+        (
+            {
+                "type": "clickhouse_table_sink",
+                "connector": "db",
+                "table": "events",
+                "columns": [],
+            },
+            ValueError,
+            "columns",
+        ),
+        (
+            {
+                "type": "clickhouse_table_sink",
+                "connector": "db",
+                "table": "events",
+                "columns": ["id", "id"],
+            },
+            ValueError,
+            "duplicate",
+        ),
+        (
+            {
+                "type": "clickhouse_table_sink",
+                "connector": "db",
+                "table": "events",
+                "batch_size": 0,
+            },
+            ValueError,
+            "batch_size",
+        ),
+        (
+            {
+                "type": "clickhouse_table_sink",
+                "connector": "db",
+                "table": "events",
+                "settings": [],
+            },
+            TypeError,
+            "settings",
+        ),
+        (
+            {
+                "type": "clickhouse_table_sink",
+                "connector": "db",
+                "table": "events",
+                "unknown": True,
+            },
+            ValueError,
+            "unsupported fields",
+        ),
+    ],
+)
+def test_strict_sink_validation(sink, error_type, message) -> None:
+    resources = {
+        "db": {"type": "clickhouse", "dsn": "http://clickhouse:8123/default"},
+        "sink": sink,
+    }
+    with pytest.raises(error_type, match=message):
+        load_app_config(_config(resources), strict=True)
+
+
+def test_catalog_marks_connector_secrets() -> None:
+    registry = ResourceRegistry()
+    register(registry)
+    catalog = {entry.type: entry for entry in registry.catalog_entries()}
+    fields = {field.name: field for field in catalog["clickhouse"].fields}
+    assert fields["dsn"].secret is True
+    assert fields["client_options"].secret is True
+
+
+def test_sink_reference_must_resolve_to_clickhouse_connector() -> None:
+    resources = {
+        "other": {"type": "http_sink", "url": "https://example.invalid"},
+        "sink": {
+            "type": "clickhouse_table_sink",
+            "connector": "other",
+            "table": "events",
+        },
+    }
+    with pytest.raises(TypeError, match="ClickHouseConnector"):
+        load_app_config(_config(resources), strict=True)

--- a/plugins/onestep-clickhouse/tests/test_clickhouse_plugin.py
+++ b/plugins/onestep-clickhouse/tests/test_clickhouse_plugin.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from importlib import metadata as importlib_metadata
 
+import pytest
+
+from onestep import ResourceRegistry, load_app_config
 from onestep_clickhouse import (
     ClickHouseConnector,
     ClickHousePayloadError,
@@ -26,3 +29,73 @@ def test_public_surface_and_entry_point() -> None:
         item.name == "clickhouse" and item.value == "onestep_clickhouse:register"
         for item in selected
     )
+
+
+def _config(resources):
+    return {
+        "apiVersion": "onestep/v1alpha1",
+        "kind": "App",
+        "app": {"name": "clickhouse"},
+        "resources": resources,
+        "tasks": [],
+    }
+
+
+def test_catalog_and_strict_yaml_surface() -> None:
+    registry = ResourceRegistry()
+    register(registry)
+    catalog = {entry.type: entry for entry in registry.catalog_entries()}
+    assert catalog["clickhouse"].roles == ("connector",)
+    assert catalog["clickhouse_table_sink"].roles == ("sink",)
+    assert catalog["clickhouse_table_sink"].topology_fields == (
+        "table",
+        "columns",
+        "batch_size",
+    )
+
+    app = load_app_config(
+        _config(
+            {
+                "db": {
+                    "type": "clickhouse",
+                    "dsn": "https://writer:secret@clickhouse:8443/analytics",
+                    "client_options": {"connect_timeout": 10},
+                },
+                "events": {
+                    "type": "clickhouse_table_sink",
+                    "connector": "db",
+                    "table": "events",
+                    "columns": ["id", "kind"],
+                    "batch_size": 100,
+                    "settings": {
+                        "async_insert": 1,
+                        "wait_for_async_insert": 1,
+                    },
+                },
+            }
+        ),
+        strict=True,
+    )
+    assert isinstance(app.resources["db"], ClickHouseConnector)
+    assert app.resources["events"].columns == ("id", "kind")
+
+
+def test_strict_yaml_rejects_unacknowledged_async_insert() -> None:
+    with pytest.raises(ValueError, match="wait_for_async_insert"):
+        load_app_config(
+            _config(
+                {
+                    "db": {
+                        "type": "clickhouse",
+                        "dsn": "http://clickhouse:8123/default",
+                    },
+                    "sink": {
+                        "type": "clickhouse_table_sink",
+                        "connector": "db",
+                        "table": "events",
+                        "settings": {"async_insert": 1},
+                    },
+                }
+            ),
+            strict=True,
+        )

--- a/plugins/onestep-clickhouse/tests/test_clickhouse_resilience.py
+++ b/plugins/onestep-clickhouse/tests/test_clickhouse_resilience.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from onestep import ConnectorErrorKind
+from onestep_clickhouse.resilience import (
+    classify_clickhouse_error,
+    redacted_clickhouse_cause,
+)
+
+
+class ServerError(Exception):
+    def __init__(self, code: int, message: str) -> None:
+        self.code = code
+        super().__init__(message)
+
+
+def test_clickhouse_error_code_classes() -> None:
+    assert (
+        classify_clickhouse_error(ServerError(516, "authentication failed"))
+        is ConnectorErrorKind.MISCONFIGURED
+    )
+    assert (
+        classify_clickhouse_error(ServerError(60, "unknown table"))
+        is ConnectorErrorKind.MISCONFIGURED
+    )
+    assert (
+        classify_clickhouse_error(ServerError(241, "memory limit"))
+        is ConnectorErrorKind.THROTTLED
+    )
+    assert (
+        classify_clickhouse_error(ServerError(53, "type mismatch"))
+        is ConnectorErrorKind.PERMANENT
+    )
+    assert (
+        classify_clickhouse_error(TimeoutError("receive timeout"))
+        is ConnectorErrorKind.UNCERTAIN
+    )
+
+
+def test_redacted_cause_preserves_code_but_caps_message() -> None:
+    cause = redacted_clickhouse_cause(ServerError(53, "x" * 1000))
+    assert cause.code == 53
+    assert len(str(cause)) < 600


### PR DESCRIPTION
## Intent

Implement the independently testable onestep-clickhouse plugin exactly to the captain-approved database-plugin design and ClickHouse implementation plan. Keep every tracked change under plugins/onestep-clickhouse and preserve Python 3.9 compatibility and onestep>=1.7.1 stable public API usage. The sink must accept one mapping or an explicitly non-empty mapping sequence, safely enforce configured or inferred columns before network I/O, chunk sequentially under direct backpressure, await clickhouse-connect async insert acknowledgement, reject fire-and-forget async_insert settings, classify typed redacted failures, stop after a failing chunk, and surface partial-commit uncertainty without automatic replay. Validate lazy single-client ownership, strict YAML catalog and references, source-ack ordering, package artifacts, documentation, and environment-gated live coverage; do not add root workspace, lockfile, CI, shared documentation, release, Docker, or bundled-worker changes, and do not publish or merge.

## What Changed

- **Plugin foundation** — Add the `plugins/onestep-clickhouse` package with `ClickHouseConnector`, row batch normalization, async table insert with server acknowledgement, and typed failure classification
- **YAML resource registration** — Register the connector as a strict YAML catalog resource with validated references for the onestep resource registry
- **Resilience and backpressure** — Implement chunk-level backpressure with stop-on-failure semantics, redacted error classification, and partial-commit uncertainty surfacing without automatic replay
- **Documentation and tests** — Add `README.md` with Python and YAML usage examples, comprehensive unit test suite (connector, plugin, resilience), and environment-gated live integration coverage

## Risk Assessment

✅ Low: The implementation is well-structured, fully self-contained under plugins/onestep-clickhouse, and every required behavior from the user intent has a corresponding unit or integration test with no identified bugs or forbidden changes.

## Testing

Ran 41 unit tests across 3 test files (connector, plugin, resilience) — all pass. Verified the package builds to a valid wheel with correct entry point. Confirmed the integration test is properly gated behind ONESTEP_CLICKHOUSE_DSN env var. All transient artifacts (venvs, dist, cache, lockfile) cleaned from the working tree. No root workspace, CI, lockfile, or shared doc changes found.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pytest tests/ --ignore=tests/integration -q (41 unit tests)`
- `uv build (wheel + sdist)`
- `uv run python -c 'from onestep_clickhouse import *' (import sanity)`
- `pytest tests/integration/test_clickhouse_live.py -v (skipped without env var)`
- `unzip -l dist/*.whl (wheel contents)`
- `entry_points.txt verification`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `README.md:132` - Root README connectors table does not list the new onestep-clickhouse plugin. The table at lines 132–142 is the project-level index of available connector packages and is now incomplete.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ No linters (ruff, flake8, mypy, pyright) are installed in this environment and none are configured in the project. Unable to run automated lint checks.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
