### PR TITLE
feat(mongodb): add onestep-mongodb plugin with collection polling, change streams, and insert/upsert sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## onestep-mongodb 0.1.0
+
+- Adds the `onestep-mongodb` plugin package with deterministic collection polling,
+  raw change-stream sources, and acknowledged insert and upsert collection sinks.
+- Registers YAML resource types for `mongodb`, `mongodb_polling`,
+  `mongodb_change_stream`, and `mongodb_collection_sink`.
+- Uses BSON Extended JSON for resume-token and cursor-state durability in generic
+  cursor stores.
+- Preserves redacted MongoDB driver error semantics through classified
+  `ConnectorOperationError` kinds.
+- Adds focused unit tests, runtime shutdown contract tests, replica-set integration
+  coverage, package validation, and metadata checks.
+
 ## 1.7.2
 
 - Makes `onestep run` configure non-destructive INFO-level stdout logging and task lifecycle event logs by default.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ the runtime takes care of fetching, concurrency, retries, dead-lettering, and
 telemetry.
 
 - **One decorator** turns any async function into a managed task
-- **Pluggable connectors** for memory, MySQL, RabbitMQ, Redis, SQS, Kafka, Feishu
+- **Pluggable connectors** for memory, MySQL, RabbitMQ, Redis, SQS, Kafka, Feishu, MongoDB
 - **Scheduling** via interval, cron, webhook, or DB-backed queues
 - **Production-ready**: retries, dead-letter, timeouts, state stores, metrics,
   and an optional control-plane reporter
@@ -140,6 +140,7 @@ Each backend ships as its own package so you only install what you use:
 | **SQS** | `queue` with batched deletes and heartbeat visibility | `pip install onestep-sqs` |
 | **Kafka** | `kafka_topic` source/sink with manual offset commits | `pip install onestep-kafka` |
 | **Feishu Bitable** | incremental source and upsert sink | `pip install onestep-feishu-bitable` |
+| **MongoDB** | deterministic polling, raw change streams, insert/upsert sinks | `pip install onestep-mongodb` |
 
 Or install everything at once:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,7 +16,7 @@ Webhook 场景。你只需用 `source` 和可选的 `sink` 声明一个任务，
 处理拉取、并发、重试、死信和遥测上报。
 
 - **一个装饰器**，把任意 async 函数变成被托管的任务
-- **可插拔连接器**：内存、MySQL、RabbitMQ、Redis、SQS、Kafka、飞书多维表格
+- **可插拔连接器**：内存、MySQL、RabbitMQ、Redis、SQS、Kafka、飞书多维表格、MongoDB
 - **多种调度方式**：间隔、Cron、Webhook、基于数据库的队列
 - **生产可用**：重试、死信、超时、状态存储、指标、控制面 Reporter
 - **两种配置方式**：纯 Python，或声明式 YAML
@@ -135,6 +135,7 @@ async def main():
 | **SQS** | `queue`，支持批量删除与心跳可见性续期 | `pip install onestep-sqs` |
 | **Kafka** | `kafka_topic` source/sink，使用手动 offset commit | `pip install onestep-kafka` |
 | **飞书多维表格** | 增量 source 与 upsert sink | `pip install onestep-feishu-bitable` |
+| **MongoDB** | 确定性轮询、原始变更流、insert/upsert sink | `pip install onestep-mongodb` |
 
 或一次性安装全部：
 

--- a/docs/yaml-task-definition.md
+++ b/docs/yaml-task-definition.md
@@ -509,6 +509,7 @@ Plugin resource types:
 - `onestep-sqs`: `sqs`, `sqs_queue`
 - `onestep-kafka`: `kafka`, `kafka_topic`
 - `onestep-feishu-bitable`: `feishu_bitable`, `feishu_bitable_incremental`, `feishu_bitable_table_sink`
+- `onestep-mongodb`: `mongodb`, `mongodb_polling`, `mongodb_change_stream`, `mongodb_collection_sink`
 
 `kafka_topic` can be used as a source, sink, or both. When used as a source,
 set `group_id`; the plugin disables Kafka auto commit and commits offsets only

--- a/plugins/onestep-mongodb/README.md
+++ b/plugins/onestep-mongodb/README.md
@@ -1,0 +1,3 @@
+# onestep-mongodb
+
+MongoDB connector plugin for onestep.

--- a/plugins/onestep-mongodb/README.md
+++ b/plugins/onestep-mongodb/README.md
@@ -1,3 +1,201 @@
 # onestep-mongodb
 
-MongoDB connector plugin for onestep.
+`onestep-mongodb` provides deterministic collection polling, raw MongoDB change
+streams, and acknowledged collection insert or stable-key upsert sinks for
+`onestep`.
+
+## Install
+
+```bash
+pip install onestep-mongodb
+```
+
+The plugin requires Python 3.9 or newer, `onestep>=1.7.1`, and
+`pymongo>=4.13`. It uses PyMongo's native `AsyncMongoClient`; Motor is not used.
+
+## Python
+
+```python
+from onestep_mongodb import MongoDBConnector
+
+mongo = MongoDBConnector(
+    "mongodb://writer:secret@mongo-rs0/app?replicaSet=rs0",
+    database="app",
+    client_options={"serverSelectionTimeoutMS": 10_000},
+)
+
+polling = mongo.poll_collection(
+    "events",
+    cursor=("updated_at", "_id"),
+    filter={"archived": False},
+    batch_size=100,
+    poll_interval_s=1.0,
+    state=durable_cursor_store,
+    state_key="events-poll",
+)
+
+changes = mongo.watch_collection(
+    "events",
+    pipeline=[{"$match": {"operationType": {"$in": ["insert", "update", "delete"]}}}],
+    full_document="updateLookup",
+    max_await_time_ms=1000,
+    state=durable_cursor_store,
+    state_key="events-change-stream",
+)
+
+sink = mongo.collection_sink(
+    "events_archive",
+    mode="upsert",
+    keys=("event_id",),
+    ordered=True,
+    batch_size=1000,
+)
+```
+
+The connector creates its client lazily and closes only a client it owns. An
+injected client remains owned by its caller. Sources close their own query cursor
+or change stream; all `close()` methods are idempotent.
+
+## Strict YAML
+
+Production configurations use an explicit durable cursor store. This example
+uses the separately configured PostgreSQL cursor-store plugin:
+
+```yaml
+apiVersion: onestep/v1alpha1
+kind: App
+
+app:
+  name: mongo-events
+
+resources:
+  mongo:
+    type: mongodb
+    uri: "${MONGODB_URI}"
+    database: app
+    client_options:
+      serverSelectionTimeoutMS: 10000
+
+  cursor_db:
+    type: postgres
+    dsn: "${POSTGRES_DSN}"
+
+  cursor_state:
+    type: postgres_cursor_store
+    connector: cursor_db
+    table: onestep_cursor
+
+  events_poll:
+    type: mongodb_polling
+    connector: mongo
+    collection: events
+    cursor: [updated_at, _id]
+    filter:
+      archived: false
+    batch_size: 100
+    poll_interval_s: 1
+    state: cursor_state
+    state_key: events-poll
+
+  events_changes:
+    type: mongodb_change_stream
+    connector: mongo
+    collection: events
+    pipeline:
+      - $match:
+          operationType:
+            $in: [insert, update, delete]
+    full_document: updateLookup
+    max_await_time_ms: 1000
+    batch_size: 100
+    poll_interval_s: 0.1
+    state: cursor_state
+    state_key: events-change-stream
+
+  archive:
+    type: mongodb_collection_sink
+    connector: mongo
+    collection: events_archive
+    mode: upsert
+    keys: [event_id]
+    ordered: true
+    batch_size: 1000
+```
+
+Polling and change streams can run with in-memory state for development, but that
+state is lost on restart. Production restart guarantees require an explicit durable
+`state` cursor-store resource. Without polling state, scanning starts from the
+beginning; without a change-stream resume token, watching starts at the current
+server position.
+
+Cursor vectors and change-stream resume tokens are encoded through BSON Extended
+JSON before they reach a generic cursor store. This preserves BSON values such as
+`ObjectId`, datetimes, `Decimal128`, binary values, and timestamps in JSON-backed
+stores.
+
+## Sources
+
+Polling uses ascending lexicographic keyset traversal. `_id` is always the final
+tie-breaker. It persists only the greatest contiguous acknowledged cursor. A
+terminal `fail()` skips the poison document and advances that contiguous cursor;
+`retry()` and `release_unstarted()` invalidate the generation and replay from the
+last committed cursor only after all stale deliveries finish. Late acknowledgements
+from invalidated generations do nothing.
+
+Polling does not emit deletes. It sees updates only if a cursor field increases,
+and can miss non-monotonic cursor updates. Use change streams for workloads that
+need those events.
+
+Change streams require a MongoDB replica set or sharded cluster. A standalone
+server is not supported. Deliveries retain the complete raw change event:
+
+```python
+{
+    "_id": {"...": "resume token"},
+    "operationType": "update",
+    "documentKey": {"_id": "..."},
+    "fullDocument": {"...": "..."},
+    "updateDescription": {"...": "..."},
+}
+```
+
+Change-stream deliveries contain the complete raw MongoDB change event. Update
+streams request `full_document: updateLookup` by default. Project or reduce the
+event in the application handler, not in YAML.
+
+The resume token advances only after contiguous delivery acknowledgement. If a
+resume token falls out of the oplog or is invalid, the source fails permanently;
+it never silently falls back to the current server position. To reset such a
+source, stop the worker, inspect the permanent history-lost error, deliberately
+delete or reset only that source's `state_key`, then restart knowing the stream
+begins at the current server position.
+
+## Sinks and delivery semantics
+
+Sinks accept exactly one mapping or a non-empty sequence of mappings. They split a
+single sequence deterministically by `batch_size`, submit chunks sequentially, and
+await every MongoDB acknowledgement. The plugin rejects unacknowledged write
+concern (`w=0`).
+
+Insert mode uses `insert_one` for one mapping and `insert_many` for sequence
+chunks. It is replay-safe only when documents have stable `_id` values; duplicate
+keys are permanent conflicts, not implicit success. Upsert mode requires all
+configured stable keys and sends `UpdateOne` operations with key equality filters
+and `$set` excluding key fields and immutable `_id`.
+
+`ordered: true` is the conservative default. `ordered: false` can report multiple
+item failures for more throughput. A bulk operation or later chunk may have
+partially committed. For non-idempotent writes this is reported as uncertain,
+preserving only redacted indexes, codes, counts, and messages.
+
+onestep delivery is at-least-once. Sink output can commit before source
+acknowledgement, and a crash in that interval can duplicate output. Multi-sink
+fan-out is not transactional. Make handlers and downstream writes idempotent
+where duplicates matter.
+
+## Deferred features
+
+Version 1 does not provide database- or cluster-wide streams, transactions, sink
+deletes, replacement or update pipelines, schema validation or DDL, GridFS,
+aggregation or partitioned polling, pre-images, expanded events, custom codecs,
+or an automatically created MongoDB-backed cursor store.

--- a/plugins/onestep-mongodb/pyproject.toml
+++ b/plugins/onestep-mongodb/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "onestep-mongodb"
+version = "0.1.0"
+description = "MongoDB connector plugin for onestep."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+dependencies = ["onestep>=1.7.1", "pymongo>=4.13"]
+
+[project.optional-dependencies]
+test = ["pytest>=8.0.0", "pytest-asyncio>=0.23.0"]
+dev = ["pytest>=8.0.0", "pytest-asyncio>=0.23.0"]
+
+[project.entry-points."onestep.resources"]
+mongodb = "onestep_mongodb:register"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/onestep_mongodb"]
+
+[tool.uv.sources]
+onestep = { path = "../..", editable = true }
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+markers = ["integration: live external service tests"]

--- a/plugins/onestep-mongodb/src/onestep_mongodb/__init__.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version as _package_version
+
+from .connector import MongoDBChangeStreamDelivery, MongoDBChangeStreamSource, MongoDBCollectionSink, MongoDBConnector, MongoDBPayloadError, MongoDBPollingDelivery, MongoDBPollingSource
+from .resources import register_resources
+
+try:
+    __version__ = _package_version("onestep-mongodb")
+except PackageNotFoundError:
+    __version__ = "dev"
+
+register = register_resources
+__all__ = ["MongoDBChangeStreamDelivery", "MongoDBChangeStreamSource", "MongoDBCollectionSink", "MongoDBConnector", "MongoDBPayloadError", "MongoDBPollingDelivery", "MongoDBPollingSource", "__version__", "register", "register_resources"]

--- a/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
@@ -174,12 +174,13 @@ class MongoDBPollingSource(Source):
             self._active_cursor = collection.find(self._query(self._scan), self.projection).sort([(field, 1) for field in self.cursor]).limit(min(limit, self.batch_size))
             documents = [document async for document in self._active_cursor]
         except Exception as exc:
-            from .resilience import classify_mongodb_error
+            from .resilience import classify_mongodb_error, redacted_mongodb_cause
 
             kind = classify_mongodb_error(exc, operation="fetch")
             if kind is None:
                 raise
-            raise ConnectorOperationError(backend="mongodb", operation=ConnectorOperation.FETCH, kind=kind, source_name=self.name, retry_delay_s=self.poll_interval_s, cause=exc) from exc
+            cause = redacted_mongodb_cause(exc)
+            raise ConnectorOperationError(backend="mongodb", operation=ConnectorOperation.FETCH, kind=kind, source_name=self.name, retry_delay_s=self.poll_interval_s, cause=cause) from cause
         finally:
             cursor = self._active_cursor
             self._active_cursor = None
@@ -290,7 +291,7 @@ class MongoDBChangeStreamSource(Source):
                     break
                 events.append(event)
         except Exception as exc:
-            from .resilience import classify_mongodb_error
+            from .resilience import classify_mongodb_error, redacted_mongodb_cause
 
             await self._tracker.invalidate(self._tracker.generation)
             stream = self._stream
@@ -318,14 +319,15 @@ class MongoDBChangeStreamSource(Source):
                 if history_lost
                 else None
             )
+            cause = redacted_mongodb_cause(exc)
             raise ConnectorOperationError(
                 backend="mongodb",
                 operation=ConnectorOperation.FETCH,
                 kind=kind,
                 source_name=self.name,
-                cause=exc,
+                cause=cause,
                 message=message,
-            ) from exc
+            ) from cause
 
         deliveries: list[Delivery] = []
         for event in events:
@@ -460,8 +462,9 @@ class MongoDBCollectionSink(Sink):
             kind = classify_mongodb_error(exc, operation="send")
             if kind is None:
                 raise
+            cause = redacted_mongodb_cause(exc)
             replay_safe = self.mode == "upsert" and bool(self.keys)
-            partial = committed > 0 or redacted_mongodb_cause(exc).committed_count > 0
+            partial = committed > 0 or cause.committed_count > 0
             if partial and not replay_safe:
                 kind = ConnectorErrorKind.UNCERTAIN
-            raise ConnectorOperationError(backend="mongodb", operation=ConnectorOperation.SEND, kind=kind, source_name=self.name, cause=redacted_mongodb_cause(exc)) from exc
+            raise ConnectorOperationError(backend="mongodb", operation=ConnectorOperation.SEND, kind=kind, source_name=self.name, cause=cause) from cause

--- a/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from onestep import Delivery, Sink, Source
+from onestep import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError, CursorStore, Delivery, Envelope, InMemoryCursorStore, Sink, Source
+
+from .state_codec import decode_state, encode_state
 
 
 @dataclass
@@ -72,27 +74,174 @@ class MongoDBPayloadError(ValueError):
 
 
 class MongoDBConnector:
-    def __init__(self, uri: str, *, database: str, client_options: dict[str, Any] | None = None, client: Any | None = None) -> None:
+    def __init__(self, uri: str, *, database: str, client_options: Mapping[str, Any] | None = None, client: Any | None = None) -> None:
+        if not uri or not database:
+            raise ValueError("uri and database must not be empty")
         self.uri = uri
         self.database_name = database
         self.client_options = dict(client_options or {})
         self._client = client
+        self._owns_client = client is None
+        self._closed = False
+
+    def _get_client(self):
+        if self._client is None:
+            from pymongo import AsyncMongoClient
+
+            self._client = AsyncMongoClient(self.uri, **self.client_options)
+        return self._client
+
+    def collection(self, name: str):
+        return self._get_client()[self.database_name][name]
+
+    def poll_collection(self, collection: str, **options: Any) -> "MongoDBPollingSource":
+        return MongoDBPollingSource(connector=self, collection=collection, **options)
+
+    def watch_collection(self, collection: str, **options: Any) -> "MongoDBChangeStreamSource":
+        return MongoDBChangeStreamSource(connector=self, collection=collection, **options)
+
+    def collection_sink(self, collection: str, **options: Any) -> "MongoDBCollectionSink":
+        return MongoDBCollectionSink(connector=self, collection=collection, **options)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._owns_client and self._client is not None:
+            result = self._client.close()
+            if hasattr(result, "__await__"):
+                await result
 
 
 class MongoDBPollingSource(Source):
+    fetch_is_cancel_safe = False
+
+    def __init__(self, *, connector: MongoDBConnector, collection: str, cursor: Sequence[str] = ("_id",), filter: Mapping[str, Any] | None = None, projection: Mapping[str, Any] | None = None, batch_size: int = 100, poll_interval_s: float = 1.0, state: CursorStore | None = None, state_key: str | None = None, initial_cursor: Sequence[Any] | None = None) -> None:
+        super().__init__(f"mongodb.polling:{collection}")
+        configured = tuple(cursor)
+        if not configured or len(set(configured)) != len(configured):
+            raise ValueError("cursor must be non-empty and unique")
+        if "_id" in configured and configured[-1] != "_id":
+            raise ValueError("_id must be the final cursor component")
+        self.cursor = configured if configured[-1] == "_id" else (*configured, "_id")
+        self.connector = connector
+        self.collection_name = collection
+        self.filter = dict(filter or {})
+        self.projection = dict(projection or {}) or None
+        self.batch_size = batch_size
+        self.poll_interval_s = poll_interval_s
+        self.state = state or InMemoryCursorStore()
+        self.state_key = state_key or f"mongodb:{connector.database_name}:{collection}:poll:{','.join(self.cursor)}"
+        self.initial_cursor = tuple(decode_state({"extended_json": list(initial_cursor)})) if initial_cursor is not None else None
+        self._committed = None
+        self._scan = None
+        self._loaded = False
+        self._active_cursor = None
+        self._tracker = _ContiguousGenerationTracker(self._save)
+
+    def _cursor_query(self, token: Sequence[Any]) -> dict[str, Any]:
+        branches = []
+        for index, field in enumerate(self.cursor):
+            branch = {self.cursor[prefix]: token[prefix] for prefix in range(index)}
+            branch[field] = {"$gt": token[index]}
+            branches.append(branch)
+        return {"$or": branches}
+
+    def _query(self, token: Sequence[Any] | None) -> dict[str, Any]:
+        cursor_query = self._cursor_query(token) if token is not None else {}
+        if self.filter and cursor_query:
+            return {"$and": [self.filter, cursor_query]}
+        return dict(self.filter or cursor_query)
+
+    async def _save(self, token: Any) -> None:
+        self._committed = tuple(token)
+        await self.state.save(self.state_key, encode_state(list(token)))
+
+    async def open(self) -> None:
+        if self._loaded:
+            return
+        loaded = await self.state.load(self.state_key)
+        self._committed = tuple(decode_state(loaded)) if loaded is not None else self.initial_cursor
+        self._scan = self._committed
+        self._loaded = True
+
     async def fetch(self, limit: int) -> list[Delivery]:
-        raise NotImplementedError
+        await self.open()
+        if not self._tracker.can_fetch:
+            return []
+        collection = self.connector.collection(self.collection_name)
+        try:
+            self._active_cursor = collection.find(self._query(self._scan), self.projection).sort([(field, 1) for field in self.cursor]).limit(min(limit, self.batch_size))
+            documents = [document async for document in self._active_cursor]
+        except Exception as exc:
+            from .resilience import classify_mongodb_error
+
+            kind = classify_mongodb_error(exc, operation="fetch")
+            if kind is None:
+                raise
+            raise ConnectorOperationError(backend="mongodb", operation=ConnectorOperation.FETCH, kind=kind, source_name=self.name, retry_delay_s=self.poll_interval_s, cause=exc) from exc
+        finally:
+            cursor = self._active_cursor
+            self._active_cursor = None
+            if cursor is not None and hasattr(cursor, "close"):
+                result = cursor.close()
+                if hasattr(result, "__await__"):
+                    await result
+        deliveries: list[Delivery] = []
+        for document in documents:
+            token = tuple(document[field] for field in self.cursor)
+            self._scan = token
+            tracked = self._tracker.add(token)
+            deliveries.append(MongoDBPollingDelivery(self, Envelope(body=document, meta={"mongodb": {"database": self.connector.database_name, "collection": self.collection_name}}), tracked))
+        return deliveries
+
+    async def invalidate(self, tracked: _TrackedToken, *, delay_s: float | None = None) -> None:
+        if delay_s:
+            await asyncio.sleep(delay_s)
+        await self._tracker.invalidate(tracked.generation)
+        self._scan = self._committed
+
+    async def close(self) -> None:
+        cursor = self._active_cursor
+        self._active_cursor = None
+        if cursor is not None and hasattr(cursor, "close"):
+            result = cursor.close()
+            if hasattr(result, "__await__"):
+                await result
 
 
 class MongoDBPollingDelivery(Delivery):
+    def __init__(self, source: MongoDBPollingSource, envelope: Envelope, tracked: _TrackedToken) -> None:
+        super().__init__(envelope)
+        self._source = source
+        self._tracked = tracked
+        self._terminal = False
+
     async def ack(self) -> None:
-        raise NotImplementedError
+        if self._terminal:
+            return
+        self._terminal = True
+        await self._source._tracker.complete(self._tracked, advance=True)
 
     async def retry(self, *, delay_s: float | None = None) -> None:
-        raise NotImplementedError
+        if self._terminal:
+            return
+        self._terminal = True
+        await self._source.invalidate(self._tracked, delay_s=delay_s)
+        await self._source._tracker.complete(self._tracked, advance=False)
 
     async def fail(self, exc: Exception | None = None) -> None:
-        raise NotImplementedError
+        if self._terminal:
+            return
+        self._terminal = True
+        await self._source._tracker.complete(self._tracked, advance=True)
+
+    async def release_unstarted(self) -> None:
+        if self._terminal:
+            return
+        self._terminal = True
+        await self._source.invalidate(self._tracked)
+        await self._source._tracker.complete(self._tracked, advance=False)
 
 
 class MongoDBChangeStreamSource(Source):

--- a/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
@@ -245,12 +245,155 @@ class MongoDBPollingDelivery(Delivery):
 
 
 class MongoDBChangeStreamSource(Source):
+    fetch_is_cancel_safe = False
+
+    def __init__(self, *, connector: MongoDBConnector, collection: str, pipeline: Sequence[Mapping[str, Any]] | None = None, full_document: str = "updateLookup", max_await_time_ms: int = 1000, batch_size: int = 100, poll_interval_s: float = 0.1, state: CursorStore | None = None, state_key: str | None = None) -> None:
+        super().__init__(f"mongodb.change_stream:{collection}")
+        self.connector = connector
+        self.collection_name = collection
+        self.pipeline = [dict(stage) for stage in (pipeline or [])]
+        self.full_document = full_document
+        self.max_await_time_ms = max_await_time_ms
+        self.batch_size = batch_size
+        self.poll_interval_s = poll_interval_s
+        self.state = state or InMemoryCursorStore()
+        self.state_key = state_key or f"mongodb:{connector.database_name}:{collection}:change-stream"
+        self._resume_token = None
+        self._loaded = False
+        self._stream = None
+        self._tracker = _ContiguousGenerationTracker(self._save)
+
+    async def _save(self, token: Any) -> None:
+        self._resume_token = token
+        await self.state.save(self.state_key, encode_state(token))
+
+    async def open(self) -> None:
+        if not self._loaded:
+            loaded = await self.state.load(self.state_key)
+            self._resume_token = decode_state(loaded) if loaded is not None else None
+            self._loaded = True
+        if self._stream is None and self._tracker.can_fetch:
+            options = {"full_document": self.full_document, "max_await_time_ms": self.max_await_time_ms}
+            if self._resume_token is not None:
+                options["resume_after"] = self._resume_token
+            self._stream = await self.connector.collection(self.collection_name).watch(self.pipeline, **options)
+
     async def fetch(self, limit: int) -> list[Delivery]:
-        raise NotImplementedError
+        await self.open()
+        if self._stream is None or not self._tracker.can_fetch:
+            return []
+        events: list[Mapping[str, Any]] = []
+        try:
+            for _ in range(min(limit, self.batch_size)):
+                event = await self._stream.try_next()
+                if event is None:
+                    break
+                events.append(event)
+        except Exception as exc:
+            from .resilience import classify_mongodb_error
+
+            await self._tracker.invalidate(self._tracker.generation)
+            stream = self._stream
+            self._stream = None
+            if stream is not None:
+                await stream.close()
+            history_lost = getattr(exc, "code", None) in {280, 286}
+            has_resumable_label = getattr(exc, "has_error_label", lambda label: False)(
+                "ResumableChangeStreamError"
+            )
+            kind = (
+                ConnectorErrorKind.PERMANENT
+                if history_lost
+                else (
+                    ConnectorErrorKind.TRANSIENT
+                    if has_resumable_label
+                    else classify_mongodb_error(exc, operation="fetch")
+                )
+            )
+            if kind is None:
+                raise
+            message = (
+                "MongoDB change-stream history is unavailable; reset durable "
+                "resume state deliberately before restarting"
+                if history_lost
+                else None
+            )
+            raise ConnectorOperationError(
+                backend="mongodb",
+                operation=ConnectorOperation.FETCH,
+                kind=kind,
+                source_name=self.name,
+                cause=exc,
+                message=message,
+            ) from exc
+
+        deliveries: list[Delivery] = []
+        for event in events:
+            token = event["_id"]
+            tracked = self._tracker.add(token)
+            meta = {
+                "mongodb": {
+                    "database": self.connector.database_name,
+                    "collection": self.collection_name,
+                    "operation_type": event.get("operationType"),
+                    "document_key": event.get("documentKey"),
+                }
+            }
+            deliveries.append(
+                MongoDBChangeStreamDelivery(
+                    self,
+                    Envelope(body=event, meta=meta),
+                    tracked,
+                )
+            )
+        return deliveries
+
+    async def invalidate(self, tracked: _TrackedToken, *, delay_s: float | None = None) -> None:
+        if delay_s:
+            await asyncio.sleep(delay_s)
+        await self._tracker.invalidate(tracked.generation)
+        if self._stream is not None:
+            await self._stream.close()
+            self._stream = None
+
+    async def close(self) -> None:
+        if self._stream is not None:
+            await self._stream.close()
+            self._stream = None
 
 
-class MongoDBChangeStreamDelivery(MongoDBPollingDelivery):
-    pass
+class MongoDBChangeStreamDelivery(Delivery):
+    def __init__(self, source: MongoDBChangeStreamSource, envelope: Envelope, tracked: _TrackedToken) -> None:
+        super().__init__(envelope)
+        self._source = source
+        self._tracked = tracked
+        self._terminal = False
+
+    async def ack(self) -> None:
+        if self._terminal:
+            return
+        self._terminal = True
+        await self._source._tracker.complete(self._tracked, advance=True)
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        if self._terminal:
+            return
+        self._terminal = True
+        await self._source.invalidate(self._tracked, delay_s=delay_s)
+        await self._source._tracker.complete(self._tracked, advance=False)
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        if self._terminal:
+            return
+        self._terminal = True
+        await self._source._tracker.complete(self._tracked, advance=True)
+
+    async def release_unstarted(self) -> None:
+        if self._terminal:
+            return
+        self._terminal = True
+        await self._source.invalidate(self._tracked)
+        await self._source._tracker.complete(self._tracked, advance=False)
 
 
 class MongoDBCollectionSink(Sink):

--- a/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
@@ -397,5 +397,71 @@ class MongoDBChangeStreamDelivery(Delivery):
 
 
 class MongoDBCollectionSink(Sink):
-    async def send(self, envelope) -> None:
-        raise NotImplementedError
+    def __init__(self, *, connector: MongoDBConnector, collection: str, mode: str = "insert", keys: Sequence[str] = (), ordered: bool = True, batch_size: int = 1000) -> None:
+        super().__init__(f"mongodb.collection:{collection}")
+        if mode not in {"insert", "upsert"}:
+            raise ValueError("mode must be insert or upsert")
+        if mode == "upsert" and not keys:
+            raise ValueError("upsert mode requires keys")
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        self.connector = connector
+        self.collection_name = collection
+        self.mode = mode
+        self.keys = tuple(keys)
+        self.ordered = ordered
+        self.batch_size = batch_size
+
+    def _documents(self, body: Any) -> list[dict[str, Any]]:
+        if isinstance(body, Mapping):
+            return [dict(body)]
+        if not isinstance(body, Sequence) or isinstance(body, (str, bytes, bytearray)) or not body:
+            raise MongoDBPayloadError("payload must be a mapping or non-empty sequence")
+        if any(not isinstance(item, Mapping) for item in body):
+            raise MongoDBPayloadError("every payload item must be a mapping")
+        return [dict(item) for item in body]
+
+    async def send(self, envelope: Envelope) -> None:
+        from pymongo import UpdateOne
+
+        collection = self.connector.collection(self.collection_name)
+        if not collection.write_concern.acknowledged:
+            raise ValueError("MongoDB sink requires acknowledged write concern")
+        try:
+            single_document = isinstance(envelope.body, Mapping)
+            documents = self._documents(envelope.body)
+            if self.mode == "upsert":
+                for index, document in enumerate(documents):
+                    missing = [key for key in self.keys if key not in document]
+                    if missing:
+                        raise MongoDBPayloadError(f"document {index} missing upsert keys {missing}")
+        except MongoDBPayloadError as exc:
+            raise ConnectorOperationError(backend="mongodb", operation=ConnectorOperation.SEND, kind=ConnectorErrorKind.PERMANENT, source_name=self.name, cause=exc) from exc
+        committed = 0
+        try:
+            for start in range(0, len(documents), self.batch_size):
+                chunk = documents[start : start + self.batch_size]
+                if self.mode == "insert":
+                    if single_document:
+                        await collection.insert_one(chunk[0])
+                    else:
+                        await collection.insert_many(chunk, ordered=self.ordered)
+                else:
+                    operations = []
+                    for document in chunk:
+                        selector = {key: document[key] for key in self.keys}
+                        update = {key: value for key, value in document.items() if key not in self.keys and key != "_id"}
+                        operations.append(UpdateOne(selector, {"$set": update}, upsert=True))
+                    await collection.bulk_write(operations, ordered=self.ordered)
+                committed += 1
+        except Exception as exc:
+            from .resilience import classify_mongodb_error, redacted_mongodb_cause
+
+            kind = classify_mongodb_error(exc, operation="send")
+            if kind is None:
+                raise
+            replay_safe = self.mode == "upsert" and bool(self.keys)
+            partial = committed > 0 or redacted_mongodb_cause(exc).committed_count > 0
+            if partial and not replay_safe:
+                kind = ConnectorErrorKind.UNCERTAIN
+            raise ConnectorOperationError(backend="mongodb", operation=ConnectorOperation.SEND, kind=kind, source_name=self.name, cause=redacted_mongodb_cause(exc)) from exc

--- a/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any
+
+from onestep import Delivery, Sink, Source
+
+
+class MongoDBPayloadError(ValueError):
+    pass
+
+
+class MongoDBConnector:
+    def __init__(self, uri: str, *, database: str, client_options: dict[str, Any] | None = None, client: Any | None = None) -> None:
+        self.uri = uri
+        self.database_name = database
+        self.client_options = dict(client_options or {})
+        self._client = client
+
+
+class MongoDBPollingSource(Source):
+    async def fetch(self, limit: int) -> list[Delivery]:
+        raise NotImplementedError
+
+
+class MongoDBPollingDelivery(Delivery):
+    async def ack(self) -> None:
+        raise NotImplementedError
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        raise NotImplementedError
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        raise NotImplementedError
+
+
+class MongoDBChangeStreamSource(Source):
+    async def fetch(self, limit: int) -> list[Delivery]:
+        raise NotImplementedError
+
+
+class MongoDBChangeStreamDelivery(MongoDBPollingDelivery):
+    pass
+
+
+class MongoDBCollectionSink(Sink):
+    async def send(self, envelope) -> None:
+        raise NotImplementedError

--- a/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
@@ -1,8 +1,70 @@
 from __future__ import annotations
 
+import asyncio
+from collections import deque
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any
 
 from onestep import Delivery, Sink, Source
+
+
+@dataclass
+class _TrackedToken:
+    generation: int
+    sequence: int
+    token: Any
+    completed: bool = False
+    advances: bool = False
+
+
+class _ContiguousGenerationTracker:
+    def __init__(self, save: Callable[[Any], Awaitable[None]]) -> None:
+        self._save = save
+        self.generation = 0
+        self._next_sequence = 0
+        self._pending: deque[_TrackedToken] = deque()
+        self._outstanding: dict[int, int] = {}
+        self._invalidated: set[int] = set()
+        self._lock = asyncio.Lock()
+
+    @property
+    def can_fetch(self) -> bool:
+        return not any(
+            generation in self._invalidated and count > 0
+            for generation, count in self._outstanding.items()
+        )
+
+    def add(self, token: Any) -> _TrackedToken:
+        tracked = _TrackedToken(self.generation, self._next_sequence, token)
+        self._next_sequence += 1
+        self._pending.append(tracked)
+        self._outstanding[tracked.generation] = self._outstanding.get(tracked.generation, 0) + 1
+        return tracked
+
+    async def invalidate(self, generation: int) -> None:
+        async with self._lock:
+            if generation == self.generation:
+                self._invalidated.add(generation)
+                self.generation += 1
+
+    async def complete(self, tracked: _TrackedToken, *, advance: bool) -> None:
+        async with self._lock:
+            stale = tracked.generation in self._invalidated
+            tracked.completed = True
+            tracked.advances = advance and not stale
+            self._outstanding[tracked.generation] = max(0, self._outstanding.get(tracked.generation, 1) - 1)
+            saved = None
+            while self._pending and self._pending[0].completed:
+                item = self._pending.popleft()
+                if item.advances:
+                    saved = item.token
+            stale_generations = [item for item, count in self._outstanding.items() if count == 0]
+            for item in stale_generations:
+                self._outstanding.pop(item, None)
+                self._invalidated.discard(item)
+            if saved is not None:
+                await self._save(saved)
 
 
 class MongoDBPayloadError(ValueError):

--- a/plugins/onestep-mongodb/src/onestep_mongodb/resilience.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/resilience.py
@@ -1,7 +1,76 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from pymongo.errors import AutoReconnect, BulkWriteError, ConfigurationError, DuplicateKeyError, ExecutionTimeout, InvalidURI, NetworkTimeout, OperationFailure, ServerSelectionTimeoutError
+
 from onestep import ConnectorErrorKind
 
 
+@dataclass(frozen=True)
+class MongoDBErrorCause(Exception):
+    code: int | None
+    failed_indexes: tuple[int, ...]
+    codes: tuple[int | None, ...]
+    committed_count: int
+    message: str
+
+    def __str__(self) -> str:
+        return f"MongoDB error code={self.code} failed_indexes={self.failed_indexes} codes={self.codes}: {self.message}"
+
+
+def redacted_mongodb_cause(exc: BaseException) -> MongoDBErrorCause:
+    details = exc.details if isinstance(exc, BulkWriteError) else {}
+    write_errors = details.get("writeErrors", []) if isinstance(details, dict) else []
+    failed_indexes = tuple(int(item["index"]) for item in write_errors if isinstance(item, dict) and "index" in item)
+    codes = tuple(item.get("code") for item in write_errors if isinstance(item, dict) and "index" in item)
+    committed_count = sum(int(details.get(key, 0) or 0) for key in ("nInserted", "nUpserted", "nMatched")) if isinstance(details, dict) else 0
+    code = getattr(exc, "code", None)
+    if code is None and write_errors:
+        code = write_errors[0].get("code")
+    if isinstance(exc, BulkWriteError):
+        message = "; ".join(
+            str(item.get("errmsg", "write error"))[:160]
+            for item in write_errors
+            if isinstance(item, dict)
+        )[:500]
+    else:
+        message = str(exc)[:500]
+    return MongoDBErrorCause(code, failed_indexes, codes, committed_count, message)
+
+
 def classify_mongodb_error(exc: BaseException, *, operation: str) -> ConnectorErrorKind | None:
+    if isinstance(exc, BulkWriteError):
+        details = exc.details if isinstance(exc.details, dict) else {}
+        codes = {
+            item.get("code")
+            for key in ("writeErrors", "writeConcernErrors")
+            for item in details.get(key, [])
+            if isinstance(item, dict)
+        }
+        if codes & {13, 18}:
+            return ConnectorErrorKind.MISCONFIGURED
+        if codes & {50, 16500}:
+            return ConnectorErrorKind.THROTTLED
+        return ConnectorErrorKind.PERMANENT
+    if isinstance(exc, (ConfigurationError, InvalidURI)):
+        return ConnectorErrorKind.MISCONFIGURED
+    if isinstance(exc, DuplicateKeyError):
+        return ConnectorErrorKind.PERMANENT
+    if isinstance(exc, OperationFailure):
+        if exc.code in {13, 18}:
+            return ConnectorErrorKind.MISCONFIGURED
+        if exc.code in {286, 280}:
+            return ConnectorErrorKind.PERMANENT
+        if exc.code in {50, 16500}:
+            return ConnectorErrorKind.THROTTLED
+        if exc.has_error_label("ResumableChangeStreamError"):
+            return ConnectorErrorKind.TRANSIENT
+        return ConnectorErrorKind.PERMANENT
+    if isinstance(exc, AutoReconnect):
+        return ConnectorErrorKind.UNCERTAIN if operation == "send" else ConnectorErrorKind.DISCONNECTED
+    if isinstance(exc, (NetworkTimeout, ExecutionTimeout)):
+        return ConnectorErrorKind.UNCERTAIN if operation == "send" else ConnectorErrorKind.TRANSIENT
+    if isinstance(exc, ServerSelectionTimeoutError):
+        return ConnectorErrorKind.DISCONNECTED
     return None

--- a/plugins/onestep-mongodb/src/onestep_mongodb/resilience.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/resilience.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from onestep import ConnectorErrorKind
+
+
+def classify_mongodb_error(exc: BaseException, *, operation: str) -> ConnectorErrorKind | None:
+    return None

--- a/plugins/onestep-mongodb/src/onestep_mongodb/resilience.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/resilience.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
+from bson.errors import InvalidDocument, InvalidStringData
 from pymongo.errors import AutoReconnect, BulkWriteError, ConfigurationError, DuplicateKeyError, ExecutionTimeout, InvalidURI, NetworkTimeout, OperationFailure, ServerSelectionTimeoutError
 
 from onestep import ConnectorErrorKind
@@ -19,6 +21,15 @@ class MongoDBErrorCause(Exception):
         return f"MongoDB error code={self.code} failed_indexes={self.failed_indexes} codes={self.codes}: {self.message}"
 
 
+_MONGODB_URI_CREDENTIALS = re.compile(r"(?i)\b(mongodb(?:\+srv)?://)[^/@\s]+@")
+_SENSITIVE_QUERY_VALUE = re.compile(r"(?i)([?&](?:password|passwd|pwd|secret|token)\s*=)[^&\s]+")
+
+
+def _redact_message(message: str) -> str:
+    message = _MONGODB_URI_CREDENTIALS.sub(r"\1<redacted>@", message)
+    return _SENSITIVE_QUERY_VALUE.sub(r"\1<redacted>", message)
+
+
 def redacted_mongodb_cause(exc: BaseException) -> MongoDBErrorCause:
     details = exc.details if isinstance(exc, BulkWriteError) else {}
     write_errors = details.get("writeErrors", []) if isinstance(details, dict) else []
@@ -30,12 +41,16 @@ def redacted_mongodb_cause(exc: BaseException) -> MongoDBErrorCause:
         code = write_errors[0].get("code")
     if isinstance(exc, BulkWriteError):
         message = "; ".join(
-            str(item.get("errmsg", "write error"))[:160]
+            _redact_message(str(item.get("errmsg", "write error")))[:160]
             for item in write_errors
             if isinstance(item, dict)
         )[:500]
+    elif isinstance(exc, (InvalidDocument, InvalidStringData)):
+        message = "invalid MongoDB document"
+    elif isinstance(exc, (ConfigurationError, InvalidURI)):
+        message = "invalid MongoDB configuration"
     else:
-        message = str(exc)[:500]
+        message = _redact_message(str(exc))[:500]
     return MongoDBErrorCause(code, failed_indexes, codes, committed_count, message)
 
 
@@ -55,8 +70,16 @@ def classify_mongodb_error(exc: BaseException, *, operation: str) -> ConnectorEr
         return ConnectorErrorKind.PERMANENT
     if isinstance(exc, (ConfigurationError, InvalidURI)):
         return ConnectorErrorKind.MISCONFIGURED
+    if isinstance(exc, (InvalidDocument, InvalidStringData)):
+        return ConnectorErrorKind.PERMANENT
     if isinstance(exc, DuplicateKeyError):
         return ConnectorErrorKind.PERMANENT
+    if isinstance(exc, ServerSelectionTimeoutError):
+        return ConnectorErrorKind.DISCONNECTED
+    if isinstance(exc, NetworkTimeout):
+        return ConnectorErrorKind.UNCERTAIN if operation == "send" else ConnectorErrorKind.DISCONNECTED
+    if isinstance(exc, ExecutionTimeout):
+        return ConnectorErrorKind.UNCERTAIN if operation == "send" else ConnectorErrorKind.TRANSIENT
     if isinstance(exc, OperationFailure):
         if exc.code in {13, 18}:
             return ConnectorErrorKind.MISCONFIGURED
@@ -69,8 +92,4 @@ def classify_mongodb_error(exc: BaseException, *, operation: str) -> ConnectorEr
         return ConnectorErrorKind.PERMANENT
     if isinstance(exc, AutoReconnect):
         return ConnectorErrorKind.UNCERTAIN if operation == "send" else ConnectorErrorKind.DISCONNECTED
-    if isinstance(exc, (NetworkTimeout, ExecutionTimeout)):
-        return ConnectorErrorKind.UNCERTAIN if operation == "send" else ConnectorErrorKind.TRANSIENT
-    if isinstance(exc, ServerSelectionTimeoutError):
-        return ConnectorErrorKind.DISCONNECTED
     return None

--- a/plugins/onestep-mongodb/src/onestep_mongodb/resources.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/resources.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from onestep import ResourceRegistry
+
+
+def register_resources(registry: ResourceRegistry) -> None:
+    return None

--- a/plugins/onestep-mongodb/src/onestep_mongodb/resources.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/resources.py
@@ -1,7 +1,164 @@
 from __future__ import annotations
 
-from onestep import ResourceRegistry
+from collections.abc import Mapping, Sequence
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from onestep import ResourceBuildContext, ResourceCatalogEntry, ResourceCatalogField, ResourceRegistry, ResourceSpecHandler, ResourceValidationContext
+
+from .connector import MongoDBConnector
+
+CONNECTOR_FIELDS = frozenset({"type", "uri", "database", "client_options"})
+POLLING_FIELDS = frozenset({"type", "connector", "collection", "cursor", "filter", "projection", "batch_size", "poll_interval_s", "state", "state_key", "initial_cursor"})
+CHANGE_FIELDS = frozenset({"type", "connector", "collection", "pipeline", "full_document", "max_await_time_ms", "batch_size", "poll_interval_s", "state", "state_key"})
+SINK_FIELDS = frozenset({"type", "connector", "collection", "mode", "keys", "ordered", "batch_size"})
+
+CONNECTOR_CATALOG = ResourceCatalogEntry(
+    type="mongodb", roles=("connector",), label="MongoDB",
+    fields=(
+        ResourceCatalogField("uri", "string", required=True, secret=True),
+        ResourceCatalogField("database", "string", required=True),
+        ResourceCatalogField("client_options", "mapping", secret=True),
+    ),
+)
+POLLING_CATALOG = ResourceCatalogEntry(
+    type="mongodb_polling", roles=("source",), label="MongoDB Polling", connector_types=("mongodb",),
+    fields=(
+        ResourceCatalogField("connector", "ref", required=True), ResourceCatalogField("collection", "string", required=True),
+        ResourceCatalogField("cursor", "string_list", default=["_id"]), ResourceCatalogField("filter", "mapping"),
+        ResourceCatalogField("projection", "mapping"), ResourceCatalogField("batch_size", "integer", default=100),
+        ResourceCatalogField("poll_interval_s", "number", default=1.0), ResourceCatalogField("state", "ref"),
+        ResourceCatalogField("state_key", "string"), ResourceCatalogField("initial_cursor", "json"),
+    ), topology_fields=("collection", "cursor", "batch_size", "poll_interval_s"),
+)
+CHANGE_CATALOG = ResourceCatalogEntry(
+    type="mongodb_change_stream", roles=("source",), label="MongoDB Change Stream", connector_types=("mongodb",),
+    fields=(
+        ResourceCatalogField("connector", "ref", required=True), ResourceCatalogField("collection", "string", required=True),
+        ResourceCatalogField("pipeline", "json"), ResourceCatalogField("full_document", "string", default="updateLookup", options=("default", "updateLookup", "whenAvailable", "required")),
+        ResourceCatalogField("max_await_time_ms", "integer", default=1000), ResourceCatalogField("batch_size", "integer", default=100),
+        ResourceCatalogField("poll_interval_s", "number", default=0.1), ResourceCatalogField("state", "ref"),
+        ResourceCatalogField("state_key", "string"),
+    ), topology_fields=("collection", "full_document", "batch_size", "max_await_time_ms"),
+)
+SINK_CATALOG = ResourceCatalogEntry(
+    type="mongodb_collection_sink", roles=("sink",), label="MongoDB Collection Sink", connector_types=("mongodb",),
+    fields=(
+        ResourceCatalogField("connector", "ref", required=True), ResourceCatalogField("collection", "string", required=True),
+        ResourceCatalogField("mode", "string", default="insert", options=("insert", "upsert")), ResourceCatalogField("keys", "string_list"),
+        ResourceCatalogField("ordered", "boolean", default=True), ResourceCatalogField("batch_size", "integer", default=1000),
+    ), topology_fields=("collection", "mode", "keys", "batch_size"),
+)
+
+
+def _unique_strings(ctx: ResourceValidationContext, spec: Mapping[str, Any], key: str, *, default: Sequence[str] | None = None) -> list[str]:
+    if key not in spec and default is not None:
+        return list(default)
+    return ctx.require_non_empty_string_list(spec, key, field=f"{ctx.field}.{key}")
+
+
+def _validate_connector(ctx: ResourceValidationContext, spec: Mapping[str, Any]) -> None:
+    uri = ctx.require_string(spec, "uri")
+    ctx.require_string(spec, "database")
+    if urlparse(uri).scheme not in {"mongodb", "mongodb+srv"}:
+        raise ValueError(f"'{ctx.field}.uri' must be a MongoDB URI")
+    options = spec.get("client_options", {})
+    if not isinstance(options, Mapping):
+        raise TypeError(f"'{ctx.field}.client_options' must be a mapping")
+    query = parse_qs(urlparse(uri).query)
+    if options.get("w") in {0, "0"} or query.get("w") == ["0"]:
+        raise ValueError(f"'{ctx.field}' requires acknowledged write concern")
+
+
+def _validate_polling(ctx: ResourceValidationContext, spec: Mapping[str, Any]) -> None:
+    ctx.require_string(spec, "connector")
+    ctx.require_string(spec, "collection")
+    cursor = _unique_strings(ctx, spec, "cursor", default=("_id",))
+    if "_id" in cursor and cursor[-1] != "_id":
+        raise ValueError(f"'{ctx.field}.cursor' requires _id as the final component")
+    for key in ("filter", "projection"):
+        if key in spec and not isinstance(spec.get(key), Mapping):
+            raise TypeError(f"'{ctx.field}.{key}' must be a mapping")
+    ctx.validate_positive_integer(spec.get("batch_size"), field=f"{ctx.field}.batch_size")
+    ctx.validate_non_negative_number(spec.get("poll_interval_s"), field=f"{ctx.field}.poll_interval_s")
+    initial = spec.get("initial_cursor")
+    effective_length = len(cursor) if cursor[-1] == "_id" else len(cursor) + 1
+    if initial is not None and (not isinstance(initial, Sequence) or isinstance(initial, (str, bytes)) or len(initial) != effective_length):
+        raise ValueError(f"'{ctx.field}.initial_cursor' must match the effective cursor length")
+
+
+def _validate_change(ctx: ResourceValidationContext, spec: Mapping[str, Any]) -> None:
+    ctx.require_string(spec, "connector")
+    ctx.require_string(spec, "collection")
+    pipeline = spec.get("pipeline", [])
+    if not isinstance(pipeline, Sequence) or isinstance(pipeline, (str, bytes)) or any(not isinstance(stage, Mapping) for stage in pipeline):
+        raise TypeError(f"'{ctx.field}.pipeline' must be a list of mappings")
+    if spec.get("full_document", "updateLookup") not in {"default", "updateLookup", "whenAvailable", "required"}:
+        raise ValueError(f"'{ctx.field}.full_document' is invalid")
+    ctx.validate_positive_integer(spec.get("max_await_time_ms"), field=f"{ctx.field}.max_await_time_ms")
+    ctx.validate_positive_integer(spec.get("batch_size"), field=f"{ctx.field}.batch_size")
+    ctx.validate_non_negative_number(spec.get("poll_interval_s"), field=f"{ctx.field}.poll_interval_s")
+
+
+def _validate_sink(ctx: ResourceValidationContext, spec: Mapping[str, Any]) -> None:
+    ctx.require_string(spec, "connector")
+    ctx.require_string(spec, "collection")
+    mode = spec.get("mode", "insert")
+    if mode not in {"insert", "upsert"}:
+        raise ValueError(f"'{ctx.field}.mode' is invalid")
+    if mode == "upsert":
+        _unique_strings(ctx, spec, "keys")
+    elif "keys" in spec:
+        _unique_strings(ctx, spec, "keys")
+    ctx.validate_positive_integer(spec.get("batch_size"), field=f"{ctx.field}.batch_size")
+
+
+def _connector(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> MongoDBConnector:
+    value = ctx.resolve_dependency(spec, "connector")
+    if not isinstance(value, MongoDBConnector):
+        raise TypeError(f"resource {spec['connector']!r} is not a MongoDBConnector")
+    return value
+
+
+def _state(ctx: ResourceBuildContext, spec: Mapping[str, Any]):
+    name = spec.get("state")
+    if name is None:
+        return None
+    resolved_name = ctx.string_value(name, field=f"{ctx.field}.state")
+    value = ctx.resolve(resolved_name)
+    if not ctx.is_cursor_store(value):
+        raise TypeError(f"resource {resolved_name!r} is not a cursor store")
+    return value
+
+
+def _build_connector(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> MongoDBConnector:
+    return MongoDBConnector(ctx.require_string(spec, "uri"), database=ctx.require_string(spec, "database"), client_options=ctx.mapping_value(spec.get("client_options"), field=f"{ctx.field}.client_options"))
+
+
+def _build_polling(ctx: ResourceBuildContext, spec: Mapping[str, Any]):
+    return _connector(ctx, spec).poll_collection(
+        ctx.require_string(spec, "collection"), cursor=tuple(ctx.string_list(spec.get("cursor", ["_id"]), field=f"{ctx.field}.cursor")),
+        filter=ctx.mapping_value(spec.get("filter"), field=f"{ctx.field}.filter"), projection=ctx.mapping_value(spec.get("projection"), field=f"{ctx.field}.projection"),
+        batch_size=spec.get("batch_size", 100), poll_interval_s=spec.get("poll_interval_s", 1.0), state=_state(ctx, spec), state_key=spec.get("state_key"), initial_cursor=spec.get("initial_cursor"),
+    )
+
+
+def _build_change(ctx: ResourceBuildContext, spec: Mapping[str, Any]):
+    pipeline = spec.get("pipeline", [])
+    return _connector(ctx, spec).watch_collection(
+        ctx.require_string(spec, "collection"), pipeline=[dict(stage) for stage in pipeline], full_document=spec.get("full_document", "updateLookup"),
+        max_await_time_ms=spec.get("max_await_time_ms", 1000), batch_size=spec.get("batch_size", 100), poll_interval_s=spec.get("poll_interval_s", 0.1),
+        state=_state(ctx, spec), state_key=spec.get("state_key"),
+    )
+
+
+def _build_sink(ctx: ResourceBuildContext, spec: Mapping[str, Any]):
+    keys = tuple(ctx.string_list(spec.get("keys"), field=f"{ctx.field}.keys")) if spec.get("keys") is not None else ()
+    return _connector(ctx, spec).collection_sink(ctx.require_string(spec, "collection"), mode=spec.get("mode", "insert"), keys=keys, ordered=spec.get("ordered", True), batch_size=spec.get("batch_size", 1000))
 
 
 def register_resources(registry: ResourceRegistry) -> None:
-    return None
+    registry.register_resource_type(ResourceSpecHandler(type="mongodb", catalog=CONNECTOR_CATALOG, allowed_fields=CONNECTOR_FIELDS, build=_build_connector, validate=_validate_connector))
+    registry.register_resource_type(ResourceSpecHandler(type="mongodb_polling", catalog=POLLING_CATALOG, allowed_fields=POLLING_FIELDS, build=_build_polling, validate=_validate_polling))
+    registry.register_resource_type(ResourceSpecHandler(type="mongodb_change_stream", catalog=CHANGE_CATALOG, allowed_fields=CHANGE_FIELDS, build=_build_change, validate=_validate_change))
+    registry.register_resource_type(ResourceSpecHandler(type="mongodb_collection_sink", catalog=SINK_CATALOG, allowed_fields=SINK_FIELDS, build=_build_sink, validate=_validate_sink))

--- a/plugins/onestep-mongodb/src/onestep_mongodb/state_codec.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/state_codec.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/plugins/onestep-mongodb/src/onestep_mongodb/state_codec.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/state_codec.py
@@ -1,1 +1,19 @@
 from __future__ import annotations
+
+import json
+from typing import Any
+
+from bson import json_util
+
+
+def encode_state(value: Any) -> dict[str, Any]:
+    return {"extended_json": json.loads(json_util.dumps(value, json_options=json_util.CANONICAL_JSON_OPTIONS))}
+
+
+def decode_state(value: Any) -> Any:
+    if not isinstance(value, dict) or "extended_json" not in value:
+        raise ValueError("MongoDB state must contain extended_json")
+    return json_util.loads(
+        json.dumps(value["extended_json"]),
+        json_options=json_util.JSONOptions(tz_aware=True),
+    )

--- a/plugins/onestep-mongodb/tests/integration/test_mongodb_live.py
+++ b/plugins/onestep-mongodb/tests/integration/test_mongodb_live.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import pytest
+from pymongo import AsyncMongoClient
+
+from onestep import Envelope
+from onestep_mongodb import MongoDBConnector
+
+URI = os.getenv("ONESTEP_MONGODB_URI")
+pytestmark = [pytest.mark.integration, pytest.mark.skipif(not URI, reason="ONESTEP_MONGODB_URI is not configured")]
+
+
+class DurableTestStore:
+    def __init__(self) -> None:
+        self.values = {}
+
+    async def load(self, key):
+        return self.values.get(key)
+
+    async def save(self, key, value):
+        self.values[key] = value
+
+
+async def _next_delivery(source, *, attempts=20):
+    for _ in range(attempts):
+        deliveries = await source.fetch(10)
+        if deliveries:
+            return deliveries[0]
+        await asyncio.sleep(0.05)
+    raise AssertionError("change stream produced no delivery")
+
+
+@pytest.mark.asyncio
+async def test_polling_restart_reads_only_later_documents() -> None:
+    name = f"poll_{uuid.uuid4().hex}"
+    client = AsyncMongoClient(URI)
+    database = client.get_default_database()
+    collection = database[name]
+    store = DurableTestStore()
+    await collection.insert_many([{"event_id": "one", "updated_at": 1}, {"event_id": "two", "updated_at": 2}])
+    connector = MongoDBConnector(URI, database=database.name, client=client)
+    first_source = connector.poll_collection(name, cursor=("updated_at", "_id"), state=store, state_key=name)
+    try:
+        deliveries = await first_source.fetch(10)
+        for delivery in deliveries:
+            await delivery.ack()
+        await collection.insert_one({"event_id": "three", "updated_at": 3})
+        second_source = connector.poll_collection(name, cursor=("updated_at", "_id"), state=store, state_key=name)
+        restarted = await second_source.fetch(10)
+        assert [item.payload["event_id"] for item in restarted] == ["three"]
+    finally:
+        await collection.drop()
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_insert_and_stable_key_upsert_are_acknowledged() -> None:
+    name = f"sink_{uuid.uuid4().hex}"
+    client = AsyncMongoClient(URI)
+    database = client.get_default_database()
+    collection = database[name]
+    connector = MongoDBConnector(URI, database=database.name, client=client)
+    try:
+        await connector.collection_sink(name).send(Envelope(body={"_id": "stable", "value": 1}))
+        upsert = connector.collection_sink(name, mode="upsert", keys=("event_id",))
+        await upsert.send(Envelope(body={"event_id": "evt", "value": 2}))
+        await upsert.send(Envelope(body={"event_id": "evt", "value": 3}))
+        assert (await collection.find_one({"_id": "stable"}))["value"] == 1
+        assert (await collection.find_one({"event_id": "evt"}))["value"] == 3
+    finally:
+        await collection.drop()
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_raw_change_events_include_update_lookup_and_delete_key() -> None:
+    name = f"changes_{uuid.uuid4().hex}"
+    client = AsyncMongoClient(URI)
+    database = client.get_default_database()
+    collection = database[name]
+    connector = MongoDBConnector(URI, database=database.name, client=client)
+    source = connector.watch_collection(name)
+    await source.open()
+    try:
+        inserted = await collection.insert_one({"value": 1})
+        insert_event = await _next_delivery(source)
+        await insert_event.ack()
+        await collection.update_one({"_id": inserted.inserted_id}, {"$set": {"value": 2}})
+        update_event = await _next_delivery(source)
+        await update_event.ack()
+        await collection.delete_one({"_id": inserted.inserted_id})
+        delete_event = await _next_delivery(source)
+        await delete_event.ack()
+        assert insert_event.payload["operationType"] == "insert" and "_id" in insert_event.payload
+        assert update_event.payload["operationType"] == "update" and update_event.payload["fullDocument"]["value"] == 2
+        assert delete_event.payload["operationType"] == "delete"
+        assert delete_event.payload["documentKey"] == {"_id": inserted.inserted_id}
+    finally:
+        await source.close()
+        await collection.drop()
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_change_stream_resumes_after_acknowledged_token() -> None:
+    name = f"resume_{uuid.uuid4().hex}"
+    state_key = f"state-{name}"
+    store = DurableTestStore()
+    client = AsyncMongoClient(URI)
+    database = client.get_default_database()
+    collection = database[name]
+    connector = MongoDBConnector(URI, database=database.name, client=client)
+    first_source = connector.watch_collection(name, state=store, state_key=state_key)
+    await first_source.open()
+    try:
+        await collection.insert_one({"sequence": 1})
+        first = await _next_delivery(first_source)
+        await first.ack()
+        await first_source.close()
+        second_source = connector.watch_collection(name, state=store, state_key=state_key)
+        await second_source.open()
+        await collection.insert_one({"sequence": 2})
+        second = await _next_delivery(second_source)
+        assert second.payload["fullDocument"]["sequence"] == 2
+        await second.ack()
+        await second_source.close()
+    finally:
+        await collection.drop()
+        await client.close()

--- a/plugins/onestep-mongodb/tests/test_mongodb_change_stream.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_change_stream.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import pytest
+from bson import ObjectId
+
+from onestep_mongodb import MongoDBConnector
+from onestep_mongodb.state_codec import decode_state, encode_state
+
+
+class RecordingStore:
+    def __init__(self, loaded=None) -> None:
+        self.loaded = loaded
+        self.saved: list[tuple[str, object]] = []
+
+    async def load(self, key):
+        return self.loaded
+
+    async def save(self, key, value):
+        self.saved.append((key, value))
+        self.loaded = value
+
+
+class FakeChangeStream:
+    def __init__(self, events) -> None:
+        self.events = list(events)
+        self.closed = False
+
+    async def try_next(self):
+        return self.events.pop(0) if self.events else None
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeWatchCollection:
+    def __init__(self, streams) -> None:
+        self.streams = list(streams)
+        self.watch_calls: list[dict] = []
+
+    async def watch(self, pipeline, **options):
+        self.watch_calls.append({"pipeline": pipeline, **options})
+        return self.streams.pop(0)
+
+
+class FakeWatchDatabase:
+    def __init__(self, collection) -> None:
+        self.collection = collection
+
+    def __getitem__(self, name):
+        return self.collection
+
+
+class FakeWatchClient:
+    def __init__(self, collection) -> None:
+        self.database = FakeWatchDatabase(collection)
+
+    def __getitem__(self, name):
+        return self.database
+
+
+def _event(hex_id: str, operation: str):
+    object_id = ObjectId(hex_id)
+    return {"_id": {"token": hex_id}, "operationType": operation, "documentKey": {"_id": object_id}}
+
+
+@pytest.mark.asyncio
+async def test_default_watch_emits_complete_raw_delete_event() -> None:
+    raw_event = _event("64b64c1234567890abcdef12", "delete")
+    stream = FakeChangeStream([raw_event])
+    collection = FakeWatchCollection([stream])
+    connector = MongoDBConnector("mongodb://local", database="app", client=FakeWatchClient(collection))
+    source = connector.watch_collection("events")
+
+    delivery = (await source.fetch(1))[0]
+
+    assert collection.watch_calls[0]["full_document"] == "updateLookup"
+    assert "resume_after" not in collection.watch_calls[0]
+    assert delivery.envelope.body == raw_event
+    assert delivery.envelope.body["operationType"] == "delete"
+    assert delivery.envelope.body["documentKey"] == {"_id": raw_event["documentKey"]["_id"]}
+
+
+@pytest.mark.asyncio
+async def test_restart_passes_decoded_resume_token() -> None:
+    token = {"token": "persisted"}
+    store = RecordingStore(encode_state(token))
+    collection = FakeWatchCollection([FakeChangeStream([])])
+    source = MongoDBConnector("mongodb://local", database="app", client=FakeWatchClient(collection)).watch_collection("events", state=store)
+
+    await source.fetch(1)
+
+    assert collection.watch_calls[0]["resume_after"] == token
+
+
+@pytest.mark.asyncio
+async def test_change_tokens_persist_only_after_contiguous_ack() -> None:
+    first_event = _event("64b64c1234567890abcdef12", "insert")
+    second_event = _event("64b64c1234567890abcdef13", "update")
+    store = RecordingStore()
+    collection = FakeWatchCollection([FakeChangeStream([first_event, second_event])])
+    source = MongoDBConnector("mongodb://local", database="app", client=FakeWatchClient(collection)).watch_collection("events", state=store)
+    first, second = await source.fetch(2)
+
+    await second.ack()
+    assert store.saved == []
+    await first.ack()
+
+    assert decode_state(store.saved[-1][1]) == second_event["_id"]
+
+
+@pytest.mark.asyncio
+async def test_retry_closes_stream_and_waits_for_stale_delivery() -> None:
+    first_stream = FakeChangeStream([_event("64b64c1234567890abcdef12", "insert"), _event("64b64c1234567890abcdef13", "update")])
+    replacement = FakeChangeStream([])
+    collection = FakeWatchCollection([first_stream, replacement])
+    store = RecordingStore()
+    source = MongoDBConnector("mongodb://local", database="app", client=FakeWatchClient(collection)).watch_collection("events", state=store)
+    first, second = await source.fetch(2)
+
+    await first.retry()
+    assert first_stream.closed is True
+    assert await source.fetch(2) == []
+    assert len(collection.watch_calls) == 1
+    await second.release_unstarted()
+    await source.fetch(2)
+
+    assert store.saved == []
+    assert len(collection.watch_calls) == 2
+    assert "resume_after" not in collection.watch_calls[1]
+
+
+from pymongo.errors import OperationFailure
+from onestep import ConnectorErrorKind, ConnectorOperationError
+
+
+@pytest.mark.asyncio
+async def test_history_lost_is_permanent_and_never_falls_back_to_now() -> None:
+    class HistoryLostStream(FakeChangeStream):
+        async def try_next(self):
+            raise OperationFailure("resume history lost", code=286)
+
+    collection = FakeWatchCollection([HistoryLostStream([])])
+    store = RecordingStore(encode_state({"token": "old"}))
+    source = MongoDBConnector("mongodb://local", database="app", client=FakeWatchClient(collection)).watch_collection("events", state=store)
+
+    with pytest.raises(ConnectorOperationError) as captured:
+        await source.fetch(1)
+
+    assert captured.value.kind is ConnectorErrorKind.PERMANENT
+    assert "reset durable resume state" in str(captured.value)
+    assert len(collection.watch_calls) == 1
+    assert collection.watch_calls[0]["resume_after"] == {"token": "old"}
+
+
+@pytest.mark.asyncio
+async def test_resumable_stream_failure_reopens_from_committed_token() -> None:
+    class ResumableStream(FakeChangeStream):
+        async def try_next(self):
+            raise OperationFailure(
+                "temporary stream failure",
+                details={"errorLabels": ["ResumableChangeStreamError"]},
+            )
+
+    token = {"token": "persisted"}
+    collection = FakeWatchCollection([ResumableStream([]), FakeChangeStream([])])
+    source = MongoDBConnector("mongodb://local", database="app", client=FakeWatchClient(collection)).watch_collection(
+        "events", state=RecordingStore(encode_state(token))
+    )
+
+    with pytest.raises(ConnectorOperationError) as captured:
+        await source.fetch(1)
+    assert captured.value.kind is ConnectorErrorKind.TRANSIENT
+
+    assert await source.fetch(1) == []
+    assert len(collection.watch_calls) == 2
+    assert collection.watch_calls[1]["resume_after"] == token

--- a/plugins/onestep-mongodb/tests/test_mongodb_plugin.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_plugin.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from importlib import metadata as importlib_metadata
+
+from onestep_mongodb import (
+    MongoDBChangeStreamDelivery,
+    MongoDBChangeStreamSource,
+    MongoDBCollectionSink,
+    MongoDBConnector,
+    MongoDBPayloadError,
+    MongoDBPollingDelivery,
+    MongoDBPollingSource,
+    register,
+    register_resources,
+)
+
+
+def test_public_surface_and_entry_point() -> None:
+    assert register is register_resources
+    assert MongoDBConnector.__name__ == "MongoDBConnector"
+    assert MongoDBPollingSource.__name__ == "MongoDBPollingSource"
+    assert MongoDBPollingDelivery.__name__ == "MongoDBPollingDelivery"
+    assert MongoDBChangeStreamSource.__name__ == "MongoDBChangeStreamSource"
+    assert MongoDBChangeStreamDelivery.__name__ == "MongoDBChangeStreamDelivery"
+    assert MongoDBCollectionSink.__name__ == "MongoDBCollectionSink"
+    assert MongoDBPayloadError.__name__ == "MongoDBPayloadError"
+    entries = importlib_metadata.entry_points()
+    selected = entries.select(group="onestep.resources") if hasattr(entries, "select") else entries.get("onestep.resources", ())
+    assert any(item.name == "mongodb" and item.value == "onestep_mongodb:register" for item in selected)

--- a/plugins/onestep-mongodb/tests/test_mongodb_plugin.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_plugin.py
@@ -14,6 +14,11 @@ from onestep_mongodb import (
     register_resources,
 )
 
+import pytest
+
+from onestep import InMemoryCursorStore, ResourceBuildContext, ResourceRegistry, load_app_config
+from onestep_mongodb.resources import _build_polling
+
 
 def test_public_surface_and_entry_point() -> None:
     assert register is register_resources
@@ -27,3 +32,56 @@ def test_public_surface_and_entry_point() -> None:
     entries = importlib_metadata.entry_points()
     selected = entries.select(group="onestep.resources") if hasattr(entries, "select") else entries.get("onestep.resources", ())
     assert any(item.name == "mongodb" and item.value == "onestep_mongodb:register" for item in selected)
+
+
+def _config(resources):
+    return {"apiVersion": "onestep/v1alpha1", "kind": "App", "app": {"name": "mongo"}, "resources": resources, "tasks": []}
+
+
+def test_catalog_roles_and_topology_are_exact() -> None:
+    registry = ResourceRegistry()
+    register(registry)
+    catalog = {entry.type: entry for entry in registry.catalog_entries()}
+    assert catalog["mongodb"].roles == ("connector",)
+    assert catalog["mongodb_polling"].topology_fields == ("collection", "cursor", "batch_size", "poll_interval_s")
+    assert catalog["mongodb_change_stream"].topology_fields == ("collection", "full_document", "batch_size", "max_await_time_ms")
+    assert catalog["mongodb_collection_sink"].topology_fields == ("collection", "mode", "keys", "batch_size")
+
+
+def test_strict_yaml_builds_all_resource_roles() -> None:
+    app = load_app_config(_config({
+        "mongo": {"type": "mongodb", "uri": "mongodb://localhost/app?replicaSet=rs0", "database": "app"},
+        "poll": {"type": "mongodb_polling", "connector": "mongo", "collection": "events", "cursor": ["updated_at", "_id"]},
+        "changes": {"type": "mongodb_change_stream", "connector": "mongo", "collection": "events", "full_document": "updateLookup"},
+        "sink": {"type": "mongodb_collection_sink", "connector": "mongo", "collection": "archive", "mode": "upsert", "keys": ["event_id"]},
+    }), strict=True)
+    assert isinstance(app.resources["mongo"], MongoDBConnector)
+    assert isinstance(app.resources["poll"], MongoDBPollingSource)
+    assert isinstance(app.resources["changes"], MongoDBChangeStreamSource)
+    assert isinstance(app.resources["sink"], MongoDBCollectionSink)
+
+
+def test_polling_builder_accepts_cursor_store_capability() -> None:
+    connector = MongoDBConnector("mongodb://localhost", database="app", client=object())
+    store = InMemoryCursorStore()
+    values = {"mongo": connector, "state": store}
+    ctx = ResourceBuildContext(name="poll", type="mongodb_polling", field="resources.poll", _resolve=values.__getitem__)
+    source = _build_polling(ctx, {"type": "mongodb_polling", "connector": "mongo", "collection": "events", "state": "state"})
+    assert source.state is store
+
+
+@pytest.mark.parametrize("resource", [
+    {"type": "mongodb", "uri": "mongodb://localhost/app?w=0", "database": "app"},
+    {"type": "mongodb_polling", "connector": "mongo", "collection": "events", "cursor": ["updated_at", "updated_at"]},
+    {"type": "mongodb_polling", "connector": "mongo", "collection": "events", "cursor": ["_id", "updated_at"]},
+    {"type": "mongodb_change_stream", "connector": "mongo", "collection": "events", "pipeline": {}},
+    {"type": "mongodb_change_stream", "connector": "mongo", "collection": "events", "full_document": "lookup"},
+    {"type": "mongodb_collection_sink", "connector": "mongo", "collection": "events", "mode": "upsert"},
+    {"type": "mongodb_collection_sink", "connector": "mongo", "collection": "events", "unknown": True},
+])
+def test_strict_yaml_rejects_invalid_resource(resource) -> None:
+    resources = {"mongo": {"type": "mongodb", "uri": "mongodb://localhost", "database": "app"}, "target": resource}
+    if resource["type"] == "mongodb":
+        resources = {"mongo": resource}
+    with pytest.raises((TypeError, ValueError)):
+        load_app_config(_config(resources), strict=True)

--- a/plugins/onestep-mongodb/tests/test_mongodb_polling.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_polling.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from bson import ObjectId
+
+from onestep_mongodb.connector import _ContiguousGenerationTracker
+from onestep_mongodb.state_codec import decode_state, encode_state
+
+
+def test_extended_json_round_trips_bson_values() -> None:
+    value = [ObjectId("64b64c1234567890abcdef12"), datetime(2026, 7, 27, tzinfo=timezone.utc)]
+    encoded = encode_state(value)
+    assert isinstance(encoded, dict)
+    assert decode_state(encoded) == value
+
+
+@pytest.mark.asyncio
+async def test_out_of_order_ack_does_not_cross_gap() -> None:
+    saved: list[object] = []
+
+    async def save(token):
+        saved.append(token)
+
+    tracker = _ContiguousGenerationTracker(save)
+    first = tracker.add("one")
+    second = tracker.add("two")
+    await tracker.complete(second, advance=True)
+    assert saved == []
+    await tracker.complete(first, advance=True)
+    assert saved == ["two"]
+
+
+@pytest.mark.asyncio
+async def test_invalidated_generation_ignores_late_ack_and_blocks_reopen() -> None:
+    saved: list[object] = []
+    tracker = _ContiguousGenerationTracker(lambda token: _append(saved, token))
+    first = tracker.add("one")
+    second = tracker.add("two")
+    await tracker.invalidate(first.generation)
+    assert tracker.can_fetch is False
+    await tracker.complete(first, advance=True)
+    assert saved == [] and tracker.can_fetch is False
+    await tracker.complete(second, advance=False)
+    assert tracker.can_fetch is True
+
+
+async def _append(values, value):
+    values.append(value)

--- a/plugins/onestep-mongodb/tests/test_mongodb_polling.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_polling.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone
 import pytest
 from bson import ObjectId
 
+from onestep import InMemoryCursorStore
+from onestep_mongodb import MongoDBConnector
 from onestep_mongodb.connector import _ContiguousGenerationTracker
 from onestep_mongodb.state_codec import decode_state, encode_state
 
@@ -48,3 +50,174 @@ async def test_invalidated_generation_ignores_late_ack_and_blocks_reopen() -> No
 
 async def _append(values, value):
     values.append(value)
+
+
+def test_composite_keyset_query_is_lexicographic() -> None:
+    source = MongoDBConnector("mongodb://local", database="app", client=object()).poll_collection("events", cursor=("updated_at", "_id"))
+    query = source._cursor_query((10, ObjectId("64b64c1234567890abcdef12")))
+    assert query == {"$or": [
+        {"updated_at": {"$gt": 10}},
+        {"updated_at": 10, "_id": {"$gt": ObjectId("64b64c1234567890abcdef12")}},
+    ]}
+
+
+def test_filter_combines_with_keyset_under_and() -> None:
+    source = MongoDBConnector("mongodb://local", database="app", client=object()).poll_collection("events", cursor=("updated_at",), filter={"archived": False})
+    query = source._query((10, ObjectId("64b64c1234567890abcdef12")))
+    assert query == {"$and": [{"archived": False}, {"$or": [{"updated_at": {"$gt": 10}}, {"updated_at": 10, "_id": {"$gt": ObjectId("64b64c1234567890abcdef12")}}]}]}
+
+
+def test_id_must_be_final_when_explicit() -> None:
+    with pytest.raises(ValueError, match="final"):
+        MongoDBConnector("mongodb://local", database="app", client=object()).poll_collection("events", cursor=("_id", "updated_at"))
+
+
+class RecordingStore:
+    def __init__(self, loaded=None) -> None:
+        self.loaded = loaded
+        self.saved: list[tuple[str, object]] = []
+
+    async def load(self, key):
+        return self.loaded
+
+    async def save(self, key, value):
+        self.saved.append((key, value))
+        self.loaded = value
+
+
+class FakeCursor:
+    def __init__(self, documents) -> None:
+        self.documents = list(documents)
+        self.sort_value = None
+        self.limit_value = None
+
+    def sort(self, value):
+        self.sort_value = value
+        return self
+
+    def limit(self, value):
+        self.limit_value = value
+        self.documents = self.documents[:value]
+        return self
+
+    def __aiter__(self):
+        self._iterator = iter(self.documents)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iterator)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class FakeCollection:
+    def __init__(self, documents) -> None:
+        self.documents = list(documents)
+        self.find_calls: list[tuple[dict, object, FakeCursor]] = []
+
+    def find(self, query, projection):
+        cursor = FakeCursor(self.documents)
+        self.find_calls.append((query, projection, cursor))
+        return cursor
+
+
+class FakeDatabase:
+    def __init__(self, collection) -> None:
+        self.collection = collection
+
+    def __getitem__(self, name):
+        return self.collection
+
+
+class FakeClient:
+    def __init__(self, collection) -> None:
+        self.database = FakeDatabase(collection)
+
+    def __getitem__(self, name):
+        return self.database
+
+
+@pytest.mark.asyncio
+async def test_polling_persists_only_the_contiguous_ack_prefix() -> None:
+    documents = [
+        {"_id": ObjectId("64b64c1234567890abcdef12"), "updated_at": 1},
+        {"_id": ObjectId("64b64c1234567890abcdef13"), "updated_at": 2},
+    ]
+    store = RecordingStore()
+    collection = FakeCollection(documents)
+    connector = MongoDBConnector("mongodb://local", database="app", client=FakeClient(collection))
+    source = connector.poll_collection("events", cursor=("updated_at", "_id"), state=store)
+
+    first, second = await source.fetch(2)
+    await second.ack()
+    assert store.saved == []
+    await first.ack()
+    assert decode_state(store.saved[-1][1]) == [2, documents[1]["_id"]]
+    assert collection.find_calls[0][2].sort_value == [("updated_at", 1), ("_id", 1)]
+    assert collection.find_calls[0][2].limit_value == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_waits_for_stale_generation_then_replays_committed_state() -> None:
+    documents = [
+        {"_id": ObjectId("64b64c1234567890abcdef12"), "updated_at": 1},
+        {"_id": ObjectId("64b64c1234567890abcdef13"), "updated_at": 2},
+    ]
+    store = RecordingStore()
+    collection = FakeCollection(documents)
+    source = MongoDBConnector("mongodb://local", database="app", client=FakeClient(collection)).poll_collection(
+        "events", cursor=("updated_at", "_id"), state=store
+    )
+
+    first, second = await source.fetch(2)
+    await first.retry()
+    assert await source.fetch(2) == []
+    await second.fail(RuntimeError("terminal stale handler"))
+    await source.fetch(2)
+
+    assert store.saved == []
+    assert collection.find_calls[-1][0] == {}
+
+
+@pytest.mark.asyncio
+async def test_terminal_fail_advances_polling_cursor() -> None:
+    document = {"_id": ObjectId("64b64c1234567890abcdef12"), "updated_at": 1}
+    store = RecordingStore()
+    source = MongoDBConnector("mongodb://local", database="app", client=FakeClient(FakeCollection([document]))).poll_collection(
+        "events", cursor=("updated_at", "_id"), state=store
+    )
+    delivery = (await source.fetch(1))[0]
+    await delivery.fail(RuntimeError("terminal handler failure"))
+    assert decode_state(store.saved[-1][1]) == [1, document["_id"]]
+
+
+@pytest.mark.asyncio
+async def test_owned_client_is_lazy_and_closes_once(monkeypatch) -> None:
+    import pymongo
+
+    collection = FakeCollection([])
+
+    class OwnedClient(FakeClient):
+        def __init__(self):
+            super().__init__(collection)
+            self.close_calls = 0
+
+        async def close(self):
+            self.close_calls += 1
+
+    client = OwnedClient()
+    factory_calls = []
+
+    def build_client(uri, **options):
+        factory_calls.append((uri, options))
+        return client
+
+    monkeypatch.setattr(pymongo, "AsyncMongoClient", build_client)
+    connector = MongoDBConnector("mongodb://local", database="app")
+    assert factory_calls == []
+    assert connector.collection("events") is collection
+    assert factory_calls == [("mongodb://local", {})]
+    await connector.close()
+    await connector.close()
+    assert client.close_calls == 1

--- a/plugins/onestep-mongodb/tests/test_mongodb_resilience.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_resilience.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from pymongo.errors import AutoReconnect, BulkWriteError, DuplicateKeyError, OperationFailure
+from bson.errors import InvalidDocument
+from pymongo.errors import AutoReconnect, BulkWriteError, DuplicateKeyError, ExecutionTimeout, NetworkTimeout, OperationFailure, ServerSelectionTimeoutError
 
 from onestep import ConnectorErrorKind
-from onestep_mongodb.resilience import classify_mongodb_error
+from onestep_mongodb.resilience import classify_mongodb_error, redacted_mongodb_cause
 
 
 def test_driver_error_classes() -> None:
@@ -13,3 +14,20 @@ def test_driver_error_classes() -> None:
     assert classify_mongodb_error(OperationFailure("auth", code=18), operation="open") is ConnectorErrorKind.MISCONFIGURED
     assert classify_mongodb_error(OperationFailure("history", code=286), operation="fetch") is ConnectorErrorKind.PERMANENT
     assert classify_mongodb_error(BulkWriteError({"writeErrors": [{"index": 0, "code": 16500, "errmsg": "busy"}]}), operation="send") is ConnectorErrorKind.THROTTLED
+
+
+def test_specific_timeout_classes_are_not_shadowed_by_parent_classes() -> None:
+    assert classify_mongodb_error(ServerSelectionTimeoutError("selection"), operation="send") is ConnectorErrorKind.DISCONNECTED
+    assert classify_mongodb_error(NetworkTimeout("fetch timed out"), operation="fetch") is ConnectorErrorKind.DISCONNECTED
+    assert classify_mongodb_error(ExecutionTimeout("query timed out"), operation="fetch") is ConnectorErrorKind.TRANSIENT
+
+
+def test_redacted_cause_does_not_retain_credentials_or_invalid_documents() -> None:
+    connection = redacted_mongodb_cause(AutoReconnect("mongodb://writer:top-secret@mongo/app disconnected"))
+    assert "top-secret" not in str(connection)
+    assert "writer" not in str(connection)
+
+    invalid = InvalidDocument("Invalid document {'password': 'document-secret'}")
+    payload = redacted_mongodb_cause(invalid)
+    assert classify_mongodb_error(invalid, operation="send") is ConnectorErrorKind.PERMANENT
+    assert "document-secret" not in str(payload)

--- a/plugins/onestep-mongodb/tests/test_mongodb_resilience.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_resilience.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pymongo.errors import AutoReconnect, BulkWriteError, DuplicateKeyError, OperationFailure
+
+from onestep import ConnectorErrorKind
+from onestep_mongodb.resilience import classify_mongodb_error
+
+
+def test_driver_error_classes() -> None:
+    assert classify_mongodb_error(AutoReconnect("lost after submit"), operation="send") is ConnectorErrorKind.UNCERTAIN
+    assert classify_mongodb_error(AutoReconnect("selection"), operation="fetch") is ConnectorErrorKind.DISCONNECTED
+    assert classify_mongodb_error(DuplicateKeyError("duplicate"), operation="send") is ConnectorErrorKind.PERMANENT
+    assert classify_mongodb_error(OperationFailure("auth", code=18), operation="open") is ConnectorErrorKind.MISCONFIGURED
+    assert classify_mongodb_error(OperationFailure("history", code=286), operation="fetch") is ConnectorErrorKind.PERMANENT
+    assert classify_mongodb_error(BulkWriteError({"writeErrors": [{"index": 0, "code": 16500, "errmsg": "busy"}]}), operation="send") is ConnectorErrorKind.THROTTLED

--- a/plugins/onestep-mongodb/tests/test_mongodb_runtime_contract.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_runtime_contract.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from bson import ObjectId
+
+from onestep import Delivery, Envelope, OneStepApp, Source
+from onestep_mongodb import MongoDBConnector
+
+
+class Store:
+    def __init__(self) -> None:
+        self.saved = []
+
+    async def load(self, key):
+        return None
+
+    async def save(self, key, value):
+        self.saved.append((key, value))
+
+
+class BlockingCursor:
+    def __init__(self, document, started, release) -> None:
+        self.document = document
+        self.started = started
+        self.release = release
+        self.yielded = False
+
+    def sort(self, value):
+        return self
+
+    def limit(self, value):
+        return self
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self.yielded:
+            raise StopAsyncIteration
+        self.started.set()
+        await self.release.wait()
+        self.yielded = True
+        return self.document
+
+
+class BlockingStream:
+    def __init__(self, event, started, release) -> None:
+        self.event = event
+        self.started = started
+        self.release = release
+        self.returned = False
+        self.closed = False
+
+    async def try_next(self):
+        self.started.set()
+        await self.release.wait()
+        if self.returned:
+            return None
+        self.returned = True
+        return self.event
+
+    async def close(self):
+        self.closed = True
+
+
+class RuntimeCollection:
+    def __init__(self, *, document=None, event=None, started, release) -> None:
+        self.document = document
+        self.event = event
+        self.started = started
+        self.release = release
+
+    def find(self, query, projection):
+        return BlockingCursor(self.document, self.started, self.release)
+
+    async def watch(self, pipeline, **options):
+        return BlockingStream(self.event, self.started, self.release)
+
+
+class Database:
+    def __init__(self, collection) -> None:
+        self.collection = collection
+
+    def __getitem__(self, name):
+        return self.collection
+
+
+class Client:
+    def __init__(self, collection) -> None:
+        self.database = Database(collection)
+
+    def __getitem__(self, name):
+        return self.database
+
+
+async def _request_stop(app, action):
+    if action == "shutdown":
+        app.request_shutdown()
+        return
+    if action == "drain":
+        app.request_drain()
+        await app.wait_for_drain()
+        app.request_shutdown()
+        return
+    app.request_task_pause("consume")
+    await app.wait_for_task_pause("consume")
+    app.request_shutdown()
+
+
+@pytest.mark.parametrize("source_kind", ["polling", "change_stream"])
+@pytest.mark.parametrize("action", ["shutdown", "drain", "pause"])
+@pytest.mark.asyncio
+async def test_stop_controls_release_unstarted_without_committing(source_kind, action) -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+    store = Store()
+    object_id = ObjectId("64b64c1234567890abcdef12")
+    collection = RuntimeCollection(
+        document={"_id": object_id, "updated_at": 1},
+        event={"_id": {"token": "one"}, "operationType": "insert", "documentKey": {"_id": object_id}},
+        started=started,
+        release=release,
+    )
+    connector = MongoDBConnector("mongodb://local", database="app", client=Client(collection))
+    source = connector.poll_collection("events", cursor=("updated_at", "_id"), state=store) if source_kind == "polling" else connector.watch_collection("events", state=store)
+    assert source.fetch_is_cancel_safe is False
+    handled = []
+    app = OneStepApp(f"mongo-{source_kind}-{action}", shutdown_timeout_s=1.0)
+
+    @app.task(source=source, name="consume", concurrency=1)
+    async def consume(ctx, item):
+        handled.append(item)
+
+    serving = asyncio.create_task(app.serve())
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    stopping = asyncio.create_task(_request_stop(app, action))
+    await asyncio.sleep(0)
+    release.set()
+    await asyncio.wait_for(stopping, timeout=2.0)
+    await asyncio.wait_for(serving, timeout=2.0)
+
+    assert handled == []
+    assert store.saved == []
+    assert source._tracker.can_fetch is True
+
+
+class AckRecordingDelivery(Delivery):
+    def __init__(self, envelope: Envelope) -> None:
+        super().__init__(envelope)
+        self.acked = False
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def retry(self, *, delay_s=None) -> None:
+        raise AssertionError("must not retry")
+
+    async def fail(self, exc=None) -> None:
+        raise AssertionError(f"unexpected failure: {exc}")
+
+
+class OneShotSource(Source):
+    poll_interval_s = 0.01
+
+    def __init__(self, delivery) -> None:
+        super().__init__("one-shot")
+        self.delivery = delivery
+        self.sent = False
+
+    async def fetch(self, limit):
+        if self.sent:
+            return []
+        self.sent = True
+        return [self.delivery]
+
+
+class BlockingSinkCollection:
+    class WriteConcern:
+        acknowledged = True
+
+    write_concern = WriteConcern()
+
+    def __init__(self, entered, release) -> None:
+        self.entered = entered
+        self.release = release
+
+    async def insert_one(self, document):
+        self.entered.set()
+        await self.release.wait()
+        return object()
+
+
+@pytest.mark.asyncio
+async def test_runtime_ack_follows_mongodb_write_acknowledgement() -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    collection = BlockingSinkCollection(entered, release)
+    connector = MongoDBConnector("mongodb://local", database="app", client=Client(collection))
+    sink = connector.collection_sink("events")
+    delivery = AckRecordingDelivery(Envelope(body={"_id": "one"}))
+    app = OneStepApp("mongodb-sink-runtime-order", shutdown_timeout_s=1.0)
+
+    @app.task(source=OneShotSource(delivery), emit=sink, concurrency=1)
+    async def forward(ctx, item):
+        ctx.app.request_shutdown()
+        return item
+
+    serving = asyncio.create_task(app.serve())
+    await entered.wait()
+    assert delivery.acked is False
+    release.set()
+    await asyncio.wait_for(serving, timeout=2.0)
+    assert delivery.acked is True

--- a/plugins/onestep-mongodb/tests/test_mongodb_sink.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_sink.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import pytest
+from pymongo.errors import BulkWriteError
+
+from onestep import ConnectorErrorKind, ConnectorOperationError, Envelope
+from onestep_mongodb import MongoDBConnector, MongoDBPayloadError
+
+
+class FakeWriteConcern:
+    def __init__(self, acknowledged=True) -> None:
+        self.acknowledged = acknowledged
+
+
+class FakeSinkCollection:
+    def __init__(self, *, acknowledged=True) -> None:
+        self.write_concern = FakeWriteConcern(acknowledged)
+        self.insert_one_calls = []
+        self.insert_many_calls = []
+        self.bulk_calls = []
+
+    async def insert_one(self, document):
+        self.insert_one_calls.append(document)
+        return object()
+
+    async def insert_many(self, documents, *, ordered):
+        self.insert_many_calls.append((documents, ordered))
+        return object()
+
+    async def bulk_write(self, operations, *, ordered):
+        self.bulk_calls.append((operations, ordered))
+        return object()
+
+
+class FakeSinkDatabase:
+    def __init__(self, collection) -> None:
+        self.collection = collection
+
+    def __getitem__(self, name):
+        return self.collection
+
+
+class FakeSinkClient:
+    def __init__(self, collection) -> None:
+        self.database = FakeSinkDatabase(collection)
+
+    def __getitem__(self, name):
+        return self.database
+
+
+def _connector(collection):
+    return MongoDBConnector("mongodb://local", database="app", client=FakeSinkClient(collection))
+
+
+@pytest.mark.asyncio
+async def test_insert_mapping_and_chunked_sequence() -> None:
+    collection = FakeSinkCollection()
+    sink = _connector(collection).collection_sink("events", batch_size=2, ordered=True)
+    await sink.send(Envelope(body={"_id": "one"}))
+    await sink.send(Envelope(body=[{"_id": "two"}, {"_id": "three"}, {"_id": "four"}]))
+    assert collection.insert_one_calls == [{"_id": "one"}]
+    assert collection.insert_many_calls == [
+        ([{"_id": "two"}, {"_id": "three"}], True),
+        ([{"_id": "four"}], True),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_upsert_uses_all_keys_and_excludes_keys_and_id_from_set() -> None:
+    collection = FakeSinkCollection()
+    sink = _connector(collection).collection_sink("events", mode="upsert", keys=("tenant", "event_id"), ordered=False)
+    await sink.send(Envelope(body={"_id": "mongo-id", "tenant": "a", "event_id": "1", "value": 3}))
+    request = collection.bulk_calls[0][0][0]
+    assert request._filter == {"tenant": "a", "event_id": "1"}
+    assert request._doc == {"$set": {"value": 3}}
+    assert collection.bulk_calls[0][1] is False
+
+
+@pytest.mark.parametrize("body", [[], "text", [1], [{"event_id": "one"}]])
+@pytest.mark.asyncio
+async def test_invalid_upsert_payloads_fail_before_client_call(body) -> None:
+    collection = FakeSinkCollection()
+    sink = _connector(collection).collection_sink("events", mode="upsert", keys=("tenant", "event_id"))
+    with pytest.raises(ConnectorOperationError) as captured:
+        await sink.send(Envelope(body=body))
+    assert captured.value.kind is ConnectorErrorKind.PERMANENT
+    assert isinstance(captured.value.cause, MongoDBPayloadError)
+    assert collection.bulk_calls == []
+
+
+@pytest.mark.asyncio
+async def test_unacknowledged_write_concern_is_rejected() -> None:
+    collection = FakeSinkCollection(acknowledged=False)
+    sink = _connector(collection).collection_sink("events")
+    with pytest.raises(ValueError, match="acknowledged"):
+        await sink.send(Envelope(body={"_id": "one"}))
+
+
+@pytest.mark.asyncio
+async def test_partial_insert_bulk_error_is_uncertain_and_redacted() -> None:
+    class PartialCollection(FakeSinkCollection):
+        async def insert_many(self, documents, *, ordered):
+            raise BulkWriteError({"writeErrors": [{"index": 1, "code": 11000, "errmsg": "duplicate"}], "nInserted": 1})
+
+    sink = _connector(PartialCollection()).collection_sink("events")
+    with pytest.raises(ConnectorOperationError) as captured:
+        await sink.send(Envelope(body=[{"_id": "one"}, {"_id": "one"}]))
+    assert captured.value.kind is ConnectorErrorKind.UNCERTAIN
+    assert captured.value.cause.failed_indexes == (1,)
+    assert captured.value.cause.codes == (11000,)
+    assert captured.value.cause.committed_count == 1
+    assert "documents" not in str(captured.value)

--- a/plugins/onestep-mongodb/uv.lock
+++ b/plugins/onestep-mongodb/uv.lock
@@ -1,0 +1,415 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197, upload-time = "2024-10-05T20:14:59.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632, upload-time = "2024-10-05T20:14:57.687Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "onestep"
+version = "1.7.2"
+source = { editable = "../../" }
+
+[package.metadata]
+requires-dist = [
+    { name = "onestep-control-plane", marker = "extra == 'all'", editable = "../onestep-control-plane" },
+    { name = "onestep-control-plane", marker = "extra == 'control-plane'", editable = "../onestep-control-plane" },
+    { name = "onestep-control-plane", marker = "extra == 'dev'", editable = "../onestep-control-plane" },
+    { name = "onestep-kafka", marker = "python_full_version >= '3.10' and extra == 'all'", directory = "../onestep-kafka" },
+    { name = "onestep-kafka", marker = "python_full_version >= '3.10' and extra == 'dev'", directory = "../onestep-kafka" },
+    { name = "onestep-kafka", marker = "python_full_version >= '3.10' and extra == 'integration'", directory = "../onestep-kafka" },
+    { name = "onestep-kafka", marker = "python_full_version >= '3.10' and extra == 'kafka'", directory = "../onestep-kafka" },
+    { name = "onestep-mq", marker = "extra == 'all'", editable = "../onestep-rabbitmq" },
+    { name = "onestep-mq", marker = "extra == 'dev'", editable = "../onestep-rabbitmq" },
+    { name = "onestep-mq", marker = "extra == 'integration'", editable = "../onestep-rabbitmq" },
+    { name = "onestep-mq", marker = "extra == 'rabbitmq'", editable = "../onestep-rabbitmq" },
+    { name = "onestep-mysql", marker = "extra == 'all'", editable = "../onestep-mysql" },
+    { name = "onestep-mysql", marker = "extra == 'dev'", editable = "../onestep-mysql" },
+    { name = "onestep-mysql", marker = "extra == 'integration'", editable = "../onestep-mysql" },
+    { name = "onestep-mysql", marker = "extra == 'mysql'", editable = "../onestep-mysql" },
+    { name = "onestep-postgres", marker = "extra == 'all'", editable = "../onestep-postgres" },
+    { name = "onestep-postgres", marker = "extra == 'dev'", editable = "../onestep-postgres" },
+    { name = "onestep-postgres", marker = "extra == 'integration'", editable = "../onestep-postgres" },
+    { name = "onestep-postgres", marker = "extra == 'postgres'", editable = "../onestep-postgres" },
+    { name = "onestep-redis", marker = "extra == 'all'", editable = "../onestep-redis" },
+    { name = "onestep-redis", marker = "extra == 'dev'", editable = "../onestep-redis" },
+    { name = "onestep-redis", marker = "extra == 'integration'", editable = "../onestep-redis" },
+    { name = "onestep-redis", marker = "extra == 'redis'", editable = "../onestep-redis" },
+    { name = "onestep-sqs", marker = "extra == 'all'", editable = "../onestep-sqs" },
+    { name = "onestep-sqs", marker = "extra == 'dev'", editable = "../onestep-sqs" },
+    { name = "onestep-sqs", marker = "extra == 'integration'", editable = "../onestep-sqs" },
+    { name = "onestep-sqs", marker = "extra == 'sqs'", editable = "../onestep-sqs" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest", marker = "extra == 'integration'", specifier = ">=8.0.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "pytest-asyncio", marker = "extra == 'integration'", specifier = ">=0.23.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
+    { name = "pyyaml", marker = "extra == 'all'", specifier = ">=6.0" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "pyyaml", marker = "extra == 'integration'", specifier = ">=6.0" },
+    { name = "pyyaml", marker = "extra == 'test'", specifier = ">=6.0" },
+    { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0" },
+]
+provides-extras = ["control-plane", "yaml", "mysql", "postgres", "rabbitmq", "redis", "sqs", "kafka", "test", "integration", "all", "dev"]
+
+[[package]]
+name = "onestep-mongodb"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "onestep" },
+    { name = "pymongo" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest-asyncio", version = "1.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+test = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest-asyncio", version = "1.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "onestep", editable = "../../" },
+    { name = "pymongo", specifier = ">=4.13" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
+]
+provides-extras = ["test", "dev"]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymongo"
+version = "4.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "dnspython", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/64/50be6fbac9c79fe2e4c17401a467da2d8764d82833d83cec325afe5cab32/pymongo-4.17.0.tar.gz", hash = "sha256:70ffa08ba641468cc068cf46c06b34f01a8ce3489f6411309fcb5ceabe6b2fc0", size = 2523370, upload-time = "2026-04-20T16:39:53.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/77/28ebbf69772a4341d530831c7a006cdb06877ac23075cb53b0a227df4fe1/pymongo-4.17.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:47b021363cd923ace5edc7a1d63c0ff8a6d9d43859b8a1ba23645f5afae63221", size = 819234, upload-time = "2026-04-20T16:37:20.888Z" },
+    { url = "https://files.pythonhosted.org/packages/88/cf/5a70cee503ff9a2fea20607607f14d189f4d975960ac0945ec306ee7b695/pymongo-4.17.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:422fa50d7d7f5c22ea0953554396c9ef95684a2d775f860bd75a7b510538dfca", size = 819969, upload-time = "2026-04-20T16:37:24.187Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d5/07b7e27e662c58d872efd104a0e8055eb6569aa1b6d4da436f3fdee7f897/pymongo-4.17.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:addd0498ebbdc6354227f6ed457ed9fce442d48a3bb30d5b5bad33e104996561", size = 1244510, upload-time = "2026-04-20T16:37:26.069Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/7cac5b1e89bd5a8e395067648241390321593a7c29243e36f91343c02a90/pymongo-4.17.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5c8e180cb2cabe37300e1e36c60aa4f2ff956cc579f0142135a5d2cba252243", size = 1263245, upload-time = "2026-04-20T16:37:28.003Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/40e8e99824c1fda18261411e65ce3b0cd3d9a6ed3c056cdd0a569adc870b/pymongo-4.17.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bd835cdb37a1adec359dd072c24f8bb14809e2644fde86fab4ee2fc9719b9483", size = 1304113, upload-time = "2026-04-20T16:37:30.048Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/94/fb7e25441dd66f2069a9b172380849b0eaa5881c18b3db217bf64a6d393c/pymongo-4.17.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4979e7e8887862bbb44d203f00cc8263a3f27237876fa691b6beba23e40e6d8", size = 1297046, upload-time = "2026-04-20T16:37:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c9/7352e0c20fe772541556e4d283c05e07ec48f8b0d2737ad930ac4a1b6655/pymongo-4.17.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:77aa4bc164b4de60d5db193b322f0f5b6ead716e831031bfdef8e8bd92205556", size = 1265708, upload-time = "2026-04-20T16:37:33.934Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e4/3df15494c2015ed297958517f0e4f6493e21b00990748068a973e66d45e0/pymongo-4.17.0-cp310-cp310-win32.whl", hash = "sha256:48bbc576677b50af043df870d84ded67cc3a9b4aa7553201beef4da5dc050a0a", size = 805533, upload-time = "2026-04-20T16:37:35.744Z" },
+    { url = "https://files.pythonhosted.org/packages/22/fa/b4e71bb8cb82ad7d21bb4e8c476f2d573ba68b20368aac36ef06e4a196b4/pymongo-4.17.0-cp310-cp310-win_amd64.whl", hash = "sha256:e46767f28dea610e02edf6c5d956ce615c3c7790ea396660b9b1efd5c5ead2e0", size = 815677, upload-time = "2026-04-20T16:37:37.808Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e2/0a4bba644f1cda3970ea1012149eeae3594ebfeed3f81fdaf32b61d90c95/pymongo-4.17.0-cp310-cp310-win_arm64.whl", hash = "sha256:757f2a4c0c2c46cab87df0333681ce69e86c9d5b45bc5203ceba5410b3489e59", size = 807293, upload-time = "2026-04-20T16:37:39.707Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e2/336d86f221cf1b56b2ed9330d4a3b98f9f38f0b37829ae9a9184617d5419/pymongo-4.17.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4141e6c6a339789b2974efa00ecd9409101672d77a0e3ee2cc3839eedf8ec4df", size = 874668, upload-time = "2026-04-20T16:37:41.39Z" },
+    { url = "https://files.pythonhosted.org/packages/34/8e/75d3c6c935d187ab59c61e9c15d9aab3f274b563eaf1706e8cae5f508dec/pymongo-4.17.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e68c76b84e0c132d9dbf9307f12ff8185702328187a87b9aca8c941303873433", size = 875294, upload-time = "2026-04-20T16:37:43.432Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ec/62e855744489dbcd54fd778aae4d80fa4c4819e8fb228ca0cf6f21a03997/pymongo-4.17.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ba2195d4f386f839a52a23ea1cfd60ffaaba78a3d7841db51b7e433001139918", size = 1496233, upload-time = "2026-04-20T16:37:45.518Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e8/93e4e5e5ce8fdf8929dabeefe24aafa5ce046028eed0dfa8eeb936e72c49/pymongo-4.17.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8446ff4bfcb6ec2a2e50998c860986a1e992136f998b7f53e7a717fb8aa5a0b9", size = 1522927, upload-time = "2026-04-20T16:37:47.492Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/425dc1d21e0f17bdea0072fc463f662f7fa06d2852af52975c9eced3c07c/pymongo-4.17.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2a0d5ac205728c86e0a02192f1aa5f865b0d7d51f8df6101c01a69a7fc620d72", size = 1583468, upload-time = "2026-04-20T16:37:49.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9d/f08b07eeffda1a43c1759f0fa625e88ae12360996eb56d42aad832fa7dff/pymongo-4.17.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:485c8a8eaa4c739f00a331fc73757898ee7c092c214a79e63866ff76aaf282ff", size = 1572787, upload-time = "2026-04-20T16:37:51.061Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/c2/6855a07aafa7b894929af23675b6fb9634800ce43122b76a62f6eeb8da2a/pymongo-4.17.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b2dfcc795f5b9fedbe179a11fdf6051581479d196582a3fe819a92a00e9b9969", size = 1526184, upload-time = "2026-04-20T16:37:53.358Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/05/c952bac7db71c1942ea3559fcd308b49754cc5004b455935fb4000d1f37b/pymongo-4.17.0-cp311-cp311-win32.whl", hash = "sha256:c2292144505fb12156b981bd440f3dc994a883da06ac726c0c8692ccdbc1c510", size = 852621, upload-time = "2026-04-20T16:37:55.28Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c0/c04da9f4c0c6252404598f4e394b862a58a9e866822a70ae261c8a018fdf/pymongo-4.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:2e190827834fce70ecdf9d46796c6dbc0ce08ea87dc2ff5bc6f3f5579b605cb9", size = 867852, upload-time = "2026-04-20T16:37:57.233Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b2/c7b4870fbeef471e947d3e014676f5910d02e0197074d692ebcf24ec049a/pymongo-4.17.0-cp311-cp311-win_arm64.whl", hash = "sha256:a8f9c40a09bb7d4b9fc8b1da65ecf6efa79bda5cb2756f39d9b6940fac1d19ae", size = 855019, upload-time = "2026-04-20T16:37:58.983Z" },
+    { url = "https://files.pythonhosted.org/packages/98/90/60bcb508840135d5ee46b51b1a950f548338aa8145a8366dbe6639ae51ac/pymongo-4.17.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53ffa94b2340dbf6b055e09a0090618c60482c158ecfc9565642fc996bf0944", size = 930529, upload-time = "2026-04-20T16:38:00.936Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/e9/313840f1e52c6dfac47f704428cbfbce59956ebe7633bffc92b03f74f0ad/pymongo-4.17.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6fe0de9d0f6791abce3471230b32b4817bf89d27b1182b6a550e1ec0fa72aa9a", size = 930665, upload-time = "2026-04-20T16:38:02.915Z" },
+    { url = "https://files.pythonhosted.org/packages/78/35/9d3565ea45b1606f635c1e2cd2563c28d66caafdc50f7ad7d979fcd1b363/pymongo-4.17.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e537e95514dae1aaa718f481ec03151a0f0394bcd05f1322896d8fc1330cb729", size = 1762369, upload-time = "2026-04-20T16:38:05.375Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ee/149b0d4b1a11c38bff6f14c23d5814c9b0843fd6dc38ad40596bdb1a62d2/pymongo-4.17.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37a8385c29881b43eab31f584100fa0eaddedd5607adf010147ba1810118be90", size = 1798044, upload-time = "2026-04-20T16:38:07.195Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d4/4cee4a7b8d8f6f0550ef6cd2fea42455c5ed619a220cb6ba4fb40d6a5bc8/pymongo-4.17.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f3ee3d241ed77a4fc99ce3cff3b289c3ebce37f61fdd7349d3592c23b82c8784", size = 1878567, upload-time = "2026-04-20T16:38:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ef/7fe366c84952619ee2f69973566c214775e083dd4df465751912153e4b72/pymongo-4.17.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9eb5d63a3c518cb0804ed678f5e2b875af032d89a7cf57a57360322cf6a4d222", size = 1864881, upload-time = "2026-04-20T16:38:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/35/b577d82c6d1be7aee7ac7e249bc86f7847998345042e5f8360de238e177b/pymongo-4.17.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e97e03fa13327c87e3fdc5656acd01e71817f0c1dc3221cd8f30de136bf4ec3", size = 1800349, upload-time = "2026-04-20T16:38:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/69/dafcf04f66e130ddd91aeb92e7a692480eda46dcd04ec1dbe82c06619e10/pymongo-4.17.0-cp312-cp312-win32.whl", hash = "sha256:6877214bff5f06f6884a9fc8d9016a4a7a5f51f537f5c51ac3a576f93e7dfb32", size = 900518, upload-time = "2026-04-20T16:38:15.541Z" },
+    { url = "https://files.pythonhosted.org/packages/11/35/5c9262a459f988b4eb2605f70815240b77a0d4131136c4326d18f1822b89/pymongo-4.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:9828485f72f63c7d802e0ec41f71906f633c2692621ab3af55ca990186b091b1", size = 920335, upload-time = "2026-04-20T16:38:17.665Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/e9c7265ee176faccf4e52c4797837e794d93569a1046f6b19a4acc36e5ad/pymongo-4.17.0-cp312-cp312-win_arm64.whl", hash = "sha256:1195370a77baf003b59b10e91ecc4706297197f0dd9d29c840cc556dc08f7cee", size = 903289, upload-time = "2026-04-20T16:38:19.33Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/6b/c1206879708b94e82fcd8b9653440ec271f79a3674d122192df383047f5a/pymongo-4.17.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:809ec74de3b9148ae43fa8df9faf53470f511c8d384f13b99d6f671f2a379f15", size = 985829, upload-time = "2026-04-20T16:38:21.031Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cf/bb044ed85160e5c40f568c7c4f4e8ea16f40764ff5d302e5befbe8f6f814/pymongo-4.17.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a431b737816bf4cddd4fa0fcef04e424ad36b7692734a64150f872fb8f3208be", size = 985899, upload-time = "2026-04-20T16:38:23.409Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0a/f6dfd5ea3901e5d6888da8de8ba728971a1d447debab681cfc56f90d1208/pymongo-4.17.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4fab10f8403169ce92f3cea921609d9ee81107306caae06c08f592d4b8ad2b5", size = 2028569, upload-time = "2026-04-20T16:38:25.343Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c5/081f59a1c02ae8c0dc73ae58e563838c44eec81aeafa7d0b93a637841c9b/pymongo-4.17.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20323b0b1c1d33770ad1fc68d429c757734ce9ad3594421c3d6618f10572b1b9", size = 2072916, upload-time = "2026-04-20T16:38:27.291Z" },
+    { url = "https://files.pythonhosted.org/packages/31/42/6e41d434297ffe8b30d9c3717916591a4a7be9075a0dcc2fafdfaaaa62ed/pymongo-4.17.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5a5de048e6da5c18e27cc2437e8c15b3b0cdc8385c15b41178b0caa3322a09c2", size = 2173234, upload-time = "2026-04-20T16:38:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/cf/1e4a7db352ef9485831c7268dfe8402f0117b32a9ad54b16e810699e3617/pymongo-4.17.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dff3de1294fbbc1db0ba6b511f77b8e540601d092538a31312e99c8a91a78b1e", size = 2156784, upload-time = "2026-04-20T16:38:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/12/10/6195be29962a61ebb5f4bd9e4c7519890b172f7968a0a0d880398c6ddb02/pymongo-4.17.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faf03e4c2aafd6de626dbd30ba246d369ae33f47f10629d1bbe40f72115027a6", size = 2074446, upload-time = "2026-04-20T16:38:34.004Z" },
+    { url = "https://files.pythonhosted.org/packages/37/48/33410b8819837ed370c738587306bdf060b59cef11823be212f4a07703c5/pymongo-4.17.0-cp313-cp313-win32.whl", hash = "sha256:c9786665926a09630c5d420c79762cfadbff35a9438bcbc4c81a9fb5ab9228b7", size = 948435, upload-time = "2026-04-20T16:38:35.922Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/77/c0ed522f798a286b99acaa7914ed8d9c80ab091f97f57c59ffed72906e5e/pymongo-4.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:5960519b4d7168f1ecdd3ea10c81b2aedeb9423651aca953cfbc8e76705d3b38", size = 972847, upload-time = "2026-04-20T16:38:37.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f0/c39480a2db385fde23861d0c8acda41cdaf1d43e46579db72c5c013a2e81/pymongo-4.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:0ff6bd2f735ab5356541e3e57d5b7dbfbc3f2ee1ccb10b6b0f82d58af69d1d8e", size = 951575, upload-time = "2026-04-20T16:38:40.544Z" },
+    { url = "https://files.pythonhosted.org/packages/da/49/2b0250762a89737ed6f9cea238331baca061b89a8ddd10dd17fee52c3970/pymongo-4.17.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ff5aa3f1c7e3f08eb0e7a016c91ba468b1850ccfd63d9b1f12f56350f4974cef", size = 1040945, upload-time = "2026-04-20T16:38:42.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1c/7a9b5447a08be20e84b6e5b17330917e8d6d9507daa3cd099a9309f11ad7/pymongo-4.17.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e816db649ba5d7de0568cf3a9f287a9dc9aad21cf0ca667ab156a7ef47fca0b0", size = 1041187, upload-time = "2026-04-20T16:38:45.358Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a1/71704f61632dfc90407a5834fe5f6132854937c4a3648f6c05c351d85a45/pymongo-4.17.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c4fded3a9f1d6a687e36ebd384ac6d00b9b00de1969aa74048e7051ec2a713", size = 2294806, upload-time = "2026-04-20T16:38:47.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/b9/aff42be75108b96c2469b1d9329b912c15108f3e7ef32fdc86da8423c330/pymongo-4.17.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2db66aa8dd253a0fc1fad3b0d23d5b3993f7ebde02fbbd7727128debf2853675", size = 2348231, upload-time = "2026-04-20T16:38:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/30/44c115b8ba1479942c15fd9480eb29a7da0ba68acd56983423ba0deb4a94/pymongo-4.17.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3987e96e7c7be4083d42e8ac2cc6c0d5b78db9973c90fce42ae800b616ca6b20", size = 2467614, upload-time = "2026-04-20T16:38:52.665Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/84/21ee95c8bf0ca7acae7ec7eb365d740bf8fc0156c194baf2c3bdfcb85ec0/pymongo-4.17.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cee36b3c0d0354f880fa7a7fdcdaf2bb5e542c2281e25c1bfadf8cfe21eba7d2", size = 2445970, upload-time = "2026-04-20T16:38:55.175Z" },
+    { url = "https://files.pythonhosted.org/packages/06/89/081d7f1809d5ca09d1e47e49f2111b245f5694de3a7af32cd3a353a6f43f/pymongo-4.17.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:320b34457b20bbcc79997801f95d25ce00472915ca5241167242b42c4359e027", size = 2348605, upload-time = "2026-04-20T16:38:57.557Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c3/0d949f9d3f2a341c1f635c398c16615e96f89f51ff424ed81e914cf1a4de/pymongo-4.17.0-cp314-cp314-win32.whl", hash = "sha256:df4a644af9ae132d4bfdb2e9516ea51a615fd881caddfbfbd071cf1354844479", size = 1004119, upload-time = "2026-04-20T16:39:00.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/55/5c3a3db1048054c695c75c5964cc8bedc2247fdb5a75ef6fab4ec8bb013e/pymongo-4.17.0-cp314-cp314-win_amd64.whl", hash = "sha256:c797f8a80957134f6dd9690367a0f8f5906d672119af2c6aa55f0c527b656bed", size = 1032314, upload-time = "2026-04-20T16:39:02.665Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/19/e235f39906134cb0ffd5574c5a59c355ef5380f0499644ab94994afbb109/pymongo-4.17.0-cp314-cp314-win_arm64.whl", hash = "sha256:68fca71e05ee5da23a8d73cee8379dfb3d26e609a377cae731d742771ed96946", size = 1007627, upload-time = "2026-04-20T16:39:04.678Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e0/c4c1a86791415b14c684fa0908f9da96de91594a3fd1fa1b8dc689fbb800/pymongo-4.17.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b4384700cffc3f1dd98e088bc0072dedf6d7d68a230bb4b972665cf69c071c1e", size = 1099151, upload-time = "2026-04-20T16:39:06.969Z" },
+    { url = "https://files.pythonhosted.org/packages/81/4b/69c67f3e23fd9b23b9bedc7ebd23754881cc9d5c5d5b2a9811e96b07f475/pymongo-4.17.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:93641192644fa1ee0f34030e774fd31022a27ad11ba22cb1716142231524f8bd", size = 1099346, upload-time = "2026-04-20T16:39:08.996Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/19/a5208f62f9508a26d73acc69bd3821b8c8adae253679a3c26d2f9652f0d5/pymongo-4.17.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:75bc3aa5b94fdb7138d357ec6ca61cd97e0c79f4f7f0bd3efe9639b15cc50942", size = 2619034, upload-time = "2026-04-20T16:39:11.049Z" },
+    { url = "https://files.pythonhosted.org/packages/77/27/426cba1ec5973082a56d4150798529bfdf4151c31391ed1fbbecb23ef2ac/pymongo-4.17.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e8f8e23c6df7c6d6929f5e734980b227706e73ee847517c9ba5af90f7fc466", size = 2689939, upload-time = "2026-04-20T16:39:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2e/f70993d1255e33f6ee59a4ec4371cc65bff7a7e3fda7d55c3386f25287e8/pymongo-4.17.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:15d3f3d732aecac1f8d481bde4029755615639bd3076f258a2147210aec8515a", size = 2824994, upload-time = "2026-04-20T16:39:16.057Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/eb/87b0e988ba889e1fcc3430c2cfc166b251872c813e92b43174298bee17ff/pymongo-4.17.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c5f62862d0f87be481fa1fe8cb811994486773c94a2b61e509285e3f2890763", size = 2801745, upload-time = "2026-04-20T16:39:18.476Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4c/3f83412d086f682d4d468761d66ddc49cf161e786ea74073045eb4491c60/pymongo-4.17.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64837adbbd72073301af51bb0fc80e3d7707fe5527cea1033ba0320f0b2f881b", size = 2684636, upload-time = "2026-04-20T16:39:20.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d8/b75f6f4ab6c8beb50b0270a4f1e2530b5774f5e116563440e1677ca1820f/pymongo-4.17.0-cp314-cp314t-win32.whl", hash = "sha256:b93b22eedc62598cf5ee9d8c8007a8e9121c50fd88137012d8985500e9dc3151", size = 1056356, upload-time = "2026-04-20T16:39:22.996Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5e/648c8a238eef18a25ed8a169ea6542d4a860bbec3e95b3d9badac2935c71/pymongo-4.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3689ea34f6b647c7d1e7bdc60fcfb214b2789ed1359a7fb96569c69f50e5f18f", size = 1090964, upload-time = "2026-04-20T16:39:24.989Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cb/d9780b66939c4fc1f024bcc7be23a2abcfe06a9745ca8fa76dc73395482e/pymongo-4.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9543d8f84c2e5608565c08ac679774811e6730770d8a645439b073422a4276fb", size = 1058526, upload-time = "2026-04-20T16:39:27.924Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f4/efa4398908a00ec64b66f35cb949fc3bace2919447ce4a5dce5fbe923f0b/pymongo-4.17.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4ae22fafca69dd3c78261969e999782ac5fc23b76cf8cccfbc3707982a74cc3d", size = 762649, upload-time = "2026-04-20T16:39:30.126Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ab/83aeee417fa4618a555a08f9c8e0556974c4f111dd3cca465a86c50291d4/pymongo-4.17.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f09645e0ce4e3825fa0baa8254064a716ed0be33f78feeedd4731016cb8aaa17", size = 763556, upload-time = "2026-04-20T16:39:32.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/20/7303d9f926aa41410691c87404f219ee2125a69cecff272226cddee4f8bc/pymongo-4.17.0-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7db10678814cdf7ea39fd308c6f41395cfa7b29d904bcd7895288963d8f892ba", size = 975118, upload-time = "2026-04-20T16:39:34.772Z" },
+    { url = "https://files.pythonhosted.org/packages/47/44/ff0c5ee9649339f121582808b6ec6f5e9fc666ae4b72a6831a027e7d9e34/pymongo-4.17.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5376ad67bb30ae910d83affcf997f706d9dee37e8b5dad8b6fedb0626e262d85", size = 984900, upload-time = "2026-04-20T16:39:37.317Z" },
+    { url = "https://files.pythonhosted.org/packages/81/8b/df7479d7cc1a5f7d8f555c64ba6f28d8fffbd8645271dd1b044bc2032ea9/pymongo-4.17.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bb3ebc86782049f6928dcc583008287cb1c17d463501c94a620f035f5b4fd463", size = 1004844, upload-time = "2026-04-20T16:39:39.498Z" },
+    { url = "https://files.pythonhosted.org/packages/02/58/c4e0aeead0be7ab1bd22212cc026f5f30c5fe050bebdaa62cbe759879875/pymongo-4.17.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:51e1915761f65f2aaabd0ba691a31d56551d3f19d1263c2d6bf261730603de5f", size = 1001467, upload-time = "2026-04-20T16:39:41.586Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ff/da669b2f45e706d51d7346dff8ac5a8fb747e29e11a8bcf01bc3e9f28d7f/pymongo-4.17.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1175563375d682260f613a96fb7a53dce746ed752bfd924eab61de3bc5bfde34", size = 985764, upload-time = "2026-04-20T16:39:43.845Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/84/131b4a57fb964775e7d35ec34769d2da37a66dee9449a1f050392eef3986/pymongo-4.17.0-cp39-cp39-win32.whl", hash = "sha256:5ab3b8ff79e0dfc49b68f3c925e8cc735ea95c60efaed84cfe75692dffcaac2a", size = 758136, upload-time = "2026-04-20T16:39:45.894Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/55/d3af567f1af9c057b30e9867c1e7d9093c1b428f6f9b2dfa0cd800563255/pymongo-4.17.0-cp39-cp39-win_amd64.whl", hash = "sha256:b24598dc3c2feccbc83b43044be48145a0dc4f9bee49ef923e3d707d54a55d85", size = 763248, upload-time = "2026-04-20T16:39:48.31Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/adfc48de803bbb52060f5f2d3b25dfd1505fddad12e088b51427085b6246/pymongo-4.17.0-cp39-cp39-win_arm64.whl", hash = "sha256:8a1be016198a03fd7727cdd55998964bfa4e5a6fd9733c8e95830628cef34d29", size = 759093, upload-time = "2026-04-20T16:39:50.597Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pluggy", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version == '3.10.*'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
## Intent

Implement the independently testable onestep-mongodb plugin exactly per the captain-approved database plugin design and MongoDB plan. Provide deterministic incremental collection polling and resumable raw-event collection change streams with default updateLookup, plus acknowledged insert and stable-key upsert sinks. Preserve mapping-or-non-empty-sequence batching, contiguous acknowledgement, generation invalidation and stale-delivery blocking, Extended JSON cursor and resume-token state encoding, resumable stream behavior, partial-commit uncertainty and idempotency semantics, strict YAML resource catalogs, lazy owned AsyncMongoClient lifecycle, stable public onestep exports, PyMongo native async APIs, and Python 3.9 compatibility. Keep all work under plugins/onestep-mongodb with no shared root integration changes, and validate the plugin-local unit, runtime, package, and metadata gates.

## What Changed

- **New plugin package**: `plugins/onestep-mongodb` with lazy owned `AsyncMongoClient` lifecycle, PyMongo native async APIs, Python 3.9 compatibility, and stable public exports
- **Deterministic collection polling**: restart-safe incremental polling with BSON-cursor state encoding, contiguous acknowledgement, and generation-gapped stale-delivery blocking
- **Resumable raw change streams**: default `updateLookup`, Extended JSON resume-token encoding, and resumable stream behavior preserving partial-commit uncertainty and idempotency semantics
- **Acknowledged sinks**: insert and stable-key upsert sinks with mapping-or-non-empty-sequence batching
- **YAML resource registration**: strict resource catalogs under the `onestep.resources` entry point group with redacted driver-error preservation
- **Validation gates**: unit tests, runtime-contract tests, package-build and metadata verification across 45 passing tests

## Risk Assessment

✅ Low: The change is well-structured, thoroughly unit-tested, meets all stated acceptance criteria, and the fix commit correctly addresses both the credential-redaction gap and the PyMongo exception hierarchy reordering (NetworkTimeout and ServerSelectionTimeoutError are subclasses of AutoReconnect and must be checked before the parent class to avoid misclassification).

## Testing

Executed 45 plugin-local unit tests across 6 test files covering all core modules (connector, resilience, state_codec, resources). Validated package build, entry point, public API exports, state codec round-trips, error classification/redaction, contiguous generation tracking, and YAML resource registration. Integration tests (test_mongodb_live.py, 4 tests) were skipped — they require a live MongoDB replica set which could not be started due to Docker Hub connectivity issues in this environment. All 45 unit tests passed with no failures.

<details>
<summary>Evidence: Unit test results</summary>

`45/45 unit tests passed (4 integration tests deselected)`

```text
============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/miclon/.no-mistakes/worktrees/e2904bd4ec09/01KYJ5J1GRQRDFKX164SE4RD1B/plugins/onestep-mongodb
configfile: pyproject.toml
plugins: asyncio-1.4.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 49 items / 4 deselected / 45 selected

plugins/onestep-mongodb/tests/test_mongodb_change_stream.py ......       [ 13%]
plugins/onestep-mongodb/tests/test_mongodb_plugin.py ...........         [ 37%]
plugins/onestep-mongodb/tests/test_mongodb_polling.py ..........         [ 60%]
plugins/onestep-mongodb/tests/test_mongodb_resilience.py ...             [ 66%]
plugins/onestep-mongodb/tests/test_mongodb_runtime_contract.py .......   [ 82%]
plugins/onestep-mongodb/tests/test_mongodb_sink.py ........              [100%]

======================= 45 passed, 4 deselected in 2.34s =======================
```
</details>
<details>
<summary>Evidence: Package validation</summary>

`Public API surface, version 0.1.0, YAML resource registration, connector lifecycle, state codec, tracker contracts, error redaction all verified`

```text
=== PUBLIC API SURFACE ===
  MongoDBChangeStreamDelivery: ABCMeta
  MongoDBChangeStreamSource: ABCMeta
  MongoDBCollectionSink: ABCMeta
  MongoDBConnector: type
  MongoDBPayloadError: type
  MongoDBPollingDelivery: ABCMeta
  MongoDBPollingSource: ABCMeta
  __version__: 0.1.0
  register: function
  register_resources: function

=== VERSION ===
  0.1.0

=== STRICT YAML RESOURCE REGISTRATION ===
  type='mongodb'                           roles=('connector',)                 fields=3
  type='mongodb_change_stream'             roles=('source',)                    fields=9
  type='mongodb_collection_sink'           roles=('sink',)                      fields=6
  type='mongodb_polling'                   roles=('source',)                    fields=10

=== CONNECTOR LIFECYCLE ===
  injected client: owned=False
  lazy client: owned=True

=== POLLING SOURCE ===
  name: mongodb.polling:events
  cursor: ('updated_at', '_id')
  fetch_is_cancel_safe: False

=== CHANGE STREAM SOURCE ===
  name: mongodb.change_stream:events
  full_document: updateLookup

=== SINK ===
  name: mongodb.collection:archive
  mode: upsert
  keys: ('event_id',)

=== STATE CODEC ===
  original:  [ObjectId('64b64c1234567890abcdef12'), datetime.datetime(2026, 7, 27, 0, 0, tzinfo=datetime.timezone.utc)]
  encoded:   extended_json dict
  decoded:   [ObjectId('64b64c1234567890abcdef12'), datetime.datetime(2026, 7, 27, 0, 0, tzinfo=FixedOffset(datetime.timedelta(0), 'UTC'))]
  roundtrip: OK

=== TRACKER CONTRACTS ===
  contiguous ack: OK
  stale delivery blocking: OK
  generation invalidation: OK

=== REDACTED ERROR CAUSES ===
  credentials redacted: OK

ALL CHECKS PASSED
```
</details>
<details>
<summary>Evidence: Build output</summary>

`Wheel and source distribution built successfully with correct entry_points.txt`

```text
Building source distribution...
Building wheel from source distribution...
Successfully built dist/onestep_mongodb-0.1.0.tar.gz
Successfully built dist/onestep_mongodb-0.1.0-py3-none-any.whl
---
Wheel contents:
Archive:  plugins/onestep-mongodb/dist/onestep_mongodb-0.1.0-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
      728  02-02-2020 00:00   onestep_mongodb/__init__.py
    20423  02-02-2020 00:00   onestep_mongodb/connector.py
     4293  02-02-2020 00:00   onestep_mongodb/resilience.py
    10386  02-02-2020 00:00   onestep_mongodb/resources.py
      574  02-02-2020 00:00   onestep_mongodb/state_codec.py
     7031  02-02-2020 00:00   onestep_mongodb-0.1.0.dist-info/METADATA
       87  02-02-2020 00:00   onestep_mongodb-0.1.0.dist-info/WHEEL
       55  02-02-2020 00:00   onestep_mongodb-0.1.0.dist-info/entry_points.txt
      760  02-02-2020 00:00   onestep_mongodb-0.1.0.dist-info/RECORD
---------                     -------
    44337                     9 files
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pytest plugins/onestep-mongodb/tests/ -v -m "not integration" (45/45 passed)`
- `uv build --directory plugins/onestep-mongodb (wheel + sdist)`
- `Package import + __all__ completeness check`
- `Entry point registration (onestep.resources group)`
- `State codec BSON Extended JSON round-trip`
- `_ContiguousGenerationTracker contracts (contiguous ack, gap blocking, invalidation)`
- `Error classification and redaction verification`
- `Connector lifecycle (injected vs owned client)`
- `YAML resource catalog building and validation`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
