### PR TITLE
fix(redis): scrub credentials from connector errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 - Bundles the three plugins in the worker image and adds isolated reliability/live compatibility gates.
 - Does not change core runtime, delivery, retry, reporter, or control-plane behavior.
 
+## onestep-redis 0.2.2
+
+- Scrubs connector URL credentials and known secret options from normalized Redis error causes.
+- Suppresses raw exception chaining for open, fetch, and send failures so reported tracebacks do not expose secrets.
+
+## onestep-mq 0.2.2
+
+- Scrubs AMQP URL credentials and known secret options from normalized RabbitMQ error causes.
+- Suppresses raw exception chaining for open, fetch, and send failures so reported tracebacks do not expose secrets.
+
 ## onestep-elasticsearch 0.1.0
 
 - Adds the common Elasticsearch/OpenSearch HTTP connector and acknowledged bulk sink.

--- a/plugins/onestep-redis/pyproject.toml
+++ b/plugins/onestep-redis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-redis"
-version = "0.2.1"
+version = "0.2.2"
 description = "Redis connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-redis/src/onestep_redis/connector.py
+++ b/plugins/onestep-redis/src/onestep_redis/connector.py
@@ -10,7 +10,7 @@ from onestep.resilience import ConnectorOperation, ConnectorOperationError
 from onestep.connectors.base import Delivery, Sink, Source
 from onestep.connectors.codec import decode_envelope, encode_envelope
 
-from .resilience import as_redis_connector_operation_error
+from .resilience import as_redis_connector_operation_error, collect_sensitive_tokens
 
 try:  # pragma: no cover - optional dependency
     from redis.asyncio import Redis
@@ -218,6 +218,12 @@ class RedisStreamQueue(Source, Sink):
         self._redis: Any | None = None
         self._opened = False
 
+    def _connection_secrets(self) -> list[str]:
+        """Secret-bearing config tokens used to scrub error messages."""
+        return collect_sensitive_tokens(
+            self.connector.url, self.connector.options
+        )
+
     async def open(self) -> None:
         """Open connection and create consumer group if needed."""
         if self._opened:
@@ -248,10 +254,11 @@ class RedisStreamQueue(Source, Sink):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=self.poll_interval_s,
+                secrets=self._connection_secrets(),
             )
             if connector_error is None:
                 raise
-            raise connector_error from exc
+            raise connector_error from None
 
     async def close(self) -> None:
         """Close connection."""
@@ -313,11 +320,12 @@ class RedisStreamQueue(Source, Sink):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=self.poll_interval_s,
+                secrets=self._connection_secrets(),
             )
             if connector_error is None:
                 raise
             await self._reset_transport_state()
-            raise connector_error from exc
+            raise connector_error from None
 
     def _process_messages(self, messages: list) -> list[Delivery]:
         """Process raw xreadgroup response into Delivery objects."""
@@ -377,11 +385,12 @@ class RedisStreamQueue(Source, Sink):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=self.poll_interval_s,
+                secrets=self._connection_secrets(),
             )
             if connector_error is None:
                 raise
             await self._reset_transport_state()
-            raise connector_error from exc
+            raise connector_error from None
 
     async def _reset_transport_state(self) -> None:
         """Reset transport state on error."""

--- a/plugins/onestep-redis/src/onestep_redis/resilience.py
+++ b/plugins/onestep-redis/src/onestep_redis/resilience.py
@@ -1,11 +1,93 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
 from onestep.resilience import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError
 
 try:  # pragma: no cover - optional dependency
     import redis.exceptions as redis_exceptions
 except ImportError:  # pragma: no cover - optional dependency
     redis_exceptions = None
+
+_REDACTED = "<redacted>"
+_MAX_MESSAGE_LENGTH = 500
+_SECRET_OPTION_KEYS = frozenset(
+    {
+        "password",
+        "passwd",
+        "pwd",
+        "secret",
+        "token",
+        "access_token",
+        "api_key",
+        "apikey",
+        "credentials",
+        "authorization",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RedisErrorCause(Exception):
+    message: str
+
+    def __str__(self) -> str:
+        return f"redis error: {self.message}"
+
+
+def collect_sensitive_tokens(*config_values: object) -> list[str]:
+    """Collect secret substrings that may surface in Redis error messages.
+
+    Tokens are derived from connector config: raw URI/connection-string values
+    (always included as a catch-all), their parsed userinfo, and known secret
+    keys inside option mappings. Error causes are scrubbed against these before
+    they leave the plugin.
+    """
+    tokens: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        if value is None:
+            return
+        text = str(value)
+        if text and text not in seen:
+            seen.add(text)
+            tokens.append(text)
+
+    for value in config_values:
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                if str(key).lower() in _SECRET_OPTION_KEYS:
+                    add(item)
+            continue
+        add(value)
+        try:
+            parsed = urlsplit(str(value))
+        except ValueError:
+            continue
+        username = parsed.username
+        password = parsed.password
+        if username and password:
+            add(f"{username}:{password}")
+            add(f"{username}:{password}@")
+        add(password)
+    return tokens
+
+
+def _redact_message(message: str, tokens: list[str]) -> str:
+    redacted = message
+    for token in sorted(tokens, key=len, reverse=True):
+        if token:
+            redacted = redacted.replace(token, _REDACTED)
+    return redacted[:_MAX_MESSAGE_LENGTH]
+
+
+def redacted_redis_cause(
+    exc: BaseException, *, secrets: list[str] | None = None
+) -> RedisErrorCause:
+    return RedisErrorCause(_redact_message(str(exc), secrets or []))
 
 
 def classify_redis_error(exc: BaseException) -> ConnectorErrorKind | None:
@@ -56,6 +138,7 @@ def as_redis_connector_operation_error(
     exc: BaseException,
     source_name: str | None = None,
     retry_delay_s: float | None = None,
+    secrets: list[str] | None = None,
 ) -> ConnectorOperationError | None:
     kind = classify_redis_error(exc)
     if kind is None:
@@ -66,5 +149,5 @@ def as_redis_connector_operation_error(
         kind=kind,
         source_name=source_name,
         retry_delay_s=retry_delay_s,
-        cause=exc,
+        cause=redacted_redis_cause(exc, secrets=secrets),
     )

--- a/plugins/onestep-redis/tests/test_redis_plugin.py
+++ b/plugins/onestep-redis/tests/test_redis_plugin.py
@@ -12,7 +12,11 @@ from onestep.resilience import ConnectorErrorKind, ConnectorOperation, Connector
 from onestep.resource_registry import ResourceRegistry
 from onestep_control_plane import ControlPlaneReporter, ControlPlaneReporterConfig
 from onestep_redis import RedisConnector, RedisStreamQueue, register
-from onestep_redis.resilience import as_redis_connector_operation_error, classify_redis_error
+from onestep_redis.resilience import (
+    as_redis_connector_operation_error,
+    classify_redis_error,
+    RedisErrorCause,
+)
 
 
 @dataclass
@@ -110,7 +114,8 @@ def test_redis_plugin_normalizes_redis_errors() -> None:
     assert normalized.kind is ConnectorErrorKind.DISCONNECTED
     assert normalized.source_name == "jobs"
     assert normalized.retry_delay_s == 0.5
-    assert normalized.cause is timeout
+    assert isinstance(normalized.cause, RedisErrorCause)
+    assert "timeout" in str(normalized.cause)
 
 
 def test_reporter_sync_payload_includes_redis_stream_topology_config() -> None:

--- a/plugins/onestep-redis/tests/test_redis_resilience.py
+++ b/plugins/onestep-redis/tests/test_redis_resilience.py
@@ -1,0 +1,76 @@
+"""Regression tests for credential redaction in Redis connector errors."""
+from __future__ import annotations
+
+import traceback
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from onestep import (
+    ConnectorErrorKind,
+    ConnectorOperationError,
+    Envelope,
+)
+from onestep_redis import RedisConnector
+from onestep_redis.resilience import (
+    collect_sensitive_tokens,
+    redacted_redis_cause,
+)
+
+
+class _RedisURLError(ConnectionError):
+    """Simulates a redis-py connection error that embeds the full URL."""
+
+
+def test_collect_sensitive_tokens_extracts_url_userinfo_and_options() -> None:
+    tokens = collect_sensitive_tokens(
+        "redis://:s3cret@redis.internal:6379/0",
+        {"password": "opts-pw", "db": 0},
+    )
+    assert "redis://:s3cret@redis.internal:6379/0" in tokens
+    assert "s3cret" in tokens
+    assert "opts-pw" in tokens
+    assert 0 not in tokens and "0" not in [t for t in tokens if t == "0"]
+
+
+def test_redacted_redis_cause_scrubs_credentials() -> None:
+    secret_url = "redis://reader:s3cret@redis.internal:6379/0"
+    exc = _RedisURLError(f"Error connecting to {secret_url}: AUTH failed")
+    cause = redacted_redis_cause(exc, secrets=[secret_url, "s3cret"])
+    rendered = str(cause)
+    assert "s3cret" not in rendered
+    assert "reader:s3cret" not in rendered
+    assert "<redacted>" in rendered
+
+
+@pytest.mark.asyncio
+async def test_send_failure_does_not_leak_url_credentials() -> None:
+    secret_url = "redis://reader:s3cret@redis.internal:6379/0"
+    connector = RedisConnector(secret_url)
+    stream = connector.stream("events")
+
+    mock_redis = AsyncMock()
+    mock_redis.xgroup_create = AsyncMock()
+    mock_redis.xadd = AsyncMock(
+        side_effect=_RedisURLError(f"Error connecting to {secret_url}: AUTH failed")
+    )
+    mock_redis.aclose = AsyncMock()
+
+    with patch.object(connector, "acquire", return_value=mock_redis):
+        with pytest.raises(ConnectorOperationError) as captured:
+            await stream.send(Envelope(body={"id": 1}))
+
+    error = captured.value
+    # The public ``cause`` must not carry credentials.
+    assert "s3cret" not in str(error.cause)
+    assert "reader:s3cret" not in str(error.cause)
+    assert "<redacted>" in str(error.cause)
+    # The original secret-bearing exception must not be chained.
+    assert error.__cause__ is None
+    assert error.__suppress_context__ is True
+    # The formatted traceback (reported by the runtime) stays clean too.
+    traceback_text = "".join(
+        traceback.format_exception(type(error), error, error.__traceback__)
+    )
+    assert "s3cret" not in traceback_text
+    assert "reader:s3cret" not in traceback_text

--- a/uv.lock
+++ b/uv.lock
@@ -1683,7 +1683,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-redis"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "plugins/onestep-redis" }
 dependencies = [
     { name = "onestep" },


### PR DESCRIPTION
## Problem

The Redis connector (like the ClickHouse one) leaked credentials through two vectors:

1. **`ConnectorOperationError.cause`** stored the *raw* exception. redis-py connection errors embed the full `redis://:password@host` URL, so `str(cause)` exposed the password.
2. **Exception chaining** — every error path did `raise connector_error from exc`, chaining the secret-bearing original. The runtime reports failures via the legacy 3-arg `traceback.format_exception(type, value, tb)`, which **follows** `__cause__`/`__context__`, so the password reached `FailureInfo.traceback` (and thus the control plane).

## Fix

- `resilience.py`: add `collect_sensitive_tokens()` (extracts the connector URL userinfo + known secret option values) and `redacted_redis_cause()` that scrub those tokens from the message before it leaves the plugin.
- `connector.py`: pass the connector's `url`/`options` as `secrets=` and switch all three raise sites (`OPEN`/`FETCH`/`SEND`) from `from exc` to `from None` to break the public chain.
- Bump `onestep-redis` `0.2.1` → `0.2.2` and update `uv.lock`.

## Verification

- New `tests/test_redis_resilience.py` asserts the cause string, `__cause__`, `__suppress_context__`, and the full formatted traceback are all free of the secret URL.
- Existing suite: 22 passed, 1 skipped.
- Pre-existing `test_redis_plugin_normalizes_redis_errors` updated for the now-redacted cause type.