### PR TITLE
fix(rabbitmq): scrub credentials from connector errors

### DIFF
--- a/plugins/onestep-rabbitmq/pyproject.toml
+++ b/plugins/onestep-rabbitmq/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-mq"
-version = "0.2.1"
+version = "0.2.2"
 description = "RabbitMQ connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-rabbitmq/src/onestep_rabbitmq/connector.py
+++ b/plugins/onestep-rabbitmq/src/onestep_rabbitmq/connector.py
@@ -10,7 +10,7 @@ from onestep.resilience import ConnectorOperation, ConnectorOperationError
 from onestep.connectors.base import Delivery, Sink, Source
 from onestep.connectors.codec import decode_envelope, encode_envelope
 
-from .resilience import as_rabbitmq_connector_operation_error
+from .resilience import as_rabbitmq_connector_operation_error, collect_sensitive_tokens
 
 try:  # pragma: no cover - optional dependency
     import aio_pika
@@ -181,6 +181,10 @@ class RabbitMQQueue(Source, Sink):
         self._exchange: Any | None = None
         self._opened = False
 
+    def _connection_secrets(self) -> list[str]:
+        """Secret-bearing config tokens used to scrub error messages."""
+        return collect_sensitive_tokens(self.connector.url, self.connector.options)
+
     async def open(self) -> None:
         if self._opened:
             return
@@ -230,10 +234,11 @@ class RabbitMQQueue(Source, Sink):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=self.poll_interval_s,
+                secrets=self._connection_secrets(),
             )
             if connector_error is None:
                 raise
-            raise connector_error from exc
+            raise connector_error from None
 
     async def close(self) -> None:
         if not self._opened:
@@ -276,11 +281,12 @@ class RabbitMQQueue(Source, Sink):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=self.poll_interval_s,
+                secrets=self._connection_secrets(),
             )
             if connector_error is None:
                 raise
             await self._reset_transport_state(release_connection=True)
-            raise connector_error from exc
+            raise connector_error from None
 
     async def send(self, envelope: Envelope) -> None:
         try:
@@ -305,11 +311,12 @@ class RabbitMQQueue(Source, Sink):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=self.poll_interval_s,
+                secrets=self._connection_secrets(),
             )
             if connector_error is None:
                 raise
             await self._reset_transport_state(release_connection=True)
-            raise connector_error from exc
+            raise connector_error from None
 
     async def _reset_transport_state(self, *, release_connection: bool) -> None:
         try:

--- a/plugins/onestep-rabbitmq/src/onestep_rabbitmq/resilience.py
+++ b/plugins/onestep-rabbitmq/src/onestep_rabbitmq/resilience.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlsplit
 
 from onestep.resilience import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError
 
@@ -13,6 +16,84 @@ try:  # pragma: no cover - optional dependency
     import aiormq.exceptions as aiormq_exceptions
 except ImportError:  # pragma: no cover - optional dependency
     aiormq_exceptions = None
+
+_REDACTED = "<redacted>"
+_MAX_MESSAGE_LENGTH = 500
+_SECRET_OPTION_KEYS = frozenset(
+    {
+        "password",
+        "passwd",
+        "pwd",
+        "secret",
+        "token",
+        "access_token",
+        "api_key",
+        "apikey",
+        "credentials",
+        "authorization",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RabbitMQErrorCause(Exception):
+    message: str
+
+    def __str__(self) -> str:
+        return f"rabbitmq error: {self.message}"
+
+
+def collect_sensitive_tokens(*config_values: object) -> list[str]:
+    """Collect secret substrings that may surface in RabbitMQ error messages.
+
+    Tokens are derived from connector config: raw AMQP URI/connection-string
+    values (always included as a catch-all), their parsed userinfo, and known
+    secret keys inside option mappings. Error causes are scrubbed against these
+    before they leave the plugin.
+    """
+    tokens: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        if value is None:
+            return
+        text = str(value)
+        if text and text not in seen:
+            seen.add(text)
+            tokens.append(text)
+
+    for value in config_values:
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                if str(key).lower() in _SECRET_OPTION_KEYS:
+                    add(item)
+            continue
+        add(value)
+        try:
+            parsed = urlsplit(str(value))
+        except ValueError:
+            continue
+        username = parsed.username
+        password = parsed.password
+        if username and password:
+            add(f"{username}:{password}")
+            add(f"{username}:{password}@")
+        add(password)
+    return tokens
+
+
+def _redact_message(message: str, tokens: list[str]) -> str:
+    redacted = message
+    for token in sorted(tokens, key=len, reverse=True):
+        if token:
+            redacted = redacted.replace(token, _REDACTED)
+    return redacted[:_MAX_MESSAGE_LENGTH]
+
+
+def redacted_rabbitmq_cause(
+    exc: BaseException, *, secrets: list[str] | None = None
+) -> RabbitMQErrorCause:
+    return RabbitMQErrorCause(_redact_message(str(exc), secrets or []))
 
 
 def classify_rabbitmq_error(exc: BaseException) -> ConnectorErrorKind | None:
@@ -73,6 +154,7 @@ def as_rabbitmq_connector_operation_error(
     exc: BaseException,
     source_name: str | None = None,
     retry_delay_s: float | None = None,
+    secrets: list[str] | None = None,
 ) -> ConnectorOperationError | None:
     kind = classify_rabbitmq_error(exc)
     if kind is None:
@@ -83,5 +165,5 @@ def as_rabbitmq_connector_operation_error(
         kind=kind,
         source_name=source_name,
         retry_delay_s=retry_delay_s,
-        cause=exc,
+        cause=redacted_rabbitmq_cause(exc, secrets=secrets),
     )

--- a/plugins/onestep-rabbitmq/tests/test_rabbitmq_connector.py
+++ b/plugins/onestep-rabbitmq/tests/test_rabbitmq_connector.py
@@ -223,3 +223,40 @@ def test_rabbitmq_queue_open_maps_connection_errors_and_releases_reference(monke
             raise AssertionError("expected ConnectorOperationError")
 
     asyncio.run(scenario())
+
+
+def test_rabbitmq_open_failure_does_not_leak_url_credentials(monkeypatch):
+    """connect_robust errors embed the full amqp URL; it must be scrubbed."""
+    import traceback
+
+    secret_url = "amqp://writer:supersecret@rabbitmq.internal:5672//"
+
+    async def leaking_connect_robust(url, **kwargs):
+        raise ConnectionError(f"could not connect to {url}: ACCESS_REFUSED")
+
+    fake_driver = SimpleNamespace(connect_robust=leaking_connect_robust)
+    monkeypatch.setattr(rabbitmq_module, "aio_pika", fake_driver)
+
+    async def scenario():
+        connector = RabbitMQConnector(secret_url)
+        queue = connector.queue("jobs", poll_interval_s=0.01)
+        try:
+            await queue.open()
+        except ConnectorOperationError as error:
+            return error
+        raise AssertionError("expected ConnectorOperationError")
+
+    error = asyncio.run(scenario())
+    # The public ``cause`` must not carry credentials.
+    assert "supersecret" not in str(error.cause)
+    assert "writer:supersecret" not in str(error.cause)
+    assert "<redacted>" in str(error.cause)
+    # The original secret-bearing exception must not be chained.
+    assert error.__cause__ is None
+    assert error.__suppress_context__ is True
+    # The formatted traceback (reported by the runtime) stays clean too.
+    traceback_text = "".join(
+        traceback.format_exception(type(error), error, error.__traceback__)
+    )
+    assert "supersecret" not in traceback_text
+    assert "writer:supersecret" not in traceback_text

--- a/plugins/onestep-rabbitmq/tests/test_rabbitmq_plugin.py
+++ b/plugins/onestep-rabbitmq/tests/test_rabbitmq_plugin.py
@@ -7,7 +7,11 @@ from onestep.config import load_app_config
 from onestep.resilience import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError
 from onestep.resource_registry import ResourceRegistry
 from onestep_rabbitmq import RabbitMQConnector, RabbitMQQueue, register
-from onestep_rabbitmq.resilience import as_rabbitmq_connector_operation_error, classify_rabbitmq_error
+from onestep_rabbitmq.resilience import (
+    as_rabbitmq_connector_operation_error,
+    classify_rabbitmq_error,
+    RabbitMQErrorCause,
+)
 
 
 def test_package_exposes_onestep_resource_entry_point() -> None:
@@ -93,7 +97,8 @@ def test_rabbitmq_plugin_normalizes_rabbitmq_errors() -> None:
     assert normalized.kind is ConnectorErrorKind.DISCONNECTED
     assert normalized.source_name == "incoming_jobs"
     assert normalized.retry_delay_s == 1.0
-    assert normalized.cause is connection_error
+    assert isinstance(normalized.cause, RabbitMQErrorCause)
+    assert "connection refused" in str(normalized.cause)
 
 
 def _entry_points_for_group(group: str) -> tuple[Any, ...]:

--- a/uv.lock
+++ b/uv.lock
@@ -1591,7 +1591,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-mq"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "plugins/onestep-rabbitmq" }
 dependencies = [
     { name = "aio-pika", version = "9.5.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Problem

Same credential-leak class as redis/#92. The RabbitMQ connector stored the *raw* exception as `ConnectorOperationError.cause` (`cause=exc`) and chained it via `raise connector_error from exc` at all three sites (OPEN/FETCH/SEND). AMQP connection errors embed the full `amqp://user:password@host` URL, so the password leaked through:
- `str(cause)`, and
- the formatted traceback — the runtime reports failures via the legacy 3-arg `traceback.format_exception(type, value, tb)`, which follows `__cause__`/`__context__`, so the secret reached `FailureInfo.traceback` (and the control plane).

## Fix

- `resilience.py`: add `collect_sensitive_tokens()` (connector AMQP URL userinfo + known secret option values) and `redacted_rabbitmq_cause()` that scrub those tokens before they leave the plugin.
- `connector.py`: pass the connector's `url`/`options` as `secrets=` and switch OPEN/FETCH/SEND from `from exc` to `from None` to break the public chain.
- Bump `onestep-mq` `0.2.1` → `0.2.2` and update `uv.lock`.

## Verification

- New regression test `test_rabbitmq_open_failure_does_not_leak_url_credentials` asserts the cause string, `__cause__`, `__suppress_context__`, and the full formatted traceback are all free of the secret URL.
- Existing suite: 7 passed, 1 skipped. `test_rabbitmq_plugin_normalizes_rabbitmq_errors` updated for the now-redacted cause type.