### PR TITLE
fix(postgres): scrub credentials from connector errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 - Bundles the three plugins in the worker image and adds isolated reliability/live compatibility gates.
 - Does not change core runtime, delivery, retry, reporter, or control-plane behavior.
 
+## onestep-postgres 0.1.2
+
+- Scrubs DSN credentials and secret values nested in SQLAlchemy engine options from normalized Postgres error causes.
+- Suppresses raw exception chaining for fetch and send failures so reported tracebacks do not expose secrets.
+
+## onestep-kafka 0.1.2
+
+- Scrubs bootstrap-server credentials and connector, consumer, and producer secret options from normalized Kafka error causes.
+- Suppresses raw exception chaining for fetch and send failures so reported tracebacks do not expose secrets.
+
 ## onestep-redis 0.2.2
 
 - Scrubs connector URL credentials and known secret options from normalized Redis error causes.

--- a/plugins/onestep-postgres/pyproject.toml
+++ b/plugins/onestep-postgres/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-postgres"
-version = "0.1.1"
+version = "0.1.2"
 description = "PostgreSQL connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-postgres/src/onestep_postgres/connector.py
+++ b/plugins/onestep-postgres/src/onestep_postgres/connector.py
@@ -12,7 +12,7 @@ from onestep.envelope import Envelope
 from onestep.resilience import ConnectorOperation
 from onestep.state import CursorStore, InMemoryCursorStore
 
-from .resilience import as_postgres_connector_operation_error
+from .resilience import as_postgres_connector_operation_error, collect_sensitive_tokens
 from .state_sqlalchemy import SQLAlchemyCursorStore, SQLAlchemyStateStore
 
 try:
@@ -29,6 +29,10 @@ class PostgresConnector:
             raise RuntimeError("PostgresConnector requires SQLAlchemy. Install onestep-postgres.")
         self.dsn = dsn
         self.engine = create_engine(dsn, future=True, pool_pre_ping=True, **engine_options)
+
+    def _secret_tokens(self) -> list[str]:
+        """Secret-bearing config tokens used to scrub error messages."""
+        return collect_sensitive_tokens(self.dsn)
         self._tables: dict[str, Any] = {}
 
     async def close(self) -> None:
@@ -229,10 +233,11 @@ class PostgresTableQueueSource(Source):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=self.poll_interval_s,
+                secrets=self.connector._secret_tokens(),
             )
             if connector_error is None:
                 raise
-            raise connector_error from exc
+            raise connector_error from None
         deliveries: list[Delivery] = []
         for row in rows:
             key_value = row[self.key]
@@ -361,10 +366,11 @@ class PostgresIncrementalSource(Source):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=self.poll_interval_s,
+                secrets=self.connector._secret_tokens(),
             )
             if connector_error is None:
                 raise
-            raise connector_error from exc
+            raise connector_error from None
         deliveries: list[Delivery] = []
         for row in rows:
             token = _CursorToken(tuple(row[column] for column in self.cursor))
@@ -435,10 +441,11 @@ class PostgresTableSink(Sink):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=1.0,
+                secrets=self.connector._secret_tokens(),
             )
             if connector_error is None:
                 raise
-            raise connector_error from exc
+            raise connector_error from None
 
     def _send_sync(self, payload: dict[str, Any]) -> None:
         table = self.connector._table(self.table_name)

--- a/plugins/onestep-postgres/src/onestep_postgres/connector.py
+++ b/plugins/onestep-postgres/src/onestep_postgres/connector.py
@@ -28,12 +28,13 @@ class PostgresConnector:
         if create_engine is None:
             raise RuntimeError("PostgresConnector requires SQLAlchemy. Install onestep-postgres.")
         self.dsn = dsn
+        self._sensitive_tokens = collect_sensitive_tokens(dsn, engine_options)
         self.engine = create_engine(dsn, future=True, pool_pre_ping=True, **engine_options)
+        self._tables: dict[str, Any] = {}
 
     def _secret_tokens(self) -> list[str]:
         """Secret-bearing config tokens used to scrub error messages."""
-        return collect_sensitive_tokens(self.dsn)
-        self._tables: dict[str, Any] = {}
+        return list(self._sensitive_tokens)
 
     async def close(self) -> None:
         await asyncio.to_thread(self.engine.dispose)

--- a/plugins/onestep-postgres/src/onestep_postgres/resilience.py
+++ b/plugins/onestep-postgres/src/onestep_postgres/resilience.py
@@ -57,11 +57,16 @@ def collect_sensitive_tokens(*config_values: object) -> list[str]:
             seen.add(text)
             tokens.append(text)
 
+    def collect_mapping(value: Mapping[object, object]) -> None:
+        for key, item in value.items():
+            if str(key).lower() in _SECRET_OPTION_KEYS:
+                add(item)
+            elif isinstance(item, Mapping):
+                collect_mapping(item)
+
     for value in config_values:
         if isinstance(value, Mapping):
-            for key, item in value.items():
-                if str(key).lower() in _SECRET_OPTION_KEYS:
-                    add(item)
+            collect_mapping(value)
             continue
         add(value)
         try:

--- a/plugins/onestep-postgres/src/onestep_postgres/resilience.py
+++ b/plugins/onestep-postgres/src/onestep_postgres/resilience.py
@@ -1,11 +1,94 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
 from onestep.resilience import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError
 
 try:  # pragma: no cover - optional dependency
     import sqlalchemy as sa
 except ImportError:  # pragma: no cover - optional dependency
     sa = None
+
+_REDACTED = "<redacted>"
+_MAX_MESSAGE_LENGTH = 500
+_SECRET_OPTION_KEYS = frozenset(
+    {
+        "password",
+        "passwd",
+        "pwd",
+        "secret",
+        "token",
+        "access_token",
+        "api_key",
+        "apikey",
+        "credentials",
+        "authorization",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PostgresErrorCause(Exception):
+    message: str
+
+    def __str__(self) -> str:
+        return f"postgres error: {self.message}"
+
+
+def collect_sensitive_tokens(*config_values: object) -> list[str]:
+    """Collect secret substrings that may surface in Postgres error messages.
+
+    SQLAlchemy masks the password in its rendered URL, but the underlying DBAPI
+    ``orig`` exception can still echo credentials (e.g. ``connection to server
+    at postgresql://user:pass@host ...``). Tokens are derived from connector
+    config (raw DSN + parsed userinfo + known secret option values) and used to
+    scrub error causes before they leave the plugin.
+    """
+    tokens: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        if value is None:
+            return
+        text = str(value)
+        if text and text not in seen:
+            seen.add(text)
+            tokens.append(text)
+
+    for value in config_values:
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                if str(key).lower() in _SECRET_OPTION_KEYS:
+                    add(item)
+            continue
+        add(value)
+        try:
+            parsed = urlsplit(str(value))
+        except ValueError:
+            continue
+        username = parsed.username
+        password = parsed.password
+        if username and password:
+            add(f"{username}:{password}")
+            add(f"{username}:{password}@")
+        add(password)
+    return tokens
+
+
+def _redact_message(message: str, tokens: list[str]) -> str:
+    redacted = message
+    for token in sorted(tokens, key=len, reverse=True):
+        if token:
+            redacted = redacted.replace(token, _REDACTED)
+    return redacted[:_MAX_MESSAGE_LENGTH]
+
+
+def redacted_postgres_cause(
+    exc: BaseException, *, secrets: list[str] | None = None
+) -> PostgresErrorCause:
+    return PostgresErrorCause(_redact_message(str(exc), secrets or []))
 
 
 def classify_sqlalchemy_error(exc: BaseException) -> ConnectorErrorKind | None:
@@ -50,6 +133,7 @@ def as_postgres_connector_operation_error(
     exc: BaseException,
     source_name: str | None = None,
     retry_delay_s: float | None = None,
+    secrets: list[str] | None = None,
 ) -> ConnectorOperationError | None:
     kind = classify_sqlalchemy_error(exc)
     if kind is None:
@@ -60,5 +144,5 @@ def as_postgres_connector_operation_error(
         kind=kind,
         source_name=source_name,
         retry_delay_s=retry_delay_s,
-        cause=exc,
+        cause=redacted_postgres_cause(exc, secrets=secrets),
     )

--- a/plugins/onestep-postgres/tests/test_postgres_plugin.py
+++ b/plugins/onestep-postgres/tests/test_postgres_plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 from importlib import metadata as importlib_metadata
 from typing import Any
@@ -18,9 +19,9 @@ from onestep_postgres import (
     register,
 )
 from onestep_postgres.resilience import (
+    PostgresErrorCause,
     as_postgres_connector_operation_error,
     classify_sqlalchemy_error,
-    PostgresErrorCause,
 )
 
 
@@ -146,11 +147,6 @@ def _entry_points_for_group(group: str) -> tuple[Any, ...]:
 
 def test_postgres_connector_error_does_not_leak_dsn_credentials() -> None:
     """DBAPI ``orig`` exceptions can echo the DSN; it must be scrubbed."""
-    import traceback
-
-    from onestep import ConnectorOperationError
-    from onestep_postgres.resilience import as_postgres_connector_operation_error
-
     secret_dsn = "postgresql://reporter:pgpassword@db.internal:5432/appdb"
     import sqlalchemy as sa
 
@@ -172,3 +168,27 @@ def test_postgres_connector_error_does_not_leak_dsn_credentials() -> None:
     assert "pgpassword" not in str(normalized.cause)
     assert "reporter:pgpassword" not in str(normalized.cause)
     assert "<redacted>" in str(normalized.cause)
+
+
+def test_postgres_connector_error_does_not_leak_connect_args_password() -> None:
+    import sqlalchemy as sa
+
+    secret = "connect-args-password"
+    connector = PostgresConnector("sqlite://", connect_args={"password": secret})
+    source = connector.incremental(table="users", key="id", cursor=("id",))
+
+    def fail_fetch(limit: int) -> list[dict[str, Any]]:
+        raise sa.exc.OperationalError(
+            statement="SELECT 1",
+            params={},
+            orig=Exception(f"password {secret} was rejected"),
+        )
+
+    source._fetch_sync = fail_fetch
+
+    with pytest.raises(ConnectorOperationError) as exc_info:
+        asyncio.run(source.fetch(1))
+
+    assert secret not in str(exc_info.value.cause)
+    assert "<redacted>" in str(exc_info.value.cause)
+    asyncio.run(connector.close())

--- a/plugins/onestep-postgres/tests/test_postgres_plugin.py
+++ b/plugins/onestep-postgres/tests/test_postgres_plugin.py
@@ -17,7 +17,11 @@ from onestep_postgres import (
     SQLAlchemyStateStore,
     register,
 )
-from onestep_postgres.resilience import as_postgres_connector_operation_error, classify_sqlalchemy_error
+from onestep_postgres.resilience import (
+    as_postgres_connector_operation_error,
+    classify_sqlalchemy_error,
+    PostgresErrorCause,
+)
 
 
 def test_package_exposes_onestep_resource_entry_point() -> None:
@@ -77,7 +81,8 @@ def test_postgres_plugin_normalizes_sqlalchemy_errors() -> None:
     assert normalized.kind is ConnectorErrorKind.TRANSIENT
     assert normalized.source_name == "postgres.incremental:users"
     assert normalized.retry_delay_s == 2.0
-    assert normalized.cause is sql_error
+    assert isinstance(normalized.cause, PostgresErrorCause)
+    assert "timeout" in str(normalized.cause)
 
 
 def test_yaml_builds_postgres_resources_via_plugin_entry_point(tmp_path) -> None:
@@ -137,3 +142,33 @@ def _entry_points_for_group(group: str) -> tuple[Any, ...]:
     if hasattr(entry_points, "select"):
         return tuple(entry_points.select(group=group))
     return tuple(entry_points.get(group, ()))
+
+
+def test_postgres_connector_error_does_not_leak_dsn_credentials() -> None:
+    """DBAPI ``orig`` exceptions can echo the DSN; it must be scrubbed."""
+    import traceback
+
+    from onestep import ConnectorOperationError
+    from onestep_postgres.resilience import as_postgres_connector_operation_error
+
+    secret_dsn = "postgresql://reporter:pgpassword@db.internal:5432/appdb"
+    import sqlalchemy as sa
+
+    orig = sa.exc.OperationalError(
+        statement="SELECT 1",
+        params={},
+        orig=Exception(
+            f"connection to server at {secret_dsn} failed: "
+            "FATAL: password authentication failed"
+        ),
+    )
+    normalized = as_postgres_connector_operation_error(
+        operation=ConnectorOperation.FETCH,
+        exc=orig,
+        source_name="postgres.incremental:users",
+        secrets=[secret_dsn, "pgpassword"],
+    )
+    assert isinstance(normalized, ConnectorOperationError)
+    assert "pgpassword" not in str(normalized.cause)
+    assert "reporter:pgpassword" not in str(normalized.cause)
+    assert "<redacted>" in str(normalized.cause)

--- a/uv.lock
+++ b/uv.lock
@@ -1652,7 +1652,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-postgres"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "plugins/onestep-postgres" }
 dependencies = [
     { name = "onestep" },


### PR DESCRIPTION
## Problem

Same credential-leak class as redis/#92. The Postgres connector stored the raw exception as `ConnectorOperationError.cause` and chained it from fetch/send failures. SQLAlchemy masks URL passwords in its own rendering, but the underlying DBAPI exception can still echo the full DSN or a password supplied through engine options such as `connect_args`.

The first version of this PR also accidentally moved `self._tables = {}` below a `return`, which made table-backed sources fail with `AttributeError`.

## Fix

- Scrub DSN userinfo and known secret values nested in SQLAlchemy engine options before normalized errors leave the plugin.
- Replace raw causes with a redacted `PostgresErrorCause` and suppress raw exception chaining at all fetch/send normalization sites.
- Restore `_tables` initialization in `PostgresConnector.__init__`.
- Bump `onestep-postgres` from `0.1.1` to `0.1.2` and update the root `uv.lock`.
- Add Postgres 0.1.2 and Kafka 0.1.2 release notes to `CHANGELOG.md` after #92 had already merged.

## Verification

- Added DSN credential and nested `connect_args.password` regression coverage through the real connector error path.
- Postgres plugin tests: `17 passed, 1 skipped`.
- Full non-integration suite after merging current `main`: `198 passed`.
- `onestep-postgres` 0.1.2 sdist and wheel build successfully.
