### PR TITLE
fix(mysql): scrub credentials from connector errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,26 @@
 - Scrubs bootstrap-server credentials and connector, consumer, and producer secret options from normalized Kafka error causes.
 - Suppresses raw exception chaining for fetch and send failures so reported tracebacks do not expose secrets.
 
+## onestep-mysql 0.3.2
+
+- Scrubs DSN credentials and secret values nested in SQLAlchemy engine options from normalized MySQL error causes.
+- Suppresses raw exception chaining for fetch and send failures so reported tracebacks do not expose secrets.
+
+## onestep-sqs 0.2.3
+
+- Scrubs AWS credentials and known secret connector options from normalized SQS error causes.
+- Suppresses raw exception chaining for open, fetch, and send failures so reported tracebacks do not expose secrets.
+
+## onestep-clickhouse 0.1.1
+
+- Scrubs DSN credentials and known secret client options from normalized ClickHouse error causes.
+- Suppresses raw exception chaining for send failures so reported tracebacks do not expose secrets.
+
+## onestep-elasticsearch 0.1.1
+
+- Scrubs host userinfo, authentication values, and configured headers from normalized Elasticsearch and OpenSearch error causes.
+- Suppresses raw exception chaining for send failures so reported tracebacks do not expose secrets.
+
 ## onestep-redis 0.2.2
 
 - Scrubs connector URL credentials and known secret options from normalized Redis error causes.

--- a/plugins/onestep-mysql/pyproject.toml
+++ b/plugins/onestep-mysql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-mysql"
-version = "0.3.1"
+version = "0.3.2"
 description = "MySQL connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-mysql/src/onestep_mysql/connector.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/connector.py
@@ -40,12 +40,13 @@ class MySQLConnector:
         if create_engine is None:
             raise RuntimeError("MySQLConnector requires SQLAlchemy. Install onestep-mysql.")
         self.dsn = dsn
+        self._sensitive_tokens = collect_sensitive_tokens(dsn, engine_options)
         self.engine = create_engine(dsn, future=True, pool_pre_ping=True, **engine_options)
+        self._tables: dict[str, Any] = {}
 
     def _secret_tokens(self) -> list[str]:
         """Secret-bearing config tokens used to scrub error messages."""
-        return collect_sensitive_tokens(self.dsn)
-        self._tables: dict[str, Any] = {}
+        return list(self._sensitive_tokens)
 
     async def close(self) -> None:
         await asyncio.to_thread(self.engine.dispose)

--- a/plugins/onestep-mysql/src/onestep_mysql/connector.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/connector.py
@@ -13,7 +13,7 @@ from onestep.state import CursorStore, InMemoryCursorStore
 
 from onestep.connectors.base import Delivery, Sink, Source
 
-from .resilience import as_mysql_connector_operation_error
+from .resilience import as_mysql_connector_operation_error, collect_sensitive_tokens
 from .state_sqlalchemy import SQLAlchemyCursorStore, SQLAlchemyStateStore
 
 try:
@@ -41,6 +41,10 @@ class MySQLConnector:
             raise RuntimeError("MySQLConnector requires SQLAlchemy. Install onestep-mysql.")
         self.dsn = dsn
         self.engine = create_engine(dsn, future=True, pool_pre_ping=True, **engine_options)
+
+    def _secret_tokens(self) -> list[str]:
+        """Secret-bearing config tokens used to scrub error messages."""
+        return collect_sensitive_tokens(self.dsn)
         self._tables: dict[str, Any] = {}
 
     async def close(self) -> None:
@@ -283,10 +287,11 @@ class TableQueueSource(Source):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=self.poll_interval_s,
+                secrets=self.connector._secret_tokens(),
             )
             if connector_error is None:
                 raise
-            raise connector_error from exc
+            raise connector_error from None
         deliveries: list[Delivery] = []
         for row in rows:
             key_value = row[self.key]
@@ -431,10 +436,11 @@ class BinlogSource(Source):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=self.poll_interval_s,
+                secrets=self.connector._secret_tokens(),
             )
             if connector_error is None:
                 raise
-            raise connector_error from exc
+            raise connector_error from None
 
         deliveries: list[Delivery] = []
         for payload, token in rows:
@@ -664,10 +670,11 @@ class IncrementalTableSource(Source):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=self.poll_interval_s,
+                secrets=self.connector._secret_tokens(),
             )
             if connector_error is None:
                 raise
-            raise connector_error from exc
+            raise connector_error from None
         deliveries: list[Delivery] = []
         for row in rows:
             token = _CursorToken(tuple(row[column] for column in self.cursor))
@@ -738,10 +745,11 @@ class TableSink(Sink):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=1.0,
+                secrets=self.connector._secret_tokens(),
             )
             if connector_error is None:
                 raise
-            raise connector_error from exc
+            raise connector_error from None
 
     def _send_sync(self, payload: dict[str, Any]) -> None:
         table = self.connector._table(self.table_name)

--- a/plugins/onestep-mysql/src/onestep_mysql/resilience.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/resilience.py
@@ -1,11 +1,94 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
 from onestep.resilience import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError
 
 try:  # pragma: no cover - optional dependency
     import sqlalchemy as sa
 except ImportError:  # pragma: no cover - optional dependency
     sa = None
+
+_REDACTED = "<redacted>"
+_MAX_MESSAGE_LENGTH = 500
+_SECRET_OPTION_KEYS = frozenset(
+    {
+        "password",
+        "passwd",
+        "pwd",
+        "secret",
+        "token",
+        "access_token",
+        "api_key",
+        "apikey",
+        "credentials",
+        "authorization",
+    }
+)
+
+
+@dataclass(frozen=True)
+class MySQLErrorCause(Exception):
+    message: str
+
+    def __str__(self) -> str:
+        return f"mysql error: {self.message}"
+
+
+def collect_sensitive_tokens(*config_values: object) -> list[str]:
+    """Collect secret substrings that may surface in MySQL error messages.
+
+    SQLAlchemy masks the password in its rendered URL, but the underlying DBAPI
+    ``orig`` exception can still echo the full DSN (e.g. ``Access denied for
+    user 'user'@'host' (using password: YES)`` after echoing the connection
+    string). Tokens are derived from connector config and used to scrub error
+    causes before they leave the plugin.
+    """
+    tokens: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        if value is None:
+            return
+        text = str(value)
+        if text and text not in seen:
+            seen.add(text)
+            tokens.append(text)
+
+    for value in config_values:
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                if str(key).lower() in _SECRET_OPTION_KEYS:
+                    add(item)
+            continue
+        add(value)
+        try:
+            parsed = urlsplit(str(value))
+        except ValueError:
+            continue
+        username = parsed.username
+        password = parsed.password
+        if username and password:
+            add(f"{username}:{password}")
+            add(f"{username}:{password}@")
+        add(password)
+    return tokens
+
+
+def _redact_message(message: str, tokens: list[str]) -> str:
+    redacted = message
+    for token in sorted(tokens, key=len, reverse=True):
+        if token:
+            redacted = redacted.replace(token, _REDACTED)
+    return redacted[:_MAX_MESSAGE_LENGTH]
+
+
+def redacted_mysql_cause(
+    exc: BaseException, *, secrets: list[str] | None = None
+) -> MySQLErrorCause:
+    return MySQLErrorCause(_redact_message(str(exc), secrets or []))
 
 
 def classify_sqlalchemy_error(exc: BaseException) -> ConnectorErrorKind | None:
@@ -48,6 +131,7 @@ def as_mysql_connector_operation_error(
     exc: BaseException,
     source_name: str | None = None,
     retry_delay_s: float | None = None,
+    secrets: list[str] | None = None,
 ) -> ConnectorOperationError | None:
     kind = classify_sqlalchemy_error(exc)
     if kind is None:
@@ -58,5 +142,5 @@ def as_mysql_connector_operation_error(
         kind=kind,
         source_name=source_name,
         retry_delay_s=retry_delay_s,
-        cause=exc,
+        cause=redacted_mysql_cause(exc, secrets=secrets),
     )

--- a/plugins/onestep-mysql/src/onestep_mysql/resilience.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/resilience.py
@@ -57,11 +57,16 @@ def collect_sensitive_tokens(*config_values: object) -> list[str]:
             seen.add(text)
             tokens.append(text)
 
+    def collect_mapping(value: Mapping[object, object]) -> None:
+        for key, item in value.items():
+            if str(key).lower() in _SECRET_OPTION_KEYS:
+                add(item)
+            elif isinstance(item, Mapping):
+                collect_mapping(item)
+
     for value in config_values:
         if isinstance(value, Mapping):
-            for key, item in value.items():
-                if str(key).lower() in _SECRET_OPTION_KEYS:
-                    add(item)
+            collect_mapping(value)
             continue
         add(value)
         try:

--- a/plugins/onestep-mysql/tests/test_mysql_plugin.py
+++ b/plugins/onestep-mysql/tests/test_mysql_plugin.py
@@ -18,7 +18,11 @@ from onestep_mysql import (
     TableSink,
     register,
 )
-from onestep_mysql.resilience import as_mysql_connector_operation_error, classify_sqlalchemy_error
+from onestep_mysql.resilience import (
+    as_mysql_connector_operation_error,
+    classify_sqlalchemy_error,
+    MySQLErrorCause,
+)
 
 
 def test_package_exposes_onestep_resource_entry_point() -> None:
@@ -78,7 +82,8 @@ def test_mysql_plugin_normalizes_sqlalchemy_errors() -> None:
     assert normalized.kind is ConnectorErrorKind.TRANSIENT
     assert normalized.source_name == "mysql.incremental:users"
     assert normalized.retry_delay_s == 2.0
-    assert normalized.cause is sql_error
+    assert isinstance(normalized.cause, MySQLErrorCause)
+    assert "timeout" in str(normalized.cause)
 
 
 def test_yaml_builds_mysql_resources_via_plugin_entry_point(tmp_path) -> None:
@@ -150,3 +155,28 @@ def _entry_points_for_group(group: str) -> tuple[Any, ...]:
     if hasattr(entry_points, "select"):
         return tuple(entry_points.select(group=group))
     return tuple(entry_points.get(group, ()))
+
+
+def test_mysql_connector_error_does_not_leak_dsn_credentials() -> None:
+    """DBAPI ``orig`` exceptions can echo the DSN; it must be scrubbed."""
+    import sqlalchemy as sa
+
+    secret_dsn = "mysql://reporter:mysqlpass@db.internal:3306/appdb"
+    orig = sa.exc.OperationalError(
+        statement="SELECT 1",
+        params={},
+        orig=Exception(
+            f"Access denied for user 'reporter'@'host' (using password: YES) "
+            f"connecting to {secret_dsn}"
+        ),
+    )
+    normalized = as_mysql_connector_operation_error(
+        operation=ConnectorOperation.FETCH,
+        exc=orig,
+        source_name="mysql.incremental:users",
+        secrets=[secret_dsn, "mysqlpass", "reporter:mysqlpass"],
+    )
+    assert isinstance(normalized, ConnectorOperationError)
+    assert "mysqlpass" not in str(normalized.cause)
+    assert "reporter:mysqlpass" not in str(normalized.cause)
+    assert "<redacted>" in str(normalized.cause)

--- a/plugins/onestep-mysql/tests/test_mysql_plugin.py
+++ b/plugins/onestep-mysql/tests/test_mysql_plugin.py
@@ -5,10 +5,6 @@ from importlib import metadata as importlib_metadata
 from typing import Any
 
 import pytest
-
-from onestep.resilience import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError
-from onestep.config import load_app_config
-from onestep.resource_registry import ResourceRegistry
 from onestep_mysql import (
     BinlogSource,
     IncrementalTableSource,
@@ -19,10 +15,18 @@ from onestep_mysql import (
     register,
 )
 from onestep_mysql.resilience import (
+    MySQLErrorCause,
     as_mysql_connector_operation_error,
     classify_sqlalchemy_error,
-    MySQLErrorCause,
 )
+
+from onestep.config import load_app_config
+from onestep.resilience import (
+    ConnectorErrorKind,
+    ConnectorOperation,
+    ConnectorOperationError,
+)
+from onestep.resource_registry import ResourceRegistry
 
 
 def test_package_exposes_onestep_resource_entry_point() -> None:
@@ -180,3 +184,13 @@ def test_mysql_connector_error_does_not_leak_dsn_credentials() -> None:
     assert "mysqlpass" not in str(normalized.cause)
     assert "reporter:mysqlpass" not in str(normalized.cause)
     assert "<redacted>" in str(normalized.cause)
+
+
+def test_mysql_connector_initializes_cache_and_collects_engine_option_secrets() -> None:
+    connector = MySQLConnector(
+        "sqlite://",
+        connect_args={"password": "engine-option-secret"},
+    )
+
+    assert connector._tables == {}
+    assert "engine-option-secret" in connector._secret_tokens()

--- a/uv.lock
+++ b/uv.lock
@@ -1620,7 +1620,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-mysql"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "plugins/onestep-mysql" }
 dependencies = [
     { name = "mysql-replication" },


### PR DESCRIPTION
## Problem

The MySQL connector exposed raw SQLAlchemy/DBAPI exceptions as `ConnectorOperationError.cause` and chained them into the public traceback. Credentials can appear in the DSN or in nested engine options such as `connect_args.password`.

The initial credential-redaction change also moved `self._tables` initialization below a `return`, breaking every table-backed MySQL resource.

## Fix

- Collect DSN credentials and secret values recursively from SQLAlchemy engine options before creating the engine.
- Restore `_tables` initialization to `MySQLConnector.__init__`.
- Pass precomputed secret tokens to all normalized fetch/send errors and suppress raw exception chaining.
- Bump `onestep-mysql` from `0.3.1` to `0.3.2` and update the root lockfile.
- Add changelog entries for the pending MySQL, SQS, ClickHouse, and Elasticsearch plugin releases.

## Verification

- Added regression coverage for table-cache initialization and nested engine-option credentials.
- MySQL plugin suite: 20 passed, 1 skipped.
- GitHub checks: 43 passed, 0 failed, 13 skipped.
