### PR TITLE
fix(sqs): scrub credentials from connector errors

### DIFF
--- a/plugins/onestep-sqs/pyproject.toml
+++ b/plugins/onestep-sqs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-sqs"
-version = "0.2.2"
+version = "0.2.3"
 description = "Amazon SQS connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-sqs/src/onestep_sqs/connector.py
+++ b/plugins/onestep-sqs/src/onestep_sqs/connector.py
@@ -10,7 +10,7 @@ from onestep.resilience import ConnectorOperation, ConnectorOperationError
 from onestep.connectors.base import Delivery, Sink, Source
 from onestep.connectors.codec import decode_envelope, encode_envelope
 
-from .resilience import as_sqs_connector_operation_error
+from .resilience import as_sqs_connector_operation_error, collect_sensitive_tokens
 
 try:  # pragma: no cover - optional dependency
     import boto3
@@ -91,6 +91,10 @@ class SQSDelivery(Delivery):
 class SQSConnector:
     region_name: str | None = None
     options: dict[str, Any] | None = None
+
+    def _secret_tokens(self) -> list[str]:
+        """Secret-bearing config tokens used to scrub error messages."""
+        return collect_sensitive_tokens(self.options)
     client: Any | None = None
     _client: Any | None = field(default=None, init=False, repr=False)
 
@@ -204,10 +208,11 @@ class SQSQueue(Source, Sink):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=max(self.poll_interval_s, float(self.wait_time_s)),
+                secrets=self.connector._secret_tokens(),
             )
             if connector_error is None:
                 raise
-            raise connector_error from exc
+            raise connector_error from None
 
     async def close(self) -> None:
         if self._delete_flusher_task is not None:
@@ -245,10 +250,11 @@ class SQSQueue(Source, Sink):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=max(self.poll_interval_s, float(self.wait_time_s)),
+                secrets=self.connector._secret_tokens(),
             )
             if connector_error is None:
                 raise
-            raise connector_error from exc
+            raise connector_error from None
 
     async def send(self, envelope: Envelope) -> None:
         try:
@@ -273,10 +279,11 @@ class SQSQueue(Source, Sink):
                 exc=exc,
                 source_name=self.name,
                 retry_delay_s=max(self.poll_interval_s, float(self.wait_time_s)),
+                secrets=self.connector._secret_tokens(),
             )
             if connector_error is None:
                 raise
-            raise connector_error from exc
+            raise connector_error from None
 
     async def stage_delete(self, message: dict[str, Any]) -> None:
         await self.open()

--- a/plugins/onestep-sqs/src/onestep_sqs/resilience.py
+++ b/plugins/onestep-sqs/src/onestep_sqs/resilience.py
@@ -1,11 +1,77 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
+
 from onestep.resilience import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError
 
 try:  # pragma: no cover - optional dependency
     import botocore.exceptions as botocore_exceptions
 except ImportError:  # pragma: no cover - optional dependency
     botocore_exceptions = None
+
+_REDACTED = "<redacted>"
+_MAX_MESSAGE_LENGTH = 500
+_SECRET_OPTION_KEYS = frozenset(
+    {
+        "password",
+        "secret",
+        "token",
+        "access_token",
+        "aws_secret_access_key",
+        "aws_access_key_id",
+        "aws_session_token",
+        "api_key",
+        "apikey",
+        "credentials",
+        "authorization",
+    }
+)
+
+
+@dataclass(frozen=True)
+class SQSErrorCause(Exception):
+    message: str
+
+    def __str__(self) -> str:
+        return f"sqs error: {self.message}"
+
+
+def collect_sensitive_tokens(*config_values: object) -> list[str]:
+    """Collect secret option values that may surface in SQS error messages."""
+    tokens: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        if value is None:
+            return
+        text = str(value)
+        if text and text not in seen:
+            seen.add(text)
+            tokens.append(text)
+
+    for value in config_values:
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                if str(key).lower() in _SECRET_OPTION_KEYS:
+                    add(item)
+            continue
+        add(value)
+    return tokens
+
+
+def _redact_message(message: str, tokens: list[str]) -> str:
+    redacted = message
+    for token in sorted(tokens, key=len, reverse=True):
+        if token:
+            redacted = redacted.replace(token, _REDACTED)
+    return redacted[:_MAX_MESSAGE_LENGTH]
+
+
+def redacted_sqs_cause(
+    exc: BaseException, *, secrets: list[str] | None = None
+) -> SQSErrorCause:
+    return SQSErrorCause(_redact_message(str(exc), secrets or []))
 
 
 def classify_sqs_error(exc: BaseException) -> ConnectorErrorKind | None:
@@ -53,6 +119,7 @@ def as_sqs_connector_operation_error(
     exc: BaseException,
     source_name: str | None = None,
     retry_delay_s: float | None = None,
+    secrets: list[str] | None = None,
 ) -> ConnectorOperationError | None:
     kind = classify_sqs_error(exc)
     if kind is None:
@@ -63,5 +130,5 @@ def as_sqs_connector_operation_error(
         kind=kind,
         source_name=source_name,
         retry_delay_s=retry_delay_s,
-        cause=exc,
+        cause=redacted_sqs_cause(exc, secrets=secrets),
     )

--- a/plugins/onestep-sqs/tests/test_sqs_plugin.py
+++ b/plugins/onestep-sqs/tests/test_sqs_plugin.py
@@ -7,7 +7,11 @@ from onestep.config import load_app_config
 from onestep.resilience import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError
 from onestep.resource_registry import ResourceRegistry
 from onestep_sqs import SQSConnector, SQSQueue, register
-from onestep_sqs.resilience import as_sqs_connector_operation_error, classify_sqs_error
+from onestep_sqs.resilience import (
+    as_sqs_connector_operation_error,
+    classify_sqs_error,
+    SQSErrorCause,
+)
 
 
 def test_package_exposes_onestep_resource_entry_point() -> None:
@@ -89,7 +93,8 @@ def test_sqs_plugin_normalizes_sqs_errors() -> None:
     assert normalized.kind is ConnectorErrorKind.DISCONNECTED
     assert normalized.source_name == "jobs"
     assert normalized.retry_delay_s == 3.0
-    assert normalized.cause is timeout
+    assert isinstance(normalized.cause, SQSErrorCause)
+    assert "timeout" in str(normalized.cause)
 
 
 def _entry_points_for_group(group: str) -> tuple[Any, ...]:
@@ -97,3 +102,23 @@ def _entry_points_for_group(group: str) -> tuple[Any, ...]:
     if hasattr(entry_points, "select"):
         return tuple(entry_points.select(group=group))
     return tuple(entry_points.get(group, ()))
+
+
+def test_sqs_connector_error_does_not_leak_option_secrets() -> None:
+    """SQS connector options that contain AWS keys must not appear in errors."""
+    secret_key = "AKIAIOSFODNN7EXAMPLE"
+    secret_token = "IQoJb3JpZ2luX2VjEPn//////////wEaCXVzLXdlc3QtMiJIMEYCIQ"
+
+    # Use a ConnectionError (matches classify_sqs_error) with secret payload
+    error = ConnectionError(f"Access denied with key {secret_key} and token {secret_token}")
+    normalized = as_sqs_connector_operation_error(
+        operation=ConnectorOperation.SEND,
+        exc=error,
+        source_name="jobs",
+        retry_delay_s=3.0,
+        secrets=[secret_key, secret_token],
+    )
+    assert isinstance(normalized, ConnectorOperationError)
+    assert secret_key not in str(normalized.cause)
+    assert secret_token not in str(normalized.cause)
+    assert "<redacted>" in str(normalized.cause)

--- a/plugins/onestep-sqs/tests/test_sqs_plugin.py
+++ b/plugins/onestep-sqs/tests/test_sqs_plugin.py
@@ -1,17 +1,25 @@
 from __future__ import annotations
 
+import asyncio
 from importlib import metadata as importlib_metadata
 from typing import Any
 
-from onestep.config import load_app_config
-from onestep.resilience import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError
-from onestep.resource_registry import ResourceRegistry
+import pytest
 from onestep_sqs import SQSConnector, SQSQueue, register
 from onestep_sqs.resilience import (
+    SQSErrorCause,
     as_sqs_connector_operation_error,
     classify_sqs_error,
-    SQSErrorCause,
 )
+
+from onestep import Envelope
+from onestep.config import load_app_config
+from onestep.resilience import (
+    ConnectorErrorKind,
+    ConnectorOperation,
+    ConnectorOperationError,
+)
+from onestep.resource_registry import ResourceRegistry
 
 
 def test_package_exposes_onestep_resource_entry_point() -> None:
@@ -105,20 +113,28 @@ def _entry_points_for_group(group: str) -> tuple[Any, ...]:
 
 
 def test_sqs_connector_error_does_not_leak_option_secrets() -> None:
-    """SQS connector options that contain AWS keys must not appear in errors."""
     secret_key = "AKIAIOSFODNN7EXAMPLE"
     secret_token = "IQoJb3JpZ2luX2VjEPn//////////wEaCXVzLXdlc3QtMiJIMEYCIQ"
 
-    # Use a ConnectionError (matches classify_sqs_error) with secret payload
-    error = ConnectionError(f"Access denied with key {secret_key} and token {secret_token}")
-    normalized = as_sqs_connector_operation_error(
-        operation=ConnectorOperation.SEND,
-        exc=error,
-        source_name="jobs",
-        retry_delay_s=3.0,
-        secrets=[secret_key, secret_token],
+    class BrokenClient:
+        def send_message(self, **kwargs: Any) -> None:
+            raise ConnectionError(
+                f"Access denied with key {secret_key} and token {secret_token}"
+            )
+
+    connector = SQSConnector(
+        options={
+            "aws_access_key_id": secret_key,
+            "aws_session_token": secret_token,
+        },
+        client=BrokenClient(),
     )
-    assert isinstance(normalized, ConnectorOperationError)
-    assert secret_key not in str(normalized.cause)
-    assert secret_token not in str(normalized.cause)
-    assert "<redacted>" in str(normalized.cause)
+    queue = connector.queue("https://sqs.example.test/123/jobs", wait_time_s=0)
+
+    with pytest.raises(ConnectorOperationError) as captured:
+        asyncio.run(queue.send(Envelope(body={"job": 1})))
+
+    cause = str(captured.value.cause)
+    assert secret_key not in cause
+    assert secret_token not in cause
+    assert "<redacted>" in cause

--- a/uv.lock
+++ b/uv.lock
@@ -1722,7 +1722,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-sqs"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "plugins/onestep-sqs" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Problem

The SQS connector exposed raw exceptions as `ConnectorOperationError.cause` and chained them into the public traceback. Connector options can contain AWS credentials such as `aws_secret_access_key` and `aws_session_token`.

## Fix

- Collect known secret values from the exact options passed to `boto3.client`.
- Pass those tokens through the open, fetch, and send normalization paths.
- Suppress raw exception chaining so formatted tracebacks cannot recover the original exception.
- Bump `onestep-sqs` from `0.2.2` to `0.2.3` and update the root lockfile.
- The release changelog entry is carried by #96, which merges first.

## Verification

- The credential regression test now exercises the real `SQSQueue.send()` path with secrets supplied through `SQSConnector.options`.
- SQS plugin suite: 18 passed, 1 skipped.
- GitHub checks: 43 passed, 0 failed, 13 skipped.
