### PR TITLE
fix(clickhouse): scrub credentials from connector errors

### DIFF
--- a/plugins/onestep-clickhouse/pyproject.toml
+++ b/plugins/onestep-clickhouse/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-clickhouse"
-version = "0.1.0"
+version = "0.1.1"
 description = "ClickHouse connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-clickhouse/src/onestep_clickhouse/connector.py
+++ b/plugins/onestep-clickhouse/src/onestep_clickhouse/connector.py
@@ -140,7 +140,7 @@ class ClickHouseTableSink(Sink):
                 kind=ConnectorErrorKind.PERMANENT,
                 source_name=self.name,
                 cause=exc,
-            ) from exc
+            ) from None
         committed = 0
         try:
             client = await self.connector._get_client()
@@ -169,5 +169,9 @@ class ClickHouseTableSink(Sink):
                 operation=ConnectorOperation.SEND,
                 kind=kind,
                 source_name=self.name,
-                cause=redacted_clickhouse_cause(exc),
-            ) from exc
+                cause=redacted_clickhouse_cause(
+                    exc,
+                    dsn=self.connector.dsn,
+                    client_options=self.connector.client_options,
+                ),
+            ) from None

--- a/plugins/onestep-clickhouse/src/onestep_clickhouse/resilience.py
+++ b/plugins/onestep-clickhouse/src/onestep_clickhouse/resilience.py
@@ -1,8 +1,28 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
 
 from onestep import ConnectorErrorKind
+
+_REDACTED = "<redacted>"
+_MAX_MESSAGE_LENGTH = 500
+_SECRET_OPTION_KEYS = frozenset(
+    {
+        "password",
+        "passwd",
+        "pwd",
+        "secret",
+        "token",
+        "access_token",
+        "api_key",
+        "apikey",
+        "credentials",
+        "authorization",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -14,8 +34,60 @@ class ClickHouseErrorCause(Exception):
         return f"ClickHouse error code={self.code}: {self.message}"
 
 
-def redacted_clickhouse_cause(exc: BaseException) -> ClickHouseErrorCause:
-    return ClickHouseErrorCause(getattr(exc, "code", None), str(exc)[:500])
+def collect_sensitive_tokens(dsn: str, client_options: dict[str, Any]) -> list[str]:
+    """Collect secret substrings from ClickHouse connector config.
+
+    Returns a list of sensitive tokens (parsed userinfo, password,
+    and known secret client_options values) that must be scrubbed from error
+    messages before they leave the plugin.
+
+    Non-sensitive parts of the DSN (host, port, database) are intentionally
+    excluded so that error messages remain useful for debugging.
+    """
+    tokens: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        if value is None:
+            return
+        text = str(value)
+        if text and text not in seen:
+            seen.add(text)
+            tokens.append(text)
+
+    try:
+        parsed = urlsplit(dsn)
+        username = parsed.username
+        password = parsed.password
+        if username and password:
+            add(f"{username}:{password}")
+            add(f"{username}:{password}@")
+        add(password)
+    except ValueError:
+        pass
+
+    for key, item in client_options.items():
+        if str(key).lower() in _SECRET_OPTION_KEYS:
+            add(item)
+
+    return tokens
+
+
+def _redact_message(message: str, tokens: list[str]) -> str:
+    redacted = message
+    for token in sorted(tokens, key=len, reverse=True):
+        if token:
+            redacted = redacted.replace(token, _REDACTED)
+    return redacted[:_MAX_MESSAGE_LENGTH]
+
+
+def redacted_clickhouse_cause(
+    exc: BaseException,
+    dsn: str | None = None,
+    client_options: dict[str, Any] | None = None,
+) -> ClickHouseErrorCause:
+    tokens = collect_sensitive_tokens(dsn or "", client_options or {})
+    return ClickHouseErrorCause(getattr(exc, "code", None), _redact_message(str(exc), tokens))
 
 
 def classify_clickhouse_error(exc: BaseException) -> ConnectorErrorKind | None:

--- a/plugins/onestep-clickhouse/tests/test_clickhouse_connector.py
+++ b/plugins/onestep-clickhouse/tests/test_clickhouse_connector.py
@@ -290,3 +290,32 @@ async def test_runtime_ack_follows_clickhouse_insert_acknowledgement() -> None:
     release.set()
     await asyncio.wait_for(serving, timeout=2.0)
     assert delivery.acked is True
+
+
+@pytest.mark.asyncio
+async def test_send_failure_does_not_leak_dsn_credentials(monkeypatch) -> None:
+    """The DSN password and client_options passwords must be scrubbed from errors."""
+    import clickhouse_connect
+
+    secret_dsn = "http://writer:supersecret@clickhouse:8123/default"
+
+    async def fail_client(**options):
+        raise ConnectionError(
+            f"cannot connect to {secret_dsn} with password 'supersecret'"
+        )
+
+    monkeypatch.setattr(clickhouse_connect, "get_async_client", fail_client)
+    sink = ClickHouseConnector(
+        secret_dsn,
+        client_options={"password": "supersecret"},
+    ).table_sink(table="events", columns=("id",))
+
+    with pytest.raises(ConnectorOperationError) as captured:
+        await sink.send(Envelope(body={"id": 1}))
+
+    err_str = str(captured.value.cause)
+    assert "supersecret" not in err_str
+    assert "writer:supersecret" not in err_str
+    assert "<redacted>" in err_str
+    # Non-sensitive info should be preserved
+    assert "default" in err_str

--- a/plugins/onestep-clickhouse/tests/test_clickhouse_resilience.py
+++ b/plugins/onestep-clickhouse/tests/test_clickhouse_resilience.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from onestep import ConnectorErrorKind
 from onestep_clickhouse.resilience import (
     classify_clickhouse_error,
+    collect_sensitive_tokens,
     redacted_clickhouse_cause,
 )
 
@@ -40,3 +41,50 @@ def test_redacted_cause_preserves_code_but_caps_message() -> None:
     cause = redacted_clickhouse_cause(ServerError(53, "x" * 1000))
     assert cause.code == 53
     assert len(str(cause)) < 600
+
+
+def test_collect_sensitive_tokens_extracts_dsn_userinfo_and_options() -> None:
+    tokens = collect_sensitive_tokens(
+        "clickhouse://writer:supersecret@ch.internal:9000/default",
+        {"password": "supersecret", "access_token": "tok123"},
+    )
+    # The raw DSN is NOT included (only parsed userinfo + option values)
+    assert "clickhouse://writer:supersecret@ch.internal:9000/default" not in tokens
+    assert "writer:supersecret" in tokens
+    assert "writer:supersecret@" in tokens
+    assert "supersecret" in tokens
+    assert "tok123" in tokens
+
+
+def test_collect_sensitive_tokens_handles_dsn_without_userinfo() -> None:
+    tokens = collect_sensitive_tokens(
+        "clickhouse://ch.internal:9000/default", {}
+    )
+    assert tokens == []
+
+
+def test_redacted_cause_scrubs_dsn_credentials_and_option_secrets() -> None:
+    exc = ServerError(
+        516,
+        "Failed to connect to clickhouse://writer:supersecret@ch.internal:9000/default: "
+        "Authentication failed for user writer with password 'supersecret'",
+    )
+    cause = redacted_clickhouse_cause(
+        exc,
+        dsn="clickhouse://writer:supersecret@ch.internal:9000/default",
+        client_options={"password": "supersecret"},
+    )
+    result = str(cause)
+    assert "supersecret" not in result
+    assert "writer:supersecret" not in result
+    assert "<redacted>" in result
+    # Non-sensitive parts should be preserved
+    assert "default" in result
+    assert "Authentication failed" in result
+
+
+def test_redacted_cause_without_secrets_keeps_message_intact() -> None:
+    exc = ServerError(53, "type mismatch")
+    cause = redacted_clickhouse_cause(exc)
+    assert "type mismatch" in str(cause)
+    assert cause.code == 53

--- a/uv.lock
+++ b/uv.lock
@@ -1409,7 +1409,7 @@ provides-extras = ["control-plane", "yaml", "mysql", "postgres", "rabbitmq", "re
 
 [[package]]
 name = "onestep-clickhouse"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "plugins/onestep-clickhouse" }
 dependencies = [
     { name = "clickhouse-connect", version = "0.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Problem

The ClickHouse connector exposed raw exceptions as `ConnectorOperationError.cause` and chained them into the public traceback. The DSN and client options can contain credentials.

## Fix

- Parse DSN userinfo and collect known secret client-option values.
- Scrub those tokens from normalized ClickHouse causes before truncating diagnostics.
- Suppress raw exception chaining on send failures.
- Bump `onestep-clickhouse` from `0.1.0` to `0.1.1` and update the root lockfile.
- The release changelog entry is carried by #96, which merges first.

## Verification

- Covers DSNs with and without userinfo, secret client options, redacted diagnostics, and the real send failure path.
- ClickHouse plugin suite on the sequential merge result: 47 passed, 1 skipped.
- GitHub checks: 39 passed, 0 failed, 11 skipped.
