### PR TITLE
fix(elasticsearch): scrub credentials from connector errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Bundles the three plugins in the worker image and adds isolated reliability/live compatibility gates.
 - Does not change core runtime, delivery, retry, reporter, or control-plane behavior.
 
+## onestep-elasticsearch 0.1.1
+
+- Keeps connector error diagnostics useful without exposing configured authentication credentials, custom header values, or URL-embedded passwords.
+
 ## onestep-elasticsearch 0.1.0
 
 - Adds the common Elasticsearch/OpenSearch HTTP connector and acknowledged bulk sink.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 - Bundles the three plugins in the worker image and adds isolated reliability/live compatibility gates.
 - Does not change core runtime, delivery, retry, reporter, or control-plane behavior.
 
-## onestep-elasticsearch 0.1.1
-
-- Keeps connector error diagnostics useful without exposing configured authentication credentials, custom header values, or URL-embedded passwords.
-
 ## onestep-elasticsearch 0.1.0
 
 - Adds the common Elasticsearch/OpenSearch HTTP connector and acknowledged bulk sink.

--- a/plugins/onestep-elasticsearch/pyproject.toml
+++ b/plugins/onestep-elasticsearch/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-elasticsearch"
-version = "0.1.0"
+version = "0.1.1"
 description = "Elasticsearch and OpenSearch connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-elasticsearch/src/onestep_elasticsearch/connector.py
+++ b/plugins/onestep-elasticsearch/src/onestep_elasticsearch/connector.py
@@ -13,7 +13,12 @@ from onestep import (
     Sink,
 )
 
-from .resilience import classify_elasticsearch_exception, classify_elasticsearch_status, redacted_es_cause
+from .resilience import (
+    classify_elasticsearch_exception,
+    classify_elasticsearch_status,
+    collect_sensitive_tokens,
+    redacted_es_cause,
+)
 
 
 def _logical_document_views(body: Any) -> Sequence[Mapping[str, Any]]:
@@ -133,7 +138,8 @@ class ElasticsearchConnector:
             self.api_key,
             self.bearer_token,
             self.client_key,
-            self.headers,
+            *self._auth_headers().values(),
+            urls=self.hosts,
         )
 
     async def _get_client(self):

--- a/plugins/onestep-elasticsearch/src/onestep_elasticsearch/connector.py
+++ b/plugins/onestep-elasticsearch/src/onestep_elasticsearch/connector.py
@@ -13,7 +13,7 @@ from onestep import (
     Sink,
 )
 
-from .resilience import classify_elasticsearch_exception, classify_elasticsearch_status
+from .resilience import classify_elasticsearch_exception, classify_elasticsearch_status, redacted_es_cause
 
 
 def _logical_document_views(body: Any) -> Sequence[Mapping[str, Any]]:
@@ -124,6 +124,17 @@ class ElasticsearchConnector:
         ):
             result = result.replace(secret, "<redacted>")
         return result
+
+    def _secret_tokens(self) -> list[str]:
+        """Secret-bearing config tokens used to scrub error messages."""
+        return collect_sensitive_tokens(
+            self.username,
+            self.password,
+            self.api_key,
+            self.bearer_token,
+            self.client_key,
+            self.headers,
+        )
 
     async def _get_client(self):
         import httpx
@@ -479,7 +490,7 @@ class ElasticsearchBulkSink(Sink):
                 kind=ConnectorErrorKind.PERMANENT,
                 source_name=self.name,
                 cause=exc,
-            ) from exc
+            ) from None
         committed_chunks = 0
         try:
             for chunk in chunks:
@@ -502,7 +513,7 @@ class ElasticsearchBulkSink(Sink):
                 kind=kind,
                 source_name=self.name,
                 cause=exc,
-            ) from exc
+            ) from None
         except (TypeError, ValueError) as exc:
             raise ConnectorOperationError(
                 backend="elasticsearch",
@@ -510,7 +521,7 @@ class ElasticsearchBulkSink(Sink):
                 kind=ConnectorErrorKind.PERMANENT,
                 source_name=self.name,
                 cause=exc,
-            ) from exc
+            ) from None
         except Exception as exc:
             kind = classify_elasticsearch_exception(exc)
             if kind is None:
@@ -522,5 +533,5 @@ class ElasticsearchBulkSink(Sink):
                 operation=ConnectorOperation.SEND,
                 kind=kind,
                 source_name=self.name,
-                cause=exc,
-            ) from exc
+                cause=redacted_es_cause(exc, secrets=self.connector._secret_tokens()),
+            ) from None

--- a/plugins/onestep-elasticsearch/src/onestep_elasticsearch/resilience.py
+++ b/plugins/onestep-elasticsearch/src/onestep_elasticsearch/resilience.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import ssl
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from urllib.parse import unquote, urlsplit
 
 import httpx
 
@@ -34,7 +35,9 @@ class EsErrorCause(Exception):
         return f"elasticsearch error: {self.message}"
 
 
-def collect_sensitive_tokens(*config_values: object) -> list[str]:
+def collect_sensitive_tokens(
+    *config_values: object, urls: Iterable[str] = ()
+) -> list[str]:
     """Collect secret substrings that may surface in ES error messages.
 
     Tokens are derived from connector config: host strings (which may contain
@@ -59,6 +62,24 @@ def collect_sensitive_tokens(*config_values: object) -> list[str]:
                     add(item)
             continue
         add(value)
+
+    for url in urls:
+        try:
+            parsed = urlsplit(url)
+        except ValueError:
+            continue
+        raw_username = parsed.username
+        raw_password = parsed.password
+        decoded_username = unquote(raw_username) if raw_username else raw_username
+        decoded_password = unquote(raw_password) if raw_password else raw_password
+        for username, password in (
+            (raw_username, raw_password),
+            (decoded_username, decoded_password),
+        ):
+            if username and password:
+                add(f"{username}:{password}")
+                add(f"{username}:{password}@")
+            add(password)
 
     return tokens
 

--- a/plugins/onestep-elasticsearch/src/onestep_elasticsearch/resilience.py
+++ b/plugins/onestep-elasticsearch/src/onestep_elasticsearch/resilience.py
@@ -1,10 +1,80 @@
 from __future__ import annotations
 
 import ssl
+from collections.abc import Mapping
+from dataclasses import dataclass
 
 import httpx
 
 from onestep import ConnectorErrorKind
+
+_REDACTED = "<redacted>"
+_MAX_MESSAGE_LENGTH = 500
+_SECRET_OPTION_KEYS = frozenset(
+    {
+        "password",
+        "secret",
+        "token",
+        "access_token",
+        "api_key",
+        "apikey",
+        "credentials",
+        "authorization",
+        "bearer_token",
+        "client_key",
+    }
+)
+
+
+@dataclass(frozen=True)
+class EsErrorCause(Exception):
+    message: str
+
+    def __str__(self) -> str:
+        return f"elasticsearch error: {self.message}"
+
+
+def collect_sensitive_tokens(*config_values: object) -> list[str]:
+    """Collect secret substrings that may surface in ES error messages.
+
+    Tokens are derived from connector config: host strings (which may contain
+    basic-auth userinfo), known secret fields (password, api_key, bearer_token,
+    client_key, etc.), and header values.
+    """
+    tokens: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        if value is None:
+            return
+        text = str(value)
+        if text and text not in seen:
+            seen.add(text)
+            tokens.append(text)
+
+    for value in config_values:
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                if str(key).lower() in _SECRET_OPTION_KEYS:
+                    add(item)
+            continue
+        add(value)
+
+    return tokens
+
+
+def _redact_message(message: str, tokens: list[str]) -> str:
+    redacted = message
+    for token in sorted(tokens, key=len, reverse=True):
+        if token:
+            redacted = redacted.replace(token, _REDACTED)
+    return redacted[:_MAX_MESSAGE_LENGTH]
+
+
+def redacted_es_cause(
+    exc: BaseException, *, secrets: list[str] | None = None
+) -> EsErrorCause:
+    return EsErrorCause(_redact_message(str(exc), secrets or []))
 
 
 def classify_elasticsearch_status(status: int) -> ConnectorErrorKind:

--- a/plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py
+++ b/plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py
@@ -412,6 +412,42 @@ async def test_bulk_diagnostics_redact_configured_credentials() -> None:
 
 
 @pytest.mark.asyncio
+async def test_transport_errors_redact_hosts_headers_and_generated_auth() -> None:
+    host_password = "url@secret"
+    header_secret = "custom-header-secret"
+    basic_password = "basic-secret"
+
+    class BrokenClient:
+        async def request(self, *args, **kwargs):
+            authorization = kwargs["headers"]["Authorization"]
+            raise httpx.ConnectError(
+                "cannot connect to "
+                "https://url-user:url@secret@search.internal:9200 "
+                f"with X-Api-Key={header_secret} and Authorization={authorization}"
+            )
+
+    connector = ElasticsearchConnector(
+        "https://url-user:url%40secret@search.internal:9200",
+        username="writer",
+        password=basic_password,
+        headers={"X-Api-Key": header_secret},
+        client=BrokenClient(),
+    )
+    sink = connector.bulk_sink(index="events")
+
+    with pytest.raises(ConnectorOperationError) as captured:
+        await sink.send(Envelope(body={"id": "one"}))
+
+    diagnostic = str(captured.value.cause)
+    assert host_password not in diagnostic
+    assert header_secret not in diagnostic
+    assert basic_password not in diagnostic
+    assert "Basic " not in diagnostic
+    assert "search.internal" in diagnostic
+    assert "<redacted>" in diagnostic
+
+
+@pytest.mark.asyncio
 async def test_missing_id_field_does_not_claim_replay_safety() -> None:
     responses = [
         httpx.Response(

--- a/uv.lock
+++ b/uv.lock
@@ -1479,7 +1479,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-elasticsearch"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "plugins/onestep-elasticsearch" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Problem

The Elasticsearch connector exposed raw transport exceptions as `ConnectorOperationError.cause` and chained them into the public traceback. Host URLs, configured headers, and generated authentication headers can contain credentials.

The initial fix also called `collect_sensitive_tokens()` without importing it, so classified transport failures raised `NameError` while handling the original exception.

## Fix

- Import and use the credential collector on the generic transport-error path.
- Collect encoded and decoded URL userinfo without redacting non-sensitive host details.
- Treat every configured header value and generated Authorization value as sensitive.
- Suppress raw exception chaining while preserving the structured `ElasticsearchBulkError.items` API.
- Bump `onestep-elasticsearch` from `0.1.0` to `0.1.1` and update the root lockfile.
- The release changelog entry is carried by #96, which merges first.

## Verification

- Added a real bulk-send transport failure covering URL userinfo, custom headers, and generated Basic authentication.
- Elasticsearch plugin suite: 42 passed, 1 skipped.
- Ruff checks and formatting checks pass.
- GitHub checks: 33 passed, 0 failed, 11 skipped.
