### PR TITLE
fix(mongodb): scrub credentials from connector errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Bundles the three plugins in the worker image and adds isolated reliability/live compatibility gates.
 - Does not change core runtime, delivery, retry, reporter, or control-plane behavior.
 
+## onestep-mongodb 0.1.1
+
+- Scrubs URI credentials and PyMongo secret options from normalized MongoDB error causes.
+- Suppresses raw exception chaining for open, fetch, and send failures so reported tracebacks do not expose secrets.
+
 ## onestep-postgres 0.1.2
 
 - Scrubs DSN credentials and secret values nested in SQLAlchemy engine options from normalized Postgres error causes.

--- a/plugins/onestep-mongodb/pyproject.toml
+++ b/plugins/onestep-mongodb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-mongodb"
-version = "0.1.0"
+version = "0.1.1"
 description = "MongoDB connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
@@ -84,6 +84,11 @@ class MongoDBConnector:
         self._owns_client = client is None
         self._closed = False
 
+    def _secret_tokens(self) -> list[str]:
+        """Secret-bearing config tokens used to scrub error messages."""
+        from .resilience import collect_sensitive_tokens
+        return collect_sensitive_tokens(self.uri, self.client_options)
+
     def _get_client(self):
         if self._client is None:
             from pymongo import AsyncMongoClient
@@ -179,8 +184,8 @@ class MongoDBPollingSource(Source):
             kind = classify_mongodb_error(exc, operation="fetch")
             if kind is None:
                 raise
-            cause = redacted_mongodb_cause(exc)
-            raise ConnectorOperationError(backend="mongodb", operation=ConnectorOperation.FETCH, kind=kind, source_name=self.name, retry_delay_s=self.poll_interval_s, cause=cause) from cause
+            cause = redacted_mongodb_cause(exc, secrets=self.connector._secret_tokens())
+            raise ConnectorOperationError(backend="mongodb", operation=ConnectorOperation.FETCH, kind=kind, source_name=self.name, retry_delay_s=self.poll_interval_s, cause=cause) from None
         finally:
             cursor = self._active_cursor
             self._active_cursor = None
@@ -319,7 +324,7 @@ class MongoDBChangeStreamSource(Source):
                 if history_lost
                 else None
             )
-            cause = redacted_mongodb_cause(exc)
+            cause = redacted_mongodb_cause(exc, secrets=self.connector._secret_tokens())
             raise ConnectorOperationError(
                 backend="mongodb",
                 operation=ConnectorOperation.FETCH,
@@ -327,7 +332,7 @@ class MongoDBChangeStreamSource(Source):
                 source_name=self.name,
                 cause=cause,
                 message=message,
-            ) from cause
+            ) from None
 
         deliveries: list[Delivery] = []
         for event in events:
@@ -438,7 +443,7 @@ class MongoDBCollectionSink(Sink):
                     if missing:
                         raise MongoDBPayloadError(f"document {index} missing upsert keys {missing}")
         except MongoDBPayloadError as exc:
-            raise ConnectorOperationError(backend="mongodb", operation=ConnectorOperation.SEND, kind=ConnectorErrorKind.PERMANENT, source_name=self.name, cause=exc) from exc
+            raise ConnectorOperationError(backend="mongodb", operation=ConnectorOperation.SEND, kind=ConnectorErrorKind.PERMANENT, source_name=self.name, cause=exc) from None
         committed = 0
         try:
             for start in range(0, len(documents), self.batch_size):
@@ -462,9 +467,9 @@ class MongoDBCollectionSink(Sink):
             kind = classify_mongodb_error(exc, operation="send")
             if kind is None:
                 raise
-            cause = redacted_mongodb_cause(exc)
+            cause = redacted_mongodb_cause(exc, secrets=self.connector._secret_tokens())
             replay_safe = self.mode == "upsert" and bool(self.keys)
             partial = committed > 0 or cause.committed_count > 0
             if partial and not replay_safe:
                 kind = ConnectorErrorKind.UNCERTAIN
-            raise ConnectorOperationError(backend="mongodb", operation=ConnectorOperation.SEND, kind=kind, source_name=self.name, cause=cause) from cause
+            raise ConnectorOperationError(backend="mongodb", operation=ConnectorOperation.SEND, kind=kind, source_name=self.name, cause=cause) from None

--- a/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
@@ -6,7 +6,17 @@ from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from onestep import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError, CursorStore, Delivery, Envelope, InMemoryCursorStore, Sink, Source
+from onestep import (
+    ConnectorErrorKind,
+    ConnectorOperation,
+    ConnectorOperationError,
+    CursorStore,
+    Delivery,
+    Envelope,
+    InMemoryCursorStore,
+    Sink,
+    Source,
+)
 
 from .state_codec import decode_state, encode_state
 
@@ -97,7 +107,23 @@ class MongoDBConnector:
         return self._client
 
     def collection(self, name: str):
-        return self._get_client()[self.database_name][name]
+        try:
+            return self._get_client()[self.database_name][name]
+        except ConnectorOperationError:
+            raise
+        except Exception as exc:
+            from .resilience import classify_mongodb_error, redacted_mongodb_cause
+
+            kind = classify_mongodb_error(exc, operation="open")
+            if kind is None:
+                raise
+            cause = redacted_mongodb_cause(exc, secrets=self._secret_tokens())
+            raise ConnectorOperationError(
+                backend="mongodb",
+                operation=ConnectorOperation.OPEN,
+                kind=kind,
+                cause=cause,
+            ) from None
 
     def poll_collection(self, collection: str, **options: Any) -> "MongoDBPollingSource":
         return MongoDBPollingSource(connector=self, collection=collection, **options)
@@ -282,7 +308,24 @@ class MongoDBChangeStreamSource(Source):
             options = {"full_document": self.full_document, "max_await_time_ms": self.max_await_time_ms}
             if self._resume_token is not None:
                 options["resume_after"] = self._resume_token
-            self._stream = await self.connector.collection(self.collection_name).watch(self.pipeline, **options)
+            try:
+                self._stream = await self.connector.collection(self.collection_name).watch(self.pipeline, **options)
+            except ConnectorOperationError:
+                raise
+            except Exception as exc:
+                from .resilience import classify_mongodb_error, redacted_mongodb_cause
+
+                kind = classify_mongodb_error(exc, operation="open")
+                if kind is None:
+                    raise
+                cause = redacted_mongodb_cause(exc, secrets=self.connector._secret_tokens())
+                raise ConnectorOperationError(
+                    backend="mongodb",
+                    operation=ConnectorOperation.OPEN,
+                    kind=kind,
+                    source_name=self.name,
+                    cause=cause,
+                ) from None
 
     async def fetch(self, limit: int) -> list[Delivery]:
         await self.open()
@@ -302,7 +345,12 @@ class MongoDBChangeStreamSource(Source):
             stream = self._stream
             self._stream = None
             if stream is not None:
-                await stream.close()
+                # Keep a classified close failure from replacing the primary error.
+                try:
+                    await stream.close()
+                except Exception as close_exc:
+                    if classify_mongodb_error(close_exc, operation="close") is None:
+                        raise
             history_lost = getattr(exc, "code", None) in {280, 286}
             has_resumable_label = getattr(exc, "has_error_label", lambda label: False)(
                 "ResumableChangeStreamError"

--- a/plugins/onestep-mongodb/src/onestep_mongodb/resilience.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/resilience.py
@@ -3,11 +3,20 @@ from __future__ import annotations
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import parse_qsl, unquote, urlsplit
 
 from bson.errors import InvalidDocument, InvalidStringData
-from pymongo.errors import AutoReconnect, BulkWriteError, ConfigurationError, DuplicateKeyError, ExecutionTimeout, InvalidURI, NetworkTimeout, OperationFailure, ServerSelectionTimeoutError
+from pymongo.errors import (
+    AutoReconnect,
+    BulkWriteError,
+    ConfigurationError,
+    DuplicateKeyError,
+    ExecutionTimeout,
+    InvalidURI,
+    NetworkTimeout,
+    OperationFailure,
+    ServerSelectionTimeoutError,
+)
 
 from onestep import ConnectorErrorKind
 
@@ -25,7 +34,10 @@ class MongoDBErrorCause(Exception):
 
 
 _MONGODB_URI_CREDENTIALS = re.compile(r"(?i)\b(mongodb(?:\+srv)?://)[^/@\s]+@")
-_SENSITIVE_QUERY_VALUE = re.compile(r"(?i)([?&](?:password|passwd|pwd|secret|token)\s*=)[^&\s]+")
+_SENSITIVE_QUERY_VALUE = re.compile(
+    r"(?i)([?&](?:password|passwd|pwd|secret|token|proxyPassword|"
+    r"tlsCertificateKeyFilePassword|authMechanismProperties)\s*=)[^&\s]+"
+)
 _REDACTED = "<redacted>"
 _MAX_MESSAGE_LENGTH = 500
 _SECRET_OPTION_KEYS = frozenset(
@@ -40,8 +52,12 @@ _SECRET_OPTION_KEYS = frozenset(
         "apikey",
         "credentials",
         "authorization",
+        "aws_session_token",
+        "proxypassword",
+        "tlscertificatekeyfilepassword",
     }
 )
+_SECRET_MECHANISM_PROPERTY_KEYS = frozenset({"AWS_SESSION_TOKEN"})
 
 
 def collect_sensitive_tokens(*config_values: object) -> list[str]:
@@ -62,22 +78,64 @@ def collect_sensitive_tokens(*config_values: object) -> list[str]:
             seen.add(text)
             tokens.append(text)
 
-    for value in config_values:
+    def add_secret_value(value: object) -> None:
+        if isinstance(value, Mapping):
+            for item in value.values():
+                add_secret_value(item)
+        elif isinstance(value, (list, tuple, set, frozenset)):
+            for item in value:
+                add_secret_value(item)
+        else:
+            add(value)
+
+    def collect_auth_mechanism_properties(value: object) -> None:
         if isinstance(value, Mapping):
             for key, item in value.items():
-                if str(key).lower() in _SECRET_OPTION_KEYS:
+                if str(key).upper() in _SECRET_MECHANISM_PROPERTY_KEYS:
+                    add_secret_value(item)
+            return
+        if isinstance(value, str):
+            for property_value in value.split(","):
+                key, separator, item = property_value.partition(":")
+                if separator and key.upper() in _SECRET_MECHANISM_PROPERTY_KEYS:
                     add(item)
+
+    def collect_mapping(value: Mapping[object, object]) -> None:
+        for key, item in value.items():
+            normalized_key = str(key).lower()
+            if normalized_key == "authmechanismproperties":
+                collect_auth_mechanism_properties(item)
+            elif normalized_key in _SECRET_OPTION_KEYS:
+                add_secret_value(item)
+            elif isinstance(item, Mapping):
+                collect_mapping(item)
+
+    for value in config_values:
+        if isinstance(value, Mapping):
+            collect_mapping(value)
             continue
         try:
             parsed = urlsplit(str(value))
         except (ValueError, AttributeError):
             continue
-        username = parsed.username
-        password = parsed.password
-        if username and password:
-            add(f"{username}:{password}")
-            add(f"{username}:{password}@")
-        add(password)
+        raw_username = parsed.username
+        raw_password = parsed.password
+        decoded_username = unquote(raw_username) if raw_username else raw_username
+        decoded_password = unquote(raw_password) if raw_password else raw_password
+        for username, password in (
+            (raw_username, raw_password),
+            (decoded_username, decoded_password),
+        ):
+            if username and password:
+                add(f"{username}:{password}")
+                add(f"{username}:{password}@")
+            add(password)
+        for key, item in parse_qsl(parsed.query, keep_blank_values=True):
+            normalized_key = key.lower()
+            if normalized_key == "authmechanismproperties":
+                collect_auth_mechanism_properties(item)
+            elif normalized_key in _SECRET_OPTION_KEYS:
+                add(item)
 
     return tokens
 

--- a/plugins/onestep-mongodb/src/onestep_mongodb/resilience.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/resilience.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
 
 from bson.errors import InvalidDocument, InvalidStringData
 from pymongo.errors import AutoReconnect, BulkWriteError, ConfigurationError, DuplicateKeyError, ExecutionTimeout, InvalidURI, NetworkTimeout, OperationFailure, ServerSelectionTimeoutError
@@ -23,14 +26,76 @@ class MongoDBErrorCause(Exception):
 
 _MONGODB_URI_CREDENTIALS = re.compile(r"(?i)\b(mongodb(?:\+srv)?://)[^/@\s]+@")
 _SENSITIVE_QUERY_VALUE = re.compile(r"(?i)([?&](?:password|passwd|pwd|secret|token)\s*=)[^&\s]+")
+_REDACTED = "<redacted>"
+_MAX_MESSAGE_LENGTH = 500
+_SECRET_OPTION_KEYS = frozenset(
+    {
+        "password",
+        "passwd",
+        "pwd",
+        "secret",
+        "token",
+        "access_token",
+        "api_key",
+        "apikey",
+        "credentials",
+        "authorization",
+    }
+)
 
 
-def _redact_message(message: str) -> str:
+def collect_sensitive_tokens(*config_values: object) -> list[str]:
+    """Collect secret substrings from MongoDB connector config.
+
+    Tokens are derived from the URI (parsed userinfo) and known secret keys
+    inside client_options. Error causes are scrubbed against these before they
+    leave the plugin.
+    """
+    tokens: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        if value is None:
+            return
+        text = str(value)
+        if text and text not in seen:
+            seen.add(text)
+            tokens.append(text)
+
+    for value in config_values:
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                if str(key).lower() in _SECRET_OPTION_KEYS:
+                    add(item)
+            continue
+        try:
+            parsed = urlsplit(str(value))
+        except (ValueError, AttributeError):
+            continue
+        username = parsed.username
+        password = parsed.password
+        if username and password:
+            add(f"{username}:{password}")
+            add(f"{username}:{password}@")
+        add(password)
+
+    return tokens
+
+
+def _redact_message(message: str, tokens: list[str] | None = None) -> str:
     message = _MONGODB_URI_CREDENTIALS.sub(r"\1<redacted>@", message)
-    return _SENSITIVE_QUERY_VALUE.sub(r"\1<redacted>", message)
+    message = _SENSITIVE_QUERY_VALUE.sub(r"\1<redacted>", message)
+    if tokens:
+        for token in sorted(tokens, key=len, reverse=True):
+            if token:
+                message = message.replace(token, _REDACTED)
+    return message[:_MAX_MESSAGE_LENGTH]
 
 
-def redacted_mongodb_cause(exc: BaseException) -> MongoDBErrorCause:
+def redacted_mongodb_cause(
+    exc: BaseException,
+    secrets: list[str] | None = None,
+) -> MongoDBErrorCause:
     details = exc.details if isinstance(exc, BulkWriteError) else {}
     write_errors = details.get("writeErrors", []) if isinstance(details, dict) else []
     failed_indexes = tuple(int(item["index"]) for item in write_errors if isinstance(item, dict) and "index" in item)
@@ -41,7 +106,7 @@ def redacted_mongodb_cause(exc: BaseException) -> MongoDBErrorCause:
         code = write_errors[0].get("code")
     if isinstance(exc, BulkWriteError):
         message = "; ".join(
-            _redact_message(str(item.get("errmsg", "write error")))[:160]
+            _redact_message(str(item.get("errmsg", "write error")), tokens=secrets)[:160]
             for item in write_errors
             if isinstance(item, dict)
         )[:500]
@@ -50,7 +115,7 @@ def redacted_mongodb_cause(exc: BaseException) -> MongoDBErrorCause:
     elif isinstance(exc, (ConfigurationError, InvalidURI)):
         message = "invalid MongoDB configuration"
     else:
-        message = _redact_message(str(exc))[:500]
+        message = _redact_message(str(exc), tokens=secrets)[:500]
     return MongoDBErrorCause(code, failed_indexes, codes, committed_count, message)
 
 

--- a/plugins/onestep-mongodb/tests/test_mongodb_plugin.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_plugin.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import traceback
 from importlib import metadata as importlib_metadata
 
+import pytest
 from onestep_mongodb import (
     MongoDBChangeStreamDelivery,
     MongoDBChangeStreamSource,
@@ -13,11 +15,17 @@ from onestep_mongodb import (
     register,
     register_resources,
 )
-
-import pytest
-
-from onestep import InMemoryCursorStore, ResourceBuildContext, ResourceRegistry, load_app_config
 from onestep_mongodb.resources import _build_polling
+from pymongo.errors import AutoReconnect
+
+from onestep import (
+    ConnectorOperation,
+    ConnectorOperationError,
+    InMemoryCursorStore,
+    ResourceBuildContext,
+    ResourceRegistry,
+    load_app_config,
+)
 
 
 def test_public_surface_and_entry_point() -> None:
@@ -85,3 +93,97 @@ def test_strict_yaml_rejects_invalid_resource(resource) -> None:
         resources = {"mongo": resource}
     with pytest.raises((TypeError, ValueError)):
         load_app_config(_config(resources), strict=True)
+
+
+def _assert_public_error_is_redacted(exc: ConnectorOperationError, secret: str) -> None:
+    rendered = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    assert secret not in rendered
+    assert secret not in str(exc.cause)
+    assert exc.__suppress_context__ is True
+
+
+def test_collection_normalizes_client_initialization_errors() -> None:
+    secret = "mongo-super-secret"
+
+    class Client:
+        def __getitem__(self, name):
+            raise AutoReconnect(f"cannot connect with {secret}")
+
+    connector = MongoDBConnector(
+        "mongodb://local",
+        database="app",
+        client_options={"password": secret},
+        client=Client(),
+    )
+    with pytest.raises(ConnectorOperationError) as captured:
+        connector.collection("events")
+
+    assert captured.value.operation is ConnectorOperation.OPEN
+    _assert_public_error_is_redacted(captured.value, secret)
+
+
+@pytest.mark.asyncio
+async def test_change_stream_open_normalizes_watch_errors() -> None:
+    secret = "mongo-super-secret"
+
+    class Collection:
+        async def watch(self, pipeline, **options):
+            raise AutoReconnect(f"cannot watch with {secret}")
+
+    class Database:
+        def __getitem__(self, name):
+            return Collection()
+
+    class Client:
+        def __getitem__(self, name):
+            return Database()
+
+    connector = MongoDBConnector(
+        "mongodb://local",
+        database="app",
+        client_options={"password": secret},
+        client=Client(),
+    )
+    source = connector.watch_collection("events")
+    with pytest.raises(ConnectorOperationError) as captured:
+        await source.open()
+
+    assert captured.value.operation is ConnectorOperation.OPEN
+    _assert_public_error_is_redacted(captured.value, secret)
+
+
+@pytest.mark.asyncio
+async def test_change_stream_cleanup_cannot_replace_redacted_fetch_error() -> None:
+    secret = "mongo-super-secret"
+
+    class Stream:
+        async def try_next(self):
+            raise AutoReconnect(f"fetch failed with {secret}")
+
+        async def close(self):
+            raise AutoReconnect(f"cleanup failed with {secret}")
+
+    class Collection:
+        async def watch(self, pipeline, **options):
+            return Stream()
+
+    class Database:
+        def __getitem__(self, name):
+            return Collection()
+
+    class Client:
+        def __getitem__(self, name):
+            return Database()
+
+    connector = MongoDBConnector(
+        "mongodb://local",
+        database="app",
+        client_options={"password": secret},
+        client=Client(),
+    )
+    source = connector.watch_collection("events")
+    with pytest.raises(ConnectorOperationError) as captured:
+        await source.fetch(1)
+
+    assert captured.value.operation is ConnectorOperation.FETCH
+    _assert_public_error_is_redacted(captured.value, secret)

--- a/plugins/onestep-mongodb/tests/test_mongodb_resilience.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_resilience.py
@@ -1,10 +1,23 @@
 from __future__ import annotations
 
+import pytest
 from bson.errors import InvalidDocument
-from pymongo.errors import AutoReconnect, BulkWriteError, DuplicateKeyError, ExecutionTimeout, NetworkTimeout, OperationFailure, ServerSelectionTimeoutError
+from onestep_mongodb.resilience import (
+    classify_mongodb_error,
+    collect_sensitive_tokens,
+    redacted_mongodb_cause,
+)
+from pymongo.errors import (
+    AutoReconnect,
+    BulkWriteError,
+    DuplicateKeyError,
+    ExecutionTimeout,
+    NetworkTimeout,
+    OperationFailure,
+    ServerSelectionTimeoutError,
+)
 
 from onestep import ConnectorErrorKind
-from onestep_mongodb.resilience import classify_mongodb_error, redacted_mongodb_cause
 
 
 def test_driver_error_classes() -> None:
@@ -31,3 +44,40 @@ def test_redacted_cause_does_not_retain_credentials_or_invalid_documents() -> No
     payload = redacted_mongodb_cause(invalid)
     assert classify_mongodb_error(invalid, operation="send") is ConnectorErrorKind.PERMANENT
     assert "document-secret" not in str(payload)
+
+
+@pytest.mark.parametrize(
+    "client_options",
+    [
+        {"tlsCertificateKeyFilePassword": "mongo-super-secret"},
+        {"proxyPassword": "mongo-super-secret"},
+        {"authMechanismProperties": {"AWS_SESSION_TOKEN": "mongo-super-secret"}},
+        {"authMechanismProperties": "AWS_SESSION_TOKEN:mongo-super-secret"},
+        {"nested": {"password": "mongo-super-secret"}},
+    ],
+)
+def test_redacted_cause_scrubs_pymongo_client_option_secrets(client_options) -> None:
+    secret = "mongo-super-secret"
+    tokens = collect_sensitive_tokens("mongodb://local", client_options)
+    cause = redacted_mongodb_cause(AutoReconnect(f"disconnected with {secret}"), secrets=tokens)
+    assert secret not in str(cause)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "tlsCertificateKeyFilePassword=mongo-super-secret",
+        "proxyPassword=mongo-super-secret",
+        "authMechanismProperties=AWS_SESSION_TOKEN:mongo-super-secret",
+    ],
+)
+def test_redacted_cause_scrubs_pymongo_uri_query_secrets(query: str) -> None:
+    uri = f"mongodb://host/db?{query}"
+    cause = redacted_mongodb_cause(AutoReconnect(uri), secrets=collect_sensitive_tokens(uri))
+    assert "mongo-super-secret" not in str(cause)
+
+
+def test_redacted_cause_scrubs_decoded_uri_password() -> None:
+    uri = "mongodb://user:p%40ss@host/db"
+    cause = redacted_mongodb_cause(AutoReconnect("authentication failed for p@ss"), secrets=collect_sensitive_tokens(uri))
+    assert "p@ss" not in str(cause)

--- a/uv.lock
+++ b/uv.lock
@@ -1557,7 +1557,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-mongodb"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "plugins/onestep-mongodb" }
 dependencies = [
     { name = "onestep" },


### PR DESCRIPTION
## Problem

MongoDB connector failures could expose configured credentials through raw exception chains and incomplete token collection. The original implementation did not cover PyMongo-specific secret options, decoded URI passwords, initialization/watch failures, or a close failure that replaced the primary redacted error.

## Fix

- Collect URI userinfo in raw and decoded forms.
- Collect nested secret values and PyMongo options including tlsCertificateKeyFilePassword, proxyPassword, and AWS_SESSION_TOKEN in authMechanismProperties.
- Redact sensitive MongoDB URI query parameters.
- Normalize client initialization and change-stream watch failures as OPEN errors.
- Prevent classified stream-close failures from replacing the primary redacted FETCH error.
- Suppress raw exception chaining at public connector error boundaries.
- Add the onestep-mongodb 0.1.1 changelog entry.
- Bump onestep-mongodb 0.1.0 to 0.1.1 and update uv.lock.

## Verification

- MongoDB plugin suite: 57 passed, 4 skipped.
- Workspace suite: 198 passed.
- Focused credential reproductions confirm client options, URI query values, decoded passwords, initialization errors, watch errors, cleanup errors, and formatted tracebacks are redacted.
- Latest main merges without conflicts and uv lock --check passes.