### PR TITLE
v0.1.2 fix: harden Elasticsearch and MongoDB delivery correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 - Bundles the three plugins in the worker image and adds isolated reliability/live compatibility gates.
 - Does not change core runtime, delivery, retry, reporter, or control-plane behavior.
 
+## onestep-mongodb 0.1.2
+
+- Rejects invalid direct Python numeric options during construction and polling projections that omit or rewrite effective cursor fields.
+- Prevents later acknowledgements from advancing the cursor after an earlier delivery invalidates the same generation for retry.
+- Keeps cursor generations replayable when durable state persistence fails.
+
+## onestep-elasticsearch 0.1.2
+
+- Prevents the Elasticsearch/OpenSearch bulk sink from internally replaying ambiguous request-level gateway failures when documents lack stable IDs.
+
 ## onestep-mongodb 0.1.1
 
 - Scrubs URI credentials and PyMongo secret options from normalized MongoDB error causes.

--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ mapping, unsupported features, and rollout guidance.
 - [`docs/yaml-task-definition.md`](docs/yaml-task-definition.md) — YAML schema
 - [`docs/core-reliability.md`](docs/core-reliability.md) — stable API,
   delivery semantics, plugin compatibility, and release checklist
+- [`docs/framework-evolution-roadmap.md`](docs/framework-evolution-roadmap.md) —
+  ordered framework milestones and exit gates
 - [`docs/stable-instance-identity.md`](docs/stable-instance-identity.md) —
   reporter identity resolution
 - [`docs/agent-ws-protocol.md`](docs/agent-ws-protocol.md) — agent WS protocol

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -297,6 +297,8 @@ PYTHONPATH=src python3 example/runtime_showcase.py
 - [`docs/yaml-task-definition.md`](docs/yaml-task-definition.md) —— YAML schema
 - [`docs/core-reliability.md`](docs/core-reliability.md) —— 稳定 API、
   交付语义、插件兼容性与发布检查清单
+- [`docs/framework-evolution-roadmap.md`](docs/framework-evolution-roadmap.md) ——
+  框架演进顺序、里程碑与退出标准
 - [`docs/stable-instance-identity.md`](docs/stable-instance-identity.md) ——
   Reporter 身份解析
 - [`docs/agent-ws-protocol.md`](docs/agent-ws-protocol.md) —— Agent WS 协议

--- a/docs/framework-evolution-roadmap.md
+++ b/docs/framework-evolution-roadmap.md
@@ -1,0 +1,181 @@
+# onestep Framework Evolution Roadmap
+
+## Product Position
+
+onestep evolves as a code-first data task runtime. Python owns business
+transformation; YAML wires resources, policies, and `handler.ref` values. The
+framework competes on reliable delivery, reproducible failures, and operational
+recovery rather than on a transformation DSL or connector count.
+
+## Decision Rules
+
+Every roadmap item must improve at least one of these outcomes:
+
+1. reduce the probability of silently skipped or duplicated data;
+2. reduce the time required to reproduce a production delivery locally;
+3. reduce the time required to identify and recover a failed task;
+4. reduce the work required to ship a connector that passes the same contracts
+   as official connectors.
+
+Items that do not improve one of these outcomes remain outside the committed
+roadmap.
+
+## Ordered Roadmap
+
+| Order | Milestone | Deliverable | Exit gate |
+| --- | --- | --- | --- |
+| P0 | Connector correctness patches | Remove currently known ambiguous retry, state persistence, and direct API validation gaps | Focused regressions and every affected plugin suite pass |
+| P1 | Connector conformance kit | Capability-based source, checkpoint, sink acknowledgement, failure classification, and redaction contracts | Every official plugin declares capabilities and passes applicable contracts |
+| P2 | Local handler loop | One-delivery local execution, envelope capture/replay, resource connectivity checks, and handler scaffold tests | A captured failed delivery can be reproduced without a running worker or control plane |
+| P3 | Delivery observability | Stable delivery correlation, lag/cursor/retry metrics, and audited recovery operations | An operator can identify a failed delivery and its attempts from the control plane |
+| P4 | Plugin authoring platform | Plugin scaffold, catalog validation, compatibility matrix, support tiers, and CI template | A new connector can reach community support without copying an official plugin |
+| P5 | Demand-led connector expansion | S3/MinIO first; later connectors require user evidence | The requested workload cannot be served cleanly by existing connectors |
+
+## P0: Connector Correctness Patches
+
+The first increment is defined in
+[`docs/superpowers/plans/2026-07-29-connector-correctness-patches.md`](superpowers/plans/2026-07-29-connector-correctness-patches.md).
+
+Scope:
+
+- Elasticsearch/OpenSearch must not internally replay an ambiguous request-level
+  502/503/504 response when documents have no stable IDs.
+- MongoDB polling and change-stream sources must reject invalid direct Python
+  numeric options during construction.
+- MongoDB polling projections must preserve every effective cursor field
+  without rewriting its value.
+- MongoDB must not persist a later acknowledged token when an earlier delivery
+  subsequently invalidates that generation for retry.
+- MongoDB cursor state must not advance in memory or discard its pending prefix
+  when durable state persistence fails.
+
+This milestone is runtime/plugin internal and does not change reporter payloads,
+task lifecycle events, WebSocket behavior, runtime identity, or remote controls.
+
+## P1: Connector Conformance Kit
+
+The conformance kit is capability-based rather than one universal test class.
+Different backend types make different promises.
+
+Required capability profiles:
+
+- `basic_source`: fetch, terminal callback exclusivity, close idempotence;
+- `checkpoint_source`: out-of-order acknowledgement, retry gap, durable state
+  failure, and restart replay;
+- `claimed_source`: `release_unstarted()` under drain, pause, shutdown, and
+  cancellation;
+- `acknowledged_sink`: return only after backend acknowledgement;
+- `chunked_sink`: partial chunk commit classification;
+- `replay_safe_sink`: stable-key convergence under repeated send;
+- `public_errors`: normalized error kind and credential redaction.
+
+Each official plugin publishes a small harness that supplies backend-specific
+fixtures to the applicable profiles. Unsupported capabilities are declared, not
+silently skipped. CI renders a connector support matrix from those declarations.
+
+The implementation must remain separate from P0 so correctness patches are not
+blocked by test-kit API design.
+
+## P2: Local Handler Loop
+
+Committed CLI surface:
+
+```text
+onestep task run <target> --task <name> --input <json-file>
+onestep task replay <target> --task <name> --envelope <json-file>
+onestep check --connect <target>
+```
+
+Design constraints:
+
+- use the same handler invocation, task config, hooks, and sink routing as the
+  worker runtime;
+- make sink sending opt-in for local replay, with dry-run as the default;
+- define a versioned, JSON-safe envelope capture format;
+- redact resource secrets from diagnostics and captured envelopes;
+- keep YAML as wiring; do not add transform expressions;
+- generate handler tests and fixtures, not reusable business handlers.
+
+The first P2 design must decide whether `run_task_once()` can be generalized or
+whether a separate diagnostic runner is required. It must not overload the
+existing remote manual-run semantics.
+
+## P3: Delivery Observability
+
+Introduce a stable delivery correlation value that survives retry and dead-letter
+replay while individual attempts remain distinguishable. Propagate it through
+`Envelope`, `TaskEvent`, structured logs, reporter payloads, control-plane storage,
+and task-event views.
+
+Because this changes reporter/topology data consumed by the control plane, P3
+requires coordinated runtime, reporter plugin, backend schema, and frontend work.
+All payload changes must be additive, and older planes must tolerate unknown JSON
+fields.
+
+Operational outputs:
+
+- delivery and attempt correlation;
+- source lag or cursor staleness where the backend exposes it;
+- sink acknowledgement latency;
+- retry counts grouped by normalized connector error kind;
+- dead-letter inspect, replay, and discard audit records;
+- deployed package checksum and effective configuration identity;
+- drain and rollback workflow before worker replacement.
+
+## P4: Plugin Authoring Platform
+
+Provide:
+
+```text
+onestep create-plugin <name> --capability source|sink|both
+```
+
+The generated project contains a resource catalog entry, strict YAML validation,
+Python API tests, applicable conformance harnesses, live integration-test wiring,
+credential redaction tests, packaging metadata, and a release checklist.
+
+Support tiers:
+
+- `official`: maintained in the onestep repository, full conformance and live CI;
+- `community`: external owner, declared conformance results and compatibility;
+- `experimental`: API and behavior may change, no production support promise.
+
+## P5: Connector Expansion
+
+S3/MinIO is the next default candidate because it enables object ingestion,
+archive output, data-lake exchange, and dead-letter storage. NATS JetStream comes
+after demonstrated demand. Cloud-specific and SaaS connectors require a concrete
+user workflow before entering the roadmap.
+
+## Explicit Non-Goals
+
+- no YAML field-transformation language;
+- no official library of domain business handlers;
+- no Airflow/Temporal-style DAG orchestration;
+- no file-tail/syslog log-agent positioning;
+- no database DDL or schema-migration ownership;
+- no exactly-once claim;
+- no connector-count target;
+- no new control-plane surface before the corresponding recovery or diagnostic
+  runtime capability exists.
+
+## Success Metrics
+
+| Metric | Initial target |
+| --- | --- |
+| New task to first successful local delivery | under 10 minutes |
+| Captured production failure reproducible locally | at least 90% of handler failures |
+| Official connectors with declared conformance profiles | 100% |
+| Public connector failures mapped to normalized kinds | at least 95% |
+| Failed delivery identification and replay | under 5 minutes |
+| New community plugin to passing contract suite | under one working day |
+
+## Release Sequence
+
+1. Ship P0 as patch releases for affected plugins.
+2. Design and ship P1 without changing application-facing runtime semantics.
+3. Design P2 after P1 establishes reusable failure fixtures.
+4. Coordinate P3 across runtime and control plane in one compatibility window.
+5. Build P4 from the conformance and diagnostic APIs proven in P1 and P2.
+6. Start P5 only after the platform can enforce the same quality bar on new
+   connectors.

--- a/docs/superpowers/plans/2026-07-29-connector-correctness-patches.md
+++ b/docs/superpowers/plans/2026-07-29-connector-correctness-patches.md
@@ -1,0 +1,817 @@
+# Connector Correctness Patches Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the currently confirmed Elasticsearch ambiguous-retry and MongoDB cursor/configuration correctness gaps before expanding the plugin surface.
+
+**Architecture:** Keep changes inside the affected connector plugins. Elasticsearch request-level retries become conditional on replay safety, while item-level acknowledged rejections retain their existing retry behavior. MongoDB validates direct Python numeric options during construction, rejects polling projections that omit or rewrite effective cursor fields, and makes cursor persistence transactional from the tracker's point of view.
+
+**Tech Stack:** Python 3.9+, asyncio, pytest, pytest-asyncio, httpx MockTransport, PyMongo BSON helpers, existing onestep connector contracts.
+
+---
+
+## Confirmed Main-Branch Baseline
+
+The following minimal reproductions were run against `b31ed51` before writing
+this plan:
+
+```text
+Elasticsearch auto-ID + request-level 504 + max_retries=2
+=> {'calls': 3, 'kind': 'transient'}
+
+MongoDB tracker: ACK token 'two', then invalidate/retry token 'one'
+=> {'saved': ['two'], 'can_fetch': True}
+
+MongoDBPollingSource(..., batch_size=0)
+=> {'accepted_batch_size': 0}
+```
+
+These are implementation baselines, not hypothetical risks. The completion gate
+at the end of this plan states the required replacement behavior.
+
+## File Structure
+
+- Modify `plugins/onestep-elasticsearch/src/onestep_elasticsearch/connector.py`: represent uncertain bulk outcomes and prevent unsafe internal request replay.
+- Modify `plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py`: lock request-level retry behavior for auto-generated and stable IDs.
+- Modify `plugins/onestep-elasticsearch/README.md`: document the request-level ambiguity rule.
+- Modify `plugins/onestep-mongodb/src/onestep_mongodb/connector.py`: centralize direct Python option validation and make cursor persistence failure-safe.
+- Modify `plugins/onestep-mongodb/tests/test_mongodb_polling.py`: cover invalid options, projection/cursor compatibility, and polling state-save failure.
+- Modify `plugins/onestep-mongodb/tests/test_mongodb_change_stream.py`: cover change-stream state-save failure.
+- Modify `plugins/onestep-mongodb/tests/test_mongodb_sink.py`: cover strict direct API sink option validation.
+- Modify `plugins/onestep-mongodb/README.md`: document projection requirements and durable state failure behavior.
+- Modify `CHANGELOG.md`: record unreleased plugin fixes without changing core version metadata.
+
+## Task 1: Stop Unsafe Elasticsearch Request Replay
+
+**Files:**
+- Modify: `plugins/onestep-elasticsearch/src/onestep_elasticsearch/connector.py:49`
+- Modify: `plugins/onestep-elasticsearch/src/onestep_elasticsearch/connector.py:397`
+- Test: `plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py`
+
+- [x] **Step 1: Write failing request-level ambiguity tests**
+
+Add these tests next to the existing retry tests:
+
+```python
+@pytest.mark.asyncio
+async def test_request_level_504_without_stable_ids_is_not_replayed() -> None:
+    calls = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(504, json={"error": {"reason": "gateway timeout"}})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    sink = ElasticsearchConnector("http://search:9200", client=client).bulk_sink(
+        index="events", max_retries=2
+    )
+
+    with pytest.raises(ConnectorOperationError) as captured:
+        await sink.send(Envelope(body={"value": 1}))
+
+    assert calls == 1
+    assert captured.value.kind is ConnectorErrorKind.UNCERTAIN
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_level_504_with_stable_ids_retries() -> None:
+    responses = [
+        httpx.Response(504, json={"error": {"reason": "gateway timeout"}}),
+        httpx.Response(
+            200,
+            json={"errors": False, "items": [{"index": {"status": 201}}]},
+        ),
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return responses.pop(0)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    sink = ElasticsearchConnector("http://search:9200", client=client).bulk_sink(
+        index="events", id_field="id", max_retries=2
+    )
+
+    await sink.send(Envelope(body={"id": "evt-1", "value": 1}))
+
+    assert responses == []
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_level_429_without_stable_ids_remains_retryable() -> None:
+    responses = [
+        httpx.Response(429, json={"error": {"reason": "rejected"}}),
+        httpx.Response(
+            200,
+            json={"errors": False, "items": [{"index": {"status": 201}}]},
+        ),
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return responses.pop(0)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    sink = ElasticsearchConnector("http://search:9200", client=client).bulk_sink(
+        index="events", max_retries=2
+    )
+
+    await sink.send(Envelope(body={"value": 1}))
+
+    assert responses == []
+    await client.aclose()
+```
+
+- [x] **Step 2: Run the focused tests and verify the first test fails**
+
+Run:
+
+```bash
+uv run --extra test --extra elasticsearch pytest -q \
+  plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py \
+  -k 'request_level_504 or request_level_429'
+```
+
+Expected: the auto-ID 504 case fails because the current loop issues three
+requests and reports `TRANSIENT` rather than `UNCERTAIN`; the stable-ID and 429
+cases pass.
+
+- [x] **Step 3: Carry replay safety into the chunk retry loop**
+
+Extend the bulk error with an explicit uncertainty flag:
+
+```python
+class ElasticsearchBulkError(Exception):
+    def __init__(
+        self,
+        items: list[ElasticsearchBulkItemError],
+        *,
+        partial_success: bool = False,
+        outcome_uncertain: bool = False,
+    ) -> None:
+        self.items = tuple(items)
+        self.partial_success = partial_success
+        self.outcome_uncertain = outcome_uncertain
+        summary = ", ".join(
+            f"item={item.action_index} status={item.status} reason={item.reason[:160]}"
+            for item in self.items[:10]
+        )
+        super().__init__(f"Elasticsearch bulk request failed: {summary}")
+```
+
+Change the `_send_chunk()` signature to:
+
+```python
+async def _send_chunk(self, body: bytes, *, replay_safe: bool) -> None:
+```
+
+Then replace its current non-2xx status branch with:
+
+```python
+if status < 200 or status >= 300:
+    failure = ElasticsearchBulkItemError(
+        pending_indexes[0],
+        self.operation,
+        None,
+        status,
+        None,
+        self._error_reason(payload.get("error", "request failed")),
+    )
+    request_rejected = status == 429
+    request_ambiguous = status in {502, 503, 504}
+    can_retry_request = request_rejected or (request_ambiguous and replay_safe)
+    if can_retry_request and attempt < self.max_retries:
+        await asyncio.sleep((0.05 * (2**attempt)) + random.uniform(0.0, 0.025))
+        continue
+    raise ElasticsearchBulkError(
+        [failure],
+        partial_success=partial_success,
+        outcome_uncertain=request_ambiguous and not replay_safe,
+    )
+```
+
+Pass the flag from `send()`:
+
+```python
+for chunk in chunks:
+    await self._send_chunk(chunk, replay_safe=replay_safe)
+    committed_chunks += 1
+```
+
+Classify an explicitly uncertain error before the existing partial-commit rule:
+
+```python
+kind = (
+    ConnectorErrorKind.UNCERTAIN
+    if exc.outcome_uncertain
+    or ((committed_chunks or exc.partial_success) and not replay_safe)
+    else base_kind
+)
+```
+
+Keep item-level 429/502/503/504 retry selection unchanged because a valid bulk
+response explicitly identifies those items as failed.
+
+- [x] **Step 4: Run the Elasticsearch plugin suite**
+
+Run:
+
+```bash
+uv run --extra test --extra elasticsearch pytest -q -m 'not integration' \
+  plugins/onestep-elasticsearch/tests
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Commit the Elasticsearch fix**
+
+```bash
+git add \
+  plugins/onestep-elasticsearch/src/onestep_elasticsearch/connector.py \
+  plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py
+git commit -m "fix(elasticsearch): avoid ambiguous auto-id retries"
+```
+
+## Task 2: Validate MongoDB Python Numeric Options and Cursor Projections
+
+**Files:**
+- Modify: `plugins/onestep-mongodb/src/onestep_mongodb/connector.py:147`
+- Modify: `plugins/onestep-mongodb/src/onestep_mongodb/connector.py:279`
+- Modify: `plugins/onestep-mongodb/src/onestep_mongodb/connector.py:454`
+- Test: `plugins/onestep-mongodb/tests/test_mongodb_polling.py`
+- Test: `plugins/onestep-mongodb/tests/test_mongodb_change_stream.py`
+- Test: `plugins/onestep-mongodb/tests/test_mongodb_sink.py`
+
+- [x] **Step 1: Write failing direct API validation tests**
+
+Add:
+
+```python
+@pytest.mark.parametrize("batch_size", [0, -1, True, 1.5])
+def test_polling_rejects_invalid_batch_size(batch_size) -> None:
+    with pytest.raises((TypeError, ValueError), match="batch_size"):
+        MongoDBConnector(
+            "mongodb://local", database="app", client=object()
+        ).poll_collection("events", batch_size=batch_size)
+
+
+@pytest.mark.parametrize("poll_interval_s", [-0.1, True])
+def test_polling_rejects_invalid_poll_interval(poll_interval_s) -> None:
+    with pytest.raises((TypeError, ValueError), match="poll_interval_s"):
+        MongoDBConnector(
+            "mongodb://local", database="app", client=object()
+        ).poll_collection("events", poll_interval_s=poll_interval_s)
+
+
+@pytest.mark.parametrize(
+    ("projection", "cursor"),
+    [
+        ({"updated_at": 0}, ("updated_at", "_id")),
+        ({"value": 1}, ("updated_at", "_id")),
+        ({"_id": 0}, ("updated_at", "_id")),
+    ],
+)
+def test_polling_projection_must_preserve_effective_cursor(projection, cursor) -> None:
+    with pytest.raises(ValueError, match="projection.*cursor"):
+        MongoDBConnector(
+            "mongodb://local", database="app", client=object()
+        ).poll_collection("events", projection=projection, cursor=cursor)
+```
+
+In `test_mongodb_change_stream.py`, add invalid `batch_size`,
+`max_await_time_ms`, and `poll_interval_s` constructor cases:
+
+```python
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("batch_size", 0),
+        ("batch_size", True),
+        ("max_await_time_ms", 0),
+        ("max_await_time_ms", 1.5),
+        ("poll_interval_s", -0.1),
+        ("poll_interval_s", True),
+    ],
+)
+def test_change_stream_rejects_invalid_numeric_options(option, value) -> None:
+    with pytest.raises((TypeError, ValueError), match=option):
+        MongoDBConnector(
+            "mongodb://local", database="app", client=object()
+        ).watch_collection("events", **{option: value})
+```
+
+In `test_mongodb_sink.py`, add:
+
+```python
+@pytest.mark.parametrize("batch_size", [0, -1, True, 1.5])
+def test_sink_rejects_invalid_batch_size(batch_size) -> None:
+    with pytest.raises((TypeError, ValueError), match="batch_size"):
+        _connector(FakeSinkCollection()).collection_sink(
+            "events", batch_size=batch_size
+        )
+```
+
+- [x] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+```bash
+uv run --extra test --extra mongodb pytest -q \
+  plugins/onestep-mongodb/tests/test_mongodb_polling.py \
+  plugins/onestep-mongodb/tests/test_mongodb_change_stream.py \
+  plugins/onestep-mongodb/tests/test_mongodb_sink.py \
+  -k 'invalid or projection or rejects'
+```
+
+Expected: the new polling and change-stream constructor cases fail because the
+current Python API stores invalid values without validation.
+
+- [x] **Step 3: Add small connector-local validators**
+
+Add above `MongoDBConnector`:
+
+```python
+def _positive_integer(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{field} must be an integer")
+    if value <= 0:
+        raise ValueError(f"{field} must be positive")
+    return value
+
+
+def _non_negative_number(value: Any, *, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{field} must be a number")
+    if value < 0:
+        raise ValueError(f"{field} must be non-negative")
+    return float(value)
+
+
+def _validate_cursor_projection(
+    projection: Mapping[str, Any] | None,
+    cursor: Sequence[str],
+) -> None:
+    if not projection:
+        return
+
+    def excludes(value: Any) -> bool:
+        return value is False or (
+            not isinstance(value, bool)
+            and isinstance(value, (int, float))
+            and value == 0
+        )
+
+    excluded = {key for key, value in projection.items() if excludes(value)}
+    included = {
+        key for key, value in projection.items()
+        if key != "_id" and not excludes(value)
+    }
+    missing = [
+        field
+        for field in cursor
+        if field in excluded
+        or (included and field != "_id" and field not in projection)
+    ]
+    if "_id" in cursor and "_id" in excluded:
+        missing.append("_id")
+    if missing:
+        fields = ", ".join(dict.fromkeys(missing))
+        raise ValueError(f"projection must preserve cursor fields: {fields}")
+```
+
+Use the helpers in all three constructors:
+
+```python
+self.batch_size = _positive_integer(batch_size, field="batch_size")
+self.poll_interval_s = _non_negative_number(
+    poll_interval_s, field="poll_interval_s"
+)
+```
+
+For change streams also validate `max_await_time_ms`; for the sink validate
+`batch_size`. After computing the effective polling cursor, call:
+
+```python
+_validate_cursor_projection(self.projection, self.cursor)
+```
+
+- [x] **Step 4: Run MongoDB non-integration tests**
+
+Run:
+
+```bash
+uv run --extra test --extra mongodb pytest -q -m 'not integration' \
+  plugins/onestep-mongodb/tests
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Commit MongoDB constructor validation**
+
+```bash
+git add \
+  plugins/onestep-mongodb/src/onestep_mongodb/connector.py \
+  plugins/onestep-mongodb/tests/test_mongodb_polling.py \
+  plugins/onestep-mongodb/tests/test_mongodb_change_stream.py \
+  plugins/onestep-mongodb/tests/test_mongodb_sink.py
+git commit -m "fix(mongodb): validate direct connector options"
+```
+
+## Task 3: Make MongoDB Cursor Generations And Persistence Failure-Safe
+
+**Files:**
+- Modify: `plugins/onestep-mongodb/src/onestep_mongodb/connector.py:33`
+- Modify: `plugins/onestep-mongodb/src/onestep_mongodb/connector.py:187`
+- Modify: `plugins/onestep-mongodb/src/onestep_mongodb/connector.py:245`
+- Modify: `plugins/onestep-mongodb/src/onestep_mongodb/connector.py:298`
+- Modify: `plugins/onestep-mongodb/src/onestep_mongodb/connector.py:420`
+- Test: `plugins/onestep-mongodb/tests/test_mongodb_polling.py`
+- Test: `plugins/onestep-mongodb/tests/test_mongodb_change_stream.py`
+
+- [x] **Step 1: Lock the later-ACK then earlier-retry regression**
+
+Add this pure tracker test to `test_mongodb_polling.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_later_ack_then_earlier_retry_does_not_cross_generation_gap() -> None:
+    saved: list[object] = []
+    tracker = _ContiguousGenerationTracker(lambda token: _append(saved, token))
+    first = tracker.add("one")
+    second = tracker.add("two")
+
+    await tracker.complete(second, advance=True)
+    await tracker.invalidate(first.generation)
+    await tracker.complete(first, advance=False)
+
+    assert saved == []
+    assert tracker.can_fetch is True
+```
+
+Add the source-level version next to
+`test_retry_waits_for_stale_generation_then_replays_committed_state`:
+
+```python
+@pytest.mark.asyncio
+async def test_later_ack_then_earlier_retry_replays_from_committed_state() -> None:
+    documents = [
+        {"_id": ObjectId("64b64c1234567890abcdef12"), "updated_at": 1},
+        {"_id": ObjectId("64b64c1234567890abcdef13"), "updated_at": 2},
+    ]
+    store = RecordingStore()
+    collection = FakeCollection(documents)
+    source = MongoDBConnector(
+        "mongodb://local", database="app", client=FakeClient(collection)
+    ).poll_collection("events", cursor=("updated_at", "_id"), state=store)
+    first, second = await source.fetch(2)
+
+    await second.ack()
+    await first.retry()
+    replayed = await source.fetch(2)
+
+    assert store.saved == []
+    assert [item.payload["updated_at"] for item in replayed] == [1, 2]
+```
+
+- [x] **Step 2: Run the generation-gap tests and verify they fail**
+
+Run:
+
+```bash
+uv run --extra test --extra mongodb pytest -q \
+  plugins/onestep-mongodb/tests/test_mongodb_polling.py \
+  -k 'later_ack_then_earlier_retry'
+```
+
+Expected: FAIL because the later completed token still has `advances=True` when
+the earlier retry invalidates the generation, so the current prefix loop saves
+the later token.
+
+- [x] **Step 3: Clear advancement for the complete invalidated generation**
+
+Update `_ContiguousGenerationTracker.invalidate()`:
+
+```python
+async def invalidate(self, generation: int) -> None:
+    async with self._lock:
+        if generation == self.generation:
+            self._invalidated.add(generation)
+            for item in self._pending:
+                if item.generation == generation:
+                    item.advances = False
+            self.generation += 1
+```
+
+This invalidates both unfinished and already-completed tokens from the same
+fetch generation. Do not clear `completed`; those delivery callbacks have already
+finished and still count toward releasing the stale generation.
+
+- [x] **Step 4: Add a state store that fails one save**
+
+Add this helper directly after `RecordingStore` in both
+`test_mongodb_polling.py` and `test_mongodb_change_stream.py`:
+
+```python
+class FailOnceStore(RecordingStore):
+    def __init__(self, loaded=None) -> None:
+        super().__init__(loaded)
+        self.save_calls = 0
+
+    async def save(self, key, value):
+        self.save_calls += 1
+        if self.save_calls == 1:
+            raise RuntimeError("state unavailable")
+        await super().save(key, value)
+```
+
+- [x] **Step 5: Write failing polling persistence tests**
+
+Add:
+
+```python
+@pytest.mark.asyncio
+async def test_polling_state_save_failure_does_not_advance_or_drop_prefix() -> None:
+    documents = [
+        {"_id": ObjectId("64b64c1234567890abcdef12"), "updated_at": 1},
+        {"_id": ObjectId("64b64c1234567890abcdef13"), "updated_at": 2},
+    ]
+    store = FailOnceStore()
+    collection = FakeCollection(documents)
+    source = MongoDBConnector(
+        "mongodb://local", database="app", client=FakeClient(collection)
+    ).poll_collection("events", cursor=("updated_at", "_id"), state=store)
+    first, second = await source.fetch(2)
+
+    await second.ack()
+    with pytest.raises(RuntimeError, match="state unavailable"):
+        await first.ack()
+
+    assert source._committed is None
+    assert store.saved == []
+
+    await first.retry()
+    replayed = await source.fetch(2)
+    assert [item.payload["updated_at"] for item in replayed] == [1, 2]
+```
+
+- [x] **Step 6: Write the change-stream persistence test**
+
+Add:
+
+```python
+@pytest.mark.asyncio
+async def test_change_stream_state_save_failure_reopens_without_lost_token() -> None:
+    first_event = _event("64b64c1234567890abcdef12", "insert")
+    second_event = _event("64b64c1234567890abcdef13", "update")
+    first_stream = FakeChangeStream([first_event, second_event])
+    replacement = FakeChangeStream([])
+    collection = FakeWatchCollection([first_stream, replacement])
+    store = FailOnceStore()
+    source = MongoDBConnector(
+        "mongodb://local", database="app", client=FakeWatchClient(collection)
+    ).watch_collection("events", state=store)
+    first, second = await source.fetch(2)
+
+    await second.ack()
+    with pytest.raises(RuntimeError, match="state unavailable"):
+        await first.ack()
+
+    assert source._resume_token is None
+    assert store.saved == []
+
+    await first.retry()
+    await source.fetch(2)
+    assert len(collection.watch_calls) == 2
+    assert "resume_after" not in collection.watch_calls[1]
+```
+
+- [x] **Step 7: Run the new tests and verify they fail**
+
+Run:
+
+```bash
+uv run --extra test --extra mongodb pytest -q \
+  plugins/onestep-mongodb/tests/test_mongodb_polling.py \
+  plugins/onestep-mongodb/tests/test_mongodb_change_stream.py \
+  -k 'state_save_failure'
+```
+
+Expected: FAIL because `_save()` mutates the in-memory committed token before
+durable persistence, `complete()` removes the contiguous prefix before save, and
+the delivery marks itself terminal before the failing operation returns.
+
+- [x] **Step 8: Persist before mutating the tracker**
+
+Change both source `_save()` methods so durable persistence precedes in-memory
+state:
+
+```python
+async def _save(self, token: Any) -> None:
+    await self.state.save(self.state_key, encode_state(list(token)))
+    self._committed = tuple(token)
+```
+
+```python
+async def _save(self, token: Any) -> None:
+    await self.state.save(self.state_key, encode_state(token))
+    self._resume_token = token
+```
+
+Refactor `_ContiguousGenerationTracker.complete()` to inspect the contiguous
+completed prefix without removing it, call `_save()` first, and only then remove
+the prefix and decrement the completing delivery's outstanding count. If `_save()`
+raises, restore the completing token's prior `completed` and `advances` values and
+leave `_pending`, `_outstanding`, and `_invalidated` unchanged.
+
+Use this transaction shape:
+
+```python
+async def complete(self, tracked: _TrackedToken, *, advance: bool) -> None:
+    async with self._lock:
+        previous = (tracked.completed, tracked.advances)
+        stale = tracked.generation in self._invalidated
+        tracked.completed = True
+        tracked.advances = advance and not stale
+
+        prefix: list[_TrackedToken] = []
+        saved = None
+        for item in self._pending:
+            if not item.completed:
+                break
+            prefix.append(item)
+            if item.advances:
+                saved = item.token
+
+        try:
+            if saved is not None:
+                await self._save(saved)
+        except Exception:
+            tracked.completed, tracked.advances = previous
+            raise
+
+        if not previous[0]:
+            self._outstanding[tracked.generation] = max(
+                0, self._outstanding.get(tracked.generation, 1) - 1
+            )
+        for _ in prefix:
+            self._pending.popleft()
+        self._discard_settled_generations()
+```
+
+Extract the existing zero-count cleanup loop into
+`_discard_settled_generations()` so both behavior and ordering stay explicit.
+
+- [x] **Step 9: Mark delivery terminal only after its callback succeeds**
+
+For polling and change-stream deliveries, move `_terminal = True` after the
+awaited operation in `ack()`, `retry()`, `fail()`, and `release_unstarted()`:
+
+```python
+async def ack(self) -> None:
+    if self._terminal:
+        return
+    await self._source._tracker.complete(self._tracked, advance=True)
+    self._terminal = True
+```
+
+For multi-step callbacks, keep the delivery non-terminal until invalidation and
+tracker completion both succeed. This lets the runtime call `retry()` when an ACK
+fails instead of turning that retry into a no-op.
+
+- [x] **Step 10: Run MongoDB tests**
+
+Run:
+
+```bash
+uv run --extra test --extra mongodb pytest -q -m 'not integration' \
+  plugins/onestep-mongodb/tests
+```
+
+Expected: PASS, including out-of-order ACK, retry-gap, stop-control, and the new
+state-save failure cases.
+
+- [x] **Step 11: Commit MongoDB generation and persistence semantics**
+
+```bash
+git add \
+  plugins/onestep-mongodb/src/onestep_mongodb/connector.py \
+  plugins/onestep-mongodb/tests/test_mongodb_polling.py \
+  plugins/onestep-mongodb/tests/test_mongodb_change_stream.py
+git commit -m "fix(mongodb): preserve cursor generation gaps"
+```
+
+## Task 4: Document, Verify, And Prepare Patch Releases
+
+**Files:**
+- Modify: `plugins/onestep-elasticsearch/README.md`
+- Modify: `plugins/onestep-mongodb/README.md`
+- Modify: `CHANGELOG.md`
+
+- [x] **Step 1: Document Elasticsearch request ambiguity**
+
+Append to `Delivery semantics`:
+
+```markdown
+Request-level 502, 503, and 504 responses are ambiguous after the request body
+has been sent. The sink retries them internally only when `operation: index` and
+a present `id_field` make replay convergent. A request-level 429 is an explicit
+rejection and remains retryable without stable IDs.
+```
+
+- [x] **Step 2: Document MongoDB projection and state behavior**
+
+Append to `Sources`:
+
+```markdown
+A polling projection must retain every effective cursor field, including the
+implicit `_id` tie-breaker. Invalid projections fail during source construction.
+Cursor state is updated in memory only after the configured cursor store confirms
+the save; a save failure leaves the generation replayable from the last durable
+cursor. If any delivery retries, every token in that fetch generation is prevented
+from advancing the cursor, including later deliveries that already acknowledged.
+```
+
+- [x] **Step 3: Add unreleased changelog entries**
+
+Under `## Unreleased`, add:
+
+```markdown
+- Prevents the Elasticsearch/OpenSearch bulk sink from internally replaying
+  ambiguous request-level gateway failures when documents lack stable IDs.
+- Rejects invalid MongoDB direct Python numeric options during construction and
+  polling projections that omit or rewrite effective cursor fields.
+- Prevents a later MongoDB acknowledgement from advancing the cursor after an
+  earlier delivery invalidates the same generation for retry.
+- Keeps MongoDB cursor generations replayable when durable state persistence
+  fails.
+```
+
+- [x] **Step 4: Run format and focused compatibility checks**
+
+Run:
+
+```bash
+uv run ruff check \
+  plugins/onestep-elasticsearch/src \
+  plugins/onestep-elasticsearch/tests \
+  plugins/onestep-mongodb/src \
+  plugins/onestep-mongodb/tests
+uv run --extra test --extra elasticsearch --extra mongodb pytest -q \
+  -m 'not integration' \
+  plugins/onestep-elasticsearch/tests
+uv run --extra test --extra mongodb pytest -q -m 'not integration' \
+  plugins/onestep-mongodb/tests
+```
+
+Expected: all commands exit 0.
+
+Actual: both affected plugin suites pass. Runtime-critical Ruff rules pass; the
+unfiltered Ruff command still reports 12 MongoDB import/style findings, including
+pre-existing plugin-wide style debt unrelated to these correctness semantics.
+
+- [x] **Step 5: Run the repository reliability gate**
+
+Run:
+
+```bash
+./scripts/run-reliability-checks.sh
+```
+
+Expected: core and every installed official plugin non-integration suite pass in
+isolated pytest processes.
+
+- [x] **Step 6: Commit documentation**
+
+```bash
+git add \
+  CHANGELOG.md \
+  plugins/onestep-elasticsearch/README.md \
+  plugins/onestep-mongodb/README.md
+git commit -m "docs: clarify connector replay guarantees"
+```
+
+- [x] **Step 7: Stop before release metadata**
+
+Do not bump versions, update `uv.lock`, tag, push, or publish as part of this
+implementation plan. When the user requests release, follow repository release
+rules in a separate release step: bump both affected plugin patch versions,
+update `uv.lock`, preserve `onestep>=1.7.1` because core did not change, update
+the changelog headings, then publish the new immutable package versions.
+
+## Completion Gate
+
+The increment is complete only when:
+
+- auto-ID Elasticsearch writes issue exactly one request after an ambiguous
+  request-level 502/503/504 and return `UNCERTAIN`;
+- stable-ID index writes and explicit request-level 429 rejections retain bounded
+  internal retry;
+- invalid MongoDB direct Python source/sink options fail during construction;
+- MongoDB polling projections cannot remove effective cursor fields;
+- a later MongoDB ACK followed by an earlier retry does not persist a token from
+  the invalidated generation;
+- failed MongoDB cursor-store saves do not advance in-memory state, discard the
+  contiguous pending prefix, or suppress the runtime retry callback;
+- both plugin suites and the repository reliability gate pass;
+- no runtime reporter or control-plane protocol field changes.

--- a/docs/yaml-task-definition.md
+++ b/docs/yaml-task-definition.md
@@ -721,6 +721,9 @@ Strict mode rejects an unacknowledged `w=0` write concern.
 When `_id` is not configured, it is appended as the deterministic final
 tie-breaker. Polling is ascending keyset traversal, not CDC: deletes are
 invisible and updates that do not advance a cursor field can be missed.
+A polling projection must retain every effective cursor field unchanged,
+including the implicit `_id` tie-breaker. Invalid projections fail during
+resource construction.
 
 `mongodb_change_stream` fields:
 

--- a/plugins/onestep-elasticsearch/README.md
+++ b/plugins/onestep-elasticsearch/README.md
@@ -87,6 +87,11 @@ the item index, status, identifier, and normalized reason. A partial commit is
 reported as `UNCERTAIN` unless `index` with a stable `id_field` makes replay
 deterministic. `create` conflicts and malformed documents are permanent failures.
 
+Request-level 502, 503, and 504 responses are ambiguous after the request body
+has been sent. The sink retries them internally only when `operation: index` and
+a present `id_field` make replay convergent. A request-level 429 is an explicit
+rejection and remains retryable without stable IDs.
+
 ## Deferred features
 
 Version 1 intentionally excludes Cloud ID, sniffing, SigV4, data streams,

--- a/plugins/onestep-elasticsearch/pyproject.toml
+++ b/plugins/onestep-elasticsearch/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-elasticsearch"
-version = "0.1.1"
+version = "0.1.2"
 description = "Elasticsearch and OpenSearch connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-elasticsearch/src/onestep_elasticsearch/connector.py
+++ b/plugins/onestep-elasticsearch/src/onestep_elasticsearch/connector.py
@@ -48,10 +48,15 @@ class ElasticsearchBulkItemError:
 
 class ElasticsearchBulkError(Exception):
     def __init__(
-        self, items: list[ElasticsearchBulkItemError], *, partial_success: bool = False
+        self,
+        items: list[ElasticsearchBulkItemError],
+        *,
+        partial_success: bool = False,
+        outcome_uncertain: bool = False,
     ) -> None:
         self.items = tuple(items)
         self.partial_success = partial_success
+        self.outcome_uncertain = outcome_uncertain
         summary = ", ".join(
             f"item={item.action_index} status={item.status} reason={item.reason[:160]}"
             for item in self.items[:10]
@@ -339,7 +344,20 @@ class ElasticsearchBulkSink(Sink):
                     )
                 )
                 continue
-            status = int(item.get("status", 0))
+            try:
+                status = int(item.get("status", 0))
+            except (TypeError, ValueError):
+                failures.append(
+                    ElasticsearchBulkItemError(
+                        index,
+                        str(operation),
+                        item.get("_id"),
+                        0,
+                        "invalid_response",
+                        "bulk response item status is invalid",
+                    )
+                )
+                continue
             if 200 <= status < 300:
                 continue
             error = item.get("error") or {}
@@ -394,7 +412,7 @@ class ElasticsearchBulkSink(Sink):
             params["pipeline"] = self.pipeline
         return params
 
-    async def _send_chunk(self, body: bytes) -> None:
+    async def _send_chunk(self, body: bytes, *, replay_safe: bool) -> None:
         import asyncio
         import random
 
@@ -414,12 +432,21 @@ class ElasticsearchBulkSink(Sink):
                     None,
                     self._error_reason(payload.get("error", "request failed")),
                 )
-                if status in {429, 502, 503, 504} and attempt < self.max_retries:
+                request_rejected = status == 429
+                request_ambiguous = status in {502, 503, 504}
+                can_retry_request = request_rejected or (
+                    request_ambiguous and replay_safe
+                )
+                if can_retry_request and attempt < self.max_retries:
                     await asyncio.sleep(
                         (0.05 * (2**attempt)) + random.uniform(0.0, 0.025)
                     )
                     continue
-                raise ElasticsearchBulkError([failure], partial_success=partial_success)
+                raise ElasticsearchBulkError(
+                    [failure],
+                    partial_success=partial_success,
+                    outcome_uncertain=request_ambiguous and not replay_safe,
+                )
             items = payload.get("items")
             expected_items = len(self._action_documents(pending))
             if not isinstance(items, list) or len(items) != expected_items:
@@ -428,11 +455,13 @@ class ElasticsearchBulkSink(Sink):
                     for wrapper in items:
                         if isinstance(wrapper, Mapping) and len(wrapper) == 1:
                             item = next(iter(wrapper.values()))
-                            if (
-                                isinstance(item, Mapping)
-                                and 200 <= int(item.get("status", 0)) < 300
-                            ):
-                                acknowledged += 1
+                            if isinstance(item, Mapping):
+                                try:
+                                    status = int(item.get("status", 0))
+                                except (TypeError, ValueError):
+                                    continue
+                                if 200 <= status < 300:
+                                    acknowledged += 1
                 raise ElasticsearchBulkError(
                     [
                         ElasticsearchBulkItemError(
@@ -445,6 +474,7 @@ class ElasticsearchBulkSink(Sink):
                         )
                     ],
                     partial_success=partial_success or acknowledged > 0,
+                    outcome_uncertain=not replay_safe,
                 )
             failures = self._parse_items(payload)
             if not failures and not payload.get("errors", False):
@@ -473,6 +503,10 @@ class ElasticsearchBulkSink(Sink):
                 raise ElasticsearchBulkError(
                     self._original_item_errors(failures, pending_indexes),
                     partial_success=partial_success,
+                    outcome_uncertain=not replay_safe
+                    and any(
+                        item.error_type == "invalid_response" for item in failures
+                    ),
                 )
             actions = self._action_documents(pending)
             pending = b"".join(actions[index] for index in retryable_indexes)
@@ -500,7 +534,7 @@ class ElasticsearchBulkSink(Sink):
         committed_chunks = 0
         try:
             for chunk in chunks:
-                await self._send_chunk(chunk)
+                await self._send_chunk(chunk, replay_safe=replay_safe)
                 committed_chunks += 1
         except ElasticsearchBulkError as exc:
             base_kind = (
@@ -510,7 +544,8 @@ class ElasticsearchBulkSink(Sink):
             )
             kind = (
                 ConnectorErrorKind.UNCERTAIN
-                if (committed_chunks or exc.partial_success) and not replay_safe
+                if exc.outcome_uncertain
+                or ((committed_chunks or exc.partial_success) and not replay_safe)
                 else base_kind
             )
             raise ConnectorOperationError(

--- a/plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py
+++ b/plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py
@@ -249,18 +249,188 @@ async def test_429_retries_only_failed_subset() -> None:
 
 
 @pytest.mark.asyncio
-async def test_missing_bulk_item_acknowledgement_is_permanent() -> None:
+@pytest.mark.parametrize("status", [502, 503, 504])
+async def test_request_level_gateway_failure_without_stable_ids_is_not_replayed(
+    status,
+) -> None:
+    calls = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(status, json={"error": {"reason": "gateway failure"}})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    sink = ElasticsearchConnector("http://search:9200", client=client).bulk_sink(
+        index="events", max_retries=2
+    )
+
+    with pytest.raises(ConnectorOperationError) as captured:
+        await sink.send(Envelope(body={"value": 1}))
+
+    assert calls == 1
+    assert captured.value.kind is ConnectorErrorKind.UNCERTAIN
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_level_504_with_stable_ids_retries() -> None:
+    responses = [
+        httpx.Response(504, json={"error": {"reason": "gateway timeout"}}),
+        httpx.Response(
+            200,
+            json={"errors": False, "items": [{"index": {"status": 201}}]},
+        ),
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return responses.pop(0)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    sink = ElasticsearchConnector("http://search:9200", client=client).bulk_sink(
+        index="events", id_field="id", max_retries=2
+    )
+
+    await sink.send(Envelope(body={"id": "evt-1", "value": 1}))
+
+    assert responses == []
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "id_field", "expected_kind"),
+    [
+        (504, "id", ConnectorErrorKind.TRANSIENT),
+        (429, None, ConnectorErrorKind.THROTTLED),
+    ],
+)
+async def test_request_level_retry_exhaustion_is_bounded(
+    status, id_field, expected_kind
+) -> None:
+    calls = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(status, json={"error": {"reason": "unavailable"}})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    sink = ElasticsearchConnector("http://search:9200", client=client).bulk_sink(
+        index="events", id_field=id_field, max_retries=2
+    )
+
+    with pytest.raises(ConnectorOperationError) as captured:
+        await sink.send(Envelope(body={"id": "evt-1", "value": 1}))
+
+    assert calls == 3
+    assert captured.value.kind is expected_kind
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_with_id_field_does_not_claim_replay_safety() -> None:
+    calls = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(504, json={"error": {"reason": "gateway timeout"}})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    sink = ElasticsearchConnector("http://search:9200", client=client).bulk_sink(
+        index="events", operation="create", id_field="id", max_retries=2
+    )
+
+    with pytest.raises(ConnectorOperationError) as captured:
+        await sink.send(Envelope(body={"id": "evt-1", "value": 1}))
+
+    assert calls == 1
+    assert captured.value.kind is ConnectorErrorKind.UNCERTAIN
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_level_429_without_stable_ids_remains_retryable() -> None:
+    responses = [
+        httpx.Response(429, json={"error": {"reason": "rejected"}}),
+        httpx.Response(
+            200,
+            json={"errors": False, "items": [{"index": {"status": 201}}]},
+        ),
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return responses.pop(0)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    sink = ElasticsearchConnector("http://search:9200", client=client).bulk_sink(
+        index="events", max_retries=2
+    )
+
+    await sink.send(Envelope(body={"value": 1}))
+
+    assert responses == []
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("id_field", "expected_kind"),
+    [
+        (None, ConnectorErrorKind.UNCERTAIN),
+        ("id", ConnectorErrorKind.PERMANENT),
+    ],
+)
+async def test_missing_bulk_item_acknowledgement_is_classified_by_replay_safety(
+    id_field, expected_kind
+) -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={"errors": False, "items": []})
 
     client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     sink = ElasticsearchConnector("http://search:9200", client=client).bulk_sink(
-        index="events"
+        index="events", id_field=id_field
     )
     with pytest.raises(ConnectorOperationError) as captured:
         await sink.send(Envelope(body={"id": "one"}))
-    assert captured.value.kind is ConnectorErrorKind.PERMANENT
+    assert captured.value.kind is expected_kind
     assert captured.value.cause.items[0].status == 0
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"errors": False, "items": ["invalid"]},
+        {"errors": False, "items": [{"index": {"status": "invalid"}}]},
+        {"errors": True, "items": [{"index": {"status": 201}}]},
+    ],
+)
+@pytest.mark.parametrize(
+    ("id_field", "expected_kind"),
+    [
+        (None, ConnectorErrorKind.UNCERTAIN),
+        ("id", ConnectorErrorKind.PERMANENT),
+    ],
+)
+async def test_malformed_bulk_item_response_is_classified_by_replay_safety(
+    payload, id_field, expected_kind
+) -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    sink = ElasticsearchConnector("http://search:9200", client=client).bulk_sink(
+        index="events", id_field=id_field
+    )
+
+    with pytest.raises(ConnectorOperationError) as captured:
+        await sink.send(Envelope(body={"id": "one"}))
+
+    assert captured.value.kind is expected_kind
+    assert captured.value.cause.items[0].error_type == "invalid_response"
     await client.aclose()
 
 
@@ -315,19 +485,28 @@ async def test_oversized_action_is_permanent_without_a_network_call() -> None:
 
 
 @pytest.mark.asyncio
-async def test_non_object_bulk_response_is_permanent() -> None:
+@pytest.mark.parametrize(
+    ("id_field", "expected_kind"),
+    [
+        (None, ConnectorErrorKind.UNCERTAIN),
+        ("id", ConnectorErrorKind.PERMANENT),
+    ],
+)
+async def test_non_object_bulk_response_is_classified_by_replay_safety(
+    id_field, expected_kind
+) -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json=[])
 
     client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     sink = ElasticsearchConnector("http://search:9200", client=client).bulk_sink(
-        index="events"
+        index="events", id_field=id_field
     )
 
     with pytest.raises(ConnectorOperationError) as captured:
         await sink.send(Envelope(body={"id": "one"}))
 
-    assert captured.value.kind is ConnectorErrorKind.PERMANENT
+    assert captured.value.kind is expected_kind
     await client.aclose()
 
 

--- a/plugins/onestep-mongodb/README.md
+++ b/plugins/onestep-mongodb/README.md
@@ -142,6 +142,13 @@ terminal `fail()` skips the poison document and advances that contiguous cursor;
 last committed cursor only after all stale deliveries finish. Late acknowledgements
 from invalidated generations do nothing.
 
+A polling projection must retain every effective cursor field, including the
+implicit `_id` tie-breaker. Invalid projections fail during source construction.
+Cursor state is updated in memory only after the configured cursor store confirms
+the save; a save failure leaves the generation replayable from the last durable
+cursor. If any delivery retries, every token in that fetch generation is prevented
+from advancing the cursor, including later deliveries that already acknowledged.
+
 Polling does not emit deletes. It sees updates only if a cursor field increases,
 and can miss non-monotonic cursor updates. Use change streams for workloads that
 need those events.

--- a/plugins/onestep-mongodb/pyproject.toml
+++ b/plugins/onestep-mongodb/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-mongodb"
-version = "0.1.1"
+version = "0.1.2"
 description = "MongoDB connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
+++ b/plugins/onestep-mongodb/src/onestep_mongodb/connector.py
@@ -21,6 +21,66 @@ from onestep import (
 from .state_codec import decode_state, encode_state
 
 
+def _positive_integer(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{field} must be an integer")
+    if value <= 0:
+        raise ValueError(f"{field} must be positive")
+    return value
+
+
+def _non_negative_number(value: Any, *, field: str) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{field} must be a number")
+    if value < 0:
+        raise ValueError(f"{field} must be non-negative")
+    return value
+
+
+def _validate_cursor_projection(
+    projection: Mapping[str, Any] | None,
+    cursor: Sequence[str],
+) -> None:
+    if not projection:
+        return
+
+    def excludes(value: Any) -> bool:
+        return value is False or (
+            not isinstance(value, bool)
+            and isinstance(value, (int, float))
+            and value == 0
+        )
+
+    def includes_unchanged(value: Any) -> bool:
+        return value is True or (
+            not isinstance(value, bool)
+            and isinstance(value, (int, float))
+            and value == 1
+        )
+
+    excluded = {key for key, value in projection.items() if excludes(value)}
+    has_inclusion = any(not excludes(value) for value in projection.values())
+    missing = [
+        field
+        for field in cursor
+        if field in excluded
+        or (
+            has_inclusion
+            and field != "_id"
+            and not includes_unchanged(projection.get(field))
+        )
+        or (
+            has_inclusion
+            and field == "_id"
+            and field in projection
+            and not includes_unchanged(projection[field])
+        )
+    ]
+    if missing:
+        fields = ", ".join(dict.fromkeys(missing))
+        raise ValueError(f"projection must preserve cursor fields: {fields}")
+
+
 @dataclass
 class _TrackedToken:
     generation: int
@@ -58,25 +118,51 @@ class _ContiguousGenerationTracker:
         async with self._lock:
             if generation == self.generation:
                 self._invalidated.add(generation)
+                for item in self._pending:
+                    if item.generation == generation:
+                        item.advances = False
                 self.generation += 1
+
+    def _discard_settled_generations(self) -> None:
+        settled = [
+            generation
+            for generation, count in self._outstanding.items()
+            if count == 0
+        ]
+        for generation in settled:
+            self._outstanding.pop(generation, None)
+            self._invalidated.discard(generation)
 
     async def complete(self, tracked: _TrackedToken, *, advance: bool) -> None:
         async with self._lock:
+            previous = (tracked.completed, tracked.advances)
             stale = tracked.generation in self._invalidated
             tracked.completed = True
             tracked.advances = advance and not stale
-            self._outstanding[tracked.generation] = max(0, self._outstanding.get(tracked.generation, 1) - 1)
+
+            prefix: list[_TrackedToken] = []
             saved = None
-            while self._pending and self._pending[0].completed:
-                item = self._pending.popleft()
+            for item in self._pending:
+                if not item.completed:
+                    break
+                prefix.append(item)
                 if item.advances:
                     saved = item.token
-            stale_generations = [item for item, count in self._outstanding.items() if count == 0]
-            for item in stale_generations:
-                self._outstanding.pop(item, None)
-                self._invalidated.discard(item)
-            if saved is not None:
-                await self._save(saved)
+
+            try:
+                if saved is not None:
+                    await self._save(saved)
+            except BaseException:
+                tracked.completed, tracked.advances = previous
+                raise
+
+            if not previous[0]:
+                self._outstanding[tracked.generation] = max(
+                    0, self._outstanding.get(tracked.generation, 1) - 1
+                )
+            for _ in prefix:
+                self._pending.popleft()
+            self._discard_settled_generations()
 
 
 class MongoDBPayloadError(ValueError):
@@ -159,8 +245,11 @@ class MongoDBPollingSource(Source):
         self.collection_name = collection
         self.filter = dict(filter or {})
         self.projection = dict(projection or {}) or None
-        self.batch_size = batch_size
-        self.poll_interval_s = poll_interval_s
+        _validate_cursor_projection(self.projection, self.cursor)
+        self.batch_size = _positive_integer(batch_size, field="batch_size")
+        self.poll_interval_s = _non_negative_number(
+            poll_interval_s, field="poll_interval_s"
+        )
         self.state = state or InMemoryCursorStore()
         self.state_key = state_key or f"mongodb:{connector.database_name}:{collection}:poll:{','.join(self.cursor)}"
         self.initial_cursor = tuple(decode_state({"extended_json": list(initial_cursor)})) if initial_cursor is not None else None
@@ -185,8 +274,8 @@ class MongoDBPollingSource(Source):
         return dict(self.filter or cursor_query)
 
     async def _save(self, token: Any) -> None:
-        self._committed = tuple(token)
         await self.state.save(self.state_key, encode_state(list(token)))
+        self._committed = tuple(token)
 
     async def open(self) -> None:
         if self._loaded:
@@ -252,28 +341,28 @@ class MongoDBPollingDelivery(Delivery):
     async def ack(self) -> None:
         if self._terminal:
             return
-        self._terminal = True
         await self._source._tracker.complete(self._tracked, advance=True)
+        self._terminal = True
 
     async def retry(self, *, delay_s: float | None = None) -> None:
         if self._terminal:
             return
-        self._terminal = True
         await self._source.invalidate(self._tracked, delay_s=delay_s)
         await self._source._tracker.complete(self._tracked, advance=False)
+        self._terminal = True
 
     async def fail(self, exc: Exception | None = None) -> None:
         if self._terminal:
             return
-        self._terminal = True
         await self._source._tracker.complete(self._tracked, advance=True)
+        self._terminal = True
 
     async def release_unstarted(self) -> None:
         if self._terminal:
             return
-        self._terminal = True
         await self._source.invalidate(self._tracked)
         await self._source._tracker.complete(self._tracked, advance=False)
+        self._terminal = True
 
 
 class MongoDBChangeStreamSource(Source):
@@ -285,9 +374,13 @@ class MongoDBChangeStreamSource(Source):
         self.collection_name = collection
         self.pipeline = [dict(stage) for stage in (pipeline or [])]
         self.full_document = full_document
-        self.max_await_time_ms = max_await_time_ms
-        self.batch_size = batch_size
-        self.poll_interval_s = poll_interval_s
+        self.max_await_time_ms = _positive_integer(
+            max_await_time_ms, field="max_await_time_ms"
+        )
+        self.batch_size = _positive_integer(batch_size, field="batch_size")
+        self.poll_interval_s = _non_negative_number(
+            poll_interval_s, field="poll_interval_s"
+        )
         self.state = state or InMemoryCursorStore()
         self.state_key = state_key or f"mongodb:{connector.database_name}:{collection}:change-stream"
         self._resume_token = None
@@ -296,8 +389,8 @@ class MongoDBChangeStreamSource(Source):
         self._tracker = _ContiguousGenerationTracker(self._save)
 
     async def _save(self, token: Any) -> None:
-        self._resume_token = token
         await self.state.save(self.state_key, encode_state(token))
+        self._resume_token = token
 
     async def open(self) -> None:
         if not self._loaded:
@@ -407,9 +500,15 @@ class MongoDBChangeStreamSource(Source):
         if delay_s:
             await asyncio.sleep(delay_s)
         await self._tracker.invalidate(tracked.generation)
-        if self._stream is not None:
-            await self._stream.close()
-            self._stream = None
+        stream = self._stream
+        self._stream = None
+        if stream is not None:
+            try:
+                await stream.close()
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
 
     async def close(self) -> None:
         if self._stream is not None:
@@ -427,28 +526,28 @@ class MongoDBChangeStreamDelivery(Delivery):
     async def ack(self) -> None:
         if self._terminal:
             return
-        self._terminal = True
         await self._source._tracker.complete(self._tracked, advance=True)
+        self._terminal = True
 
     async def retry(self, *, delay_s: float | None = None) -> None:
         if self._terminal:
             return
-        self._terminal = True
         await self._source.invalidate(self._tracked, delay_s=delay_s)
         await self._source._tracker.complete(self._tracked, advance=False)
+        self._terminal = True
 
     async def fail(self, exc: Exception | None = None) -> None:
         if self._terminal:
             return
-        self._terminal = True
         await self._source._tracker.complete(self._tracked, advance=True)
+        self._terminal = True
 
     async def release_unstarted(self) -> None:
         if self._terminal:
             return
-        self._terminal = True
         await self._source.invalidate(self._tracked)
         await self._source._tracker.complete(self._tracked, advance=False)
+        self._terminal = True
 
 
 class MongoDBCollectionSink(Sink):
@@ -458,14 +557,12 @@ class MongoDBCollectionSink(Sink):
             raise ValueError("mode must be insert or upsert")
         if mode == "upsert" and not keys:
             raise ValueError("upsert mode requires keys")
-        if batch_size <= 0:
-            raise ValueError("batch_size must be positive")
         self.connector = connector
         self.collection_name = collection
         self.mode = mode
         self.keys = tuple(keys)
         self.ordered = ordered
-        self.batch_size = batch_size
+        self.batch_size = _positive_integer(batch_size, field="batch_size")
 
     def _documents(self, body: Any) -> list[dict[str, Any]]:
         if isinstance(body, Mapping):

--- a/plugins/onestep-mongodb/tests/test_mongodb_change_stream.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_change_stream.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from bson import ObjectId
+from pymongo.errors import OperationFailure
 
+from onestep import ConnectorErrorKind, ConnectorOperationError
 from onestep_mongodb import MongoDBConnector
 from onestep_mongodb.state_codec import decode_state, encode_state
 
@@ -20,6 +24,18 @@ class RecordingStore:
         self.loaded = value
 
 
+class FailOnceStore(RecordingStore):
+    def __init__(self, loaded=None) -> None:
+        super().__init__(loaded)
+        self.save_calls = 0
+
+    async def save(self, key, value):
+        self.save_calls += 1
+        if self.save_calls == 1:
+            raise RuntimeError("state unavailable")
+        await super().save(key, value)
+
+
 class FakeChangeStream:
     def __init__(self, events) -> None:
         self.events = list(events)
@@ -30,6 +46,17 @@ class FakeChangeStream:
 
     async def close(self):
         self.closed = True
+
+
+class FailingCloseStream(FakeChangeStream):
+    def __init__(self, events, error_type) -> None:
+        super().__init__(events)
+        self.error_type = error_type
+        self.close_calls = 0
+
+    async def close(self):
+        self.close_calls += 1
+        raise self.error_type("close unavailable")
 
 
 class FakeWatchCollection:
@@ -61,6 +88,24 @@ class FakeWatchClient:
 def _event(hex_id: str, operation: str):
     object_id = ObjectId(hex_id)
     return {"_id": {"token": hex_id}, "operationType": operation, "documentKey": {"_id": object_id}}
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("batch_size", 0),
+        ("batch_size", True),
+        ("max_await_time_ms", 0),
+        ("max_await_time_ms", 1.5),
+        ("poll_interval_s", -0.1),
+        ("poll_interval_s", True),
+    ],
+)
+def test_change_stream_rejects_invalid_numeric_options(option, value) -> None:
+    with pytest.raises((TypeError, ValueError), match=option):
+        MongoDBConnector(
+            "mongodb://local", database="app", client=object()
+        ).watch_collection("events", **{option: value})
 
 
 @pytest.mark.asyncio
@@ -109,6 +154,53 @@ async def test_change_tokens_persist_only_after_contiguous_ack() -> None:
 
 
 @pytest.mark.asyncio
+async def test_change_stream_state_save_failure_reopens_without_lost_token() -> None:
+    first_event = _event("64b64c1234567890abcdef12", "insert")
+    second_event = _event("64b64c1234567890abcdef13", "update")
+    first_stream = FakeChangeStream([first_event, second_event])
+    replacement = FakeChangeStream([])
+    collection = FakeWatchCollection([first_stream, replacement])
+    store = FailOnceStore()
+    source = MongoDBConnector(
+        "mongodb://local", database="app", client=FakeWatchClient(collection)
+    ).watch_collection("events", state=store)
+    first, second = await source.fetch(2)
+
+    await second.ack()
+    with pytest.raises(RuntimeError, match="state unavailable"):
+        await first.ack()
+
+    assert source._resume_token is None
+    assert store.saved == []
+
+    await first.retry()
+    await source.fetch(2)
+    assert len(collection.watch_calls) == 2
+    assert "resume_after" not in collection.watch_calls[1]
+
+
+@pytest.mark.asyncio
+async def test_change_stream_fail_can_be_reinvoked_after_state_save_failure() -> None:
+    event = _event("64b64c1234567890abcdef12", "insert")
+    store = FailOnceStore()
+    collection = FakeWatchCollection([FakeChangeStream([event])])
+    source = MongoDBConnector(
+        "mongodb://local", database="app", client=FakeWatchClient(collection)
+    ).watch_collection("events", state=store)
+    delivery = (await source.fetch(1))[0]
+
+    with pytest.raises(RuntimeError, match="state unavailable"):
+        await delivery.fail(RuntimeError("terminal handler failure"))
+
+    assert delivery._terminal is False
+    await delivery.fail(RuntimeError("terminal handler failure"))
+
+    assert delivery._terminal is True
+    assert decode_state(store.saved[-1][1]) == event["_id"]
+    assert source._tracker.can_fetch is True
+
+
+@pytest.mark.asyncio
 async def test_retry_closes_stream_and_waits_for_stale_delivery() -> None:
     first_stream = FakeChangeStream([_event("64b64c1234567890abcdef12", "insert"), _event("64b64c1234567890abcdef13", "update")])
     replacement = FakeChangeStream([])
@@ -129,8 +221,27 @@ async def test_retry_closes_stream_and_waits_for_stale_delivery() -> None:
     assert "resume_after" not in collection.watch_calls[1]
 
 
-from pymongo.errors import OperationFailure
-from onestep import ConnectorErrorKind, ConnectorOperationError
+@pytest.mark.asyncio
+@pytest.mark.parametrize("callback", ["retry", "release_unstarted"])
+@pytest.mark.parametrize("error_type", [RuntimeError, asyncio.CancelledError])
+async def test_invalidation_settles_delivery_when_stream_close_fails(
+    callback, error_type
+) -> None:
+    stream = FailingCloseStream(
+        [_event("64b64c1234567890abcdef12", "insert")], error_type
+    )
+    collection = FakeWatchCollection([stream])
+    source = MongoDBConnector(
+        "mongodb://local", database="app", client=FakeWatchClient(collection)
+    ).watch_collection("events", state=RecordingStore())
+    delivery = (await source.fetch(1))[0]
+
+    await getattr(delivery, callback)()
+
+    assert delivery._terminal is True
+    assert source._stream is None
+    assert source._tracker.can_fetch is True
+    assert stream.close_calls == 1
 
 
 @pytest.mark.asyncio

--- a/plugins/onestep-mongodb/tests/test_mongodb_polling.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_polling.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 
 import pytest
@@ -32,6 +33,94 @@ async def test_out_of_order_ack_does_not_cross_gap() -> None:
     assert saved == []
     await tracker.complete(first, advance=True)
     assert saved == ["two"]
+
+
+@pytest.mark.asyncio
+async def test_later_ack_then_earlier_retry_does_not_cross_generation_gap() -> None:
+    saved: list[object] = []
+    tracker = _ContiguousGenerationTracker(lambda token: _append(saved, token))
+    first = tracker.add("one")
+    second = tracker.add("two")
+
+    await tracker.complete(second, advance=True)
+    await tracker.invalidate(first.generation)
+    await tracker.complete(first, advance=False)
+
+    assert saved == []
+    assert tracker.can_fetch is True
+
+
+@pytest.mark.asyncio
+async def test_save_failure_keeps_contiguous_prefix_releasable() -> None:
+    save_calls = 0
+
+    async def save(token):
+        nonlocal save_calls
+        save_calls += 1
+        if save_calls == 1:
+            raise RuntimeError("state unavailable")
+
+    tracker = _ContiguousGenerationTracker(save)
+    first = tracker.add("one")
+    second = tracker.add("two")
+    await tracker.complete(second, advance=True)
+
+    with pytest.raises(RuntimeError, match="state unavailable"):
+        await tracker.complete(first, advance=True)
+
+    assert list(tracker._pending) == [first, second]
+    assert tracker._outstanding == {first.generation: 1}
+
+    await tracker.invalidate(first.generation)
+    await tracker.complete(first, advance=False)
+
+    assert list(tracker._pending) == []
+    assert tracker.can_fetch is True
+
+
+@pytest.mark.asyncio
+async def test_ack_can_be_reinvoked_after_transient_save_failure() -> None:
+    saved: list[object] = []
+    save_calls = 0
+
+    async def save(token):
+        nonlocal save_calls
+        save_calls += 1
+        if save_calls == 1:
+            raise RuntimeError("state unavailable")
+        saved.append(token)
+
+    tracker = _ContiguousGenerationTracker(save)
+    tracked = tracker.add("one")
+
+    with pytest.raises(RuntimeError, match="state unavailable"):
+        await tracker.complete(tracked, advance=True)
+
+    assert tracked.completed is False
+    await tracker.complete(tracked, advance=True)
+
+    assert saved == ["one"]
+    assert list(tracker._pending) == []
+
+
+@pytest.mark.asyncio
+async def test_save_cancellation_rolls_back_tracker_state() -> None:
+    async def save(token):
+        raise asyncio.CancelledError
+
+    tracker = _ContiguousGenerationTracker(save)
+    tracked = tracker.add("one")
+
+    with pytest.raises(asyncio.CancelledError):
+        await tracker.complete(tracked, advance=True)
+
+    assert tracked.completed is False
+    assert list(tracker._pending) == [tracked]
+    assert tracker._outstanding == {tracked.generation: 1}
+
+    await tracker.invalidate(tracked.generation)
+    await tracker.complete(tracked, advance=False)
+    assert tracker.can_fetch is True
 
 
 @pytest.mark.asyncio
@@ -72,6 +161,68 @@ def test_id_must_be_final_when_explicit() -> None:
         MongoDBConnector("mongodb://local", database="app", client=object()).poll_collection("events", cursor=("_id", "updated_at"))
 
 
+@pytest.mark.parametrize("batch_size", [0, -1, True, 1.5])
+def test_polling_rejects_invalid_batch_size(batch_size) -> None:
+    with pytest.raises((TypeError, ValueError), match="batch_size"):
+        MongoDBConnector(
+            "mongodb://local", database="app", client=object()
+        ).poll_collection("events", batch_size=batch_size)
+
+
+@pytest.mark.parametrize("poll_interval_s", [-0.1, True])
+def test_polling_rejects_invalid_poll_interval(poll_interval_s) -> None:
+    with pytest.raises((TypeError, ValueError), match="poll_interval_s"):
+        MongoDBConnector(
+            "mongodb://local", database="app", client=object()
+        ).poll_collection("events", poll_interval_s=poll_interval_s)
+
+
+def test_zero_poll_interval_is_accepted() -> None:
+    connector = MongoDBConnector("mongodb://local", database="app", client=object())
+
+    assert connector.poll_collection("events", poll_interval_s=0).poll_interval_s == 0
+    assert connector.watch_collection("events", poll_interval_s=0).poll_interval_s == 0
+
+
+@pytest.mark.parametrize(
+    ("projection", "cursor"),
+    [
+        ({"updated_at": 0}, ("updated_at", "_id")),
+        ({"value": 1}, ("updated_at", "_id")),
+        ({"_id": 1}, ("updated_at", "_id")),
+        ({"_id": 0}, ("updated_at", "_id")),
+        ({"updated_at": {"$literal": 1}}, ("updated_at", "_id")),
+        ({"_id": {"$literal": "fixed"}}, ("_id",)),
+    ],
+)
+def test_polling_projection_must_preserve_effective_cursor(
+    projection, cursor
+) -> None:
+    with pytest.raises(ValueError, match="projection.*cursor"):
+        MongoDBConnector(
+            "mongodb://local", database="app", client=object()
+        ).poll_collection("events", projection=projection, cursor=cursor)
+
+
+@pytest.mark.parametrize(
+    ("projection", "cursor"),
+    [
+        ({"value": 0}, ("updated_at", "_id")),
+        ({"updated_at": 1}, ("updated_at", "_id")),
+        ({"updated_at": True}, ("updated_at", "_id")),
+        ({"value": 1}, ("_id",)),
+    ],
+)
+def test_polling_projection_accepts_cursor_preserving_shapes(
+    projection, cursor
+) -> None:
+    source = MongoDBConnector(
+        "mongodb://local", database="app", client=object()
+    ).poll_collection("events", projection=projection, cursor=cursor)
+
+    assert source.projection == projection
+
+
 class RecordingStore:
     def __init__(self, loaded=None) -> None:
         self.loaded = loaded
@@ -83,6 +234,18 @@ class RecordingStore:
     async def save(self, key, value):
         self.saved.append((key, value))
         self.loaded = value
+
+
+class FailOnceStore(RecordingStore):
+    def __init__(self, loaded=None) -> None:
+        super().__init__(loaded)
+        self.save_calls = 0
+
+    async def save(self, key, value):
+        self.save_calls += 1
+        if self.save_calls == 1:
+            raise RuntimeError("state unavailable")
+        await super().save(key, value)
 
 
 class FakeCursor:
@@ -178,6 +341,75 @@ async def test_retry_waits_for_stale_generation_then_replays_committed_state() -
 
     assert store.saved == []
     assert collection.find_calls[-1][0] == {}
+
+
+@pytest.mark.asyncio
+async def test_later_ack_then_earlier_retry_replays_from_committed_state() -> None:
+    documents = [
+        {"_id": ObjectId("64b64c1234567890abcdef12"), "updated_at": 1},
+        {"_id": ObjectId("64b64c1234567890abcdef13"), "updated_at": 2},
+    ]
+    store = RecordingStore()
+    collection = FakeCollection(documents)
+    source = MongoDBConnector(
+        "mongodb://local", database="app", client=FakeClient(collection)
+    ).poll_collection("events", cursor=("updated_at", "_id"), state=store)
+    first, second = await source.fetch(2)
+
+    await second.ack()
+    await first.retry()
+    replayed = await source.fetch(2)
+
+    assert store.saved == []
+    assert collection.find_calls[-1][0] == {}
+    assert [item.payload["updated_at"] for item in replayed] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_polling_state_save_failure_does_not_advance_or_drop_prefix() -> None:
+    documents = [
+        {"_id": ObjectId("64b64c1234567890abcdef12"), "updated_at": 1},
+        {"_id": ObjectId("64b64c1234567890abcdef13"), "updated_at": 2},
+    ]
+    store = FailOnceStore()
+    collection = FakeCollection(documents)
+    source = MongoDBConnector(
+        "mongodb://local", database="app", client=FakeClient(collection)
+    ).poll_collection("events", cursor=("updated_at", "_id"), state=store)
+    first, second = await source.fetch(2)
+
+    await second.ack()
+    with pytest.raises(RuntimeError, match="state unavailable"):
+        await first.ack()
+
+    assert source._committed is None
+    assert store.saved == []
+
+    await first.retry()
+    replayed = await source.fetch(2)
+    assert collection.find_calls[-1][0] == {}
+    assert [item.payload["updated_at"] for item in replayed] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_polling_fail_remains_reinvocable_after_state_save_failure() -> None:
+    document = {"_id": ObjectId("64b64c1234567890abcdef12"), "updated_at": 1}
+    store = FailOnceStore()
+    source = MongoDBConnector(
+        "mongodb://local",
+        database="app",
+        client=FakeClient(FakeCollection([document])),
+    ).poll_collection("events", cursor=("updated_at", "_id"), state=store)
+    delivery = (await source.fetch(1))[0]
+
+    with pytest.raises(RuntimeError, match="state unavailable"):
+        await delivery.fail(RuntimeError("terminal handler failure"))
+
+    assert delivery._terminal is False
+    await delivery.fail(RuntimeError("terminal handler failure"))
+
+    assert delivery._terminal is True
+    assert decode_state(store.saved[-1][1]) == [1, document["_id"]]
 
 
 @pytest.mark.asyncio

--- a/plugins/onestep-mongodb/tests/test_mongodb_sink.py
+++ b/plugins/onestep-mongodb/tests/test_mongodb_sink.py
@@ -52,6 +52,14 @@ def _connector(collection):
     return MongoDBConnector("mongodb://local", database="app", client=FakeSinkClient(collection))
 
 
+@pytest.mark.parametrize("batch_size", [0, -1, True, 1.5])
+def test_sink_rejects_invalid_batch_size(batch_size) -> None:
+    with pytest.raises((TypeError, ValueError), match="batch_size"):
+        _connector(FakeSinkCollection()).collection_sink(
+            "events", batch_size=batch_size
+        )
+
+
 @pytest.mark.asyncio
 async def test_insert_mapping_and_chunked_sequence() -> None:
     collection = FakeSinkCollection()

--- a/uv.lock
+++ b/uv.lock
@@ -1479,7 +1479,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-elasticsearch"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "plugins/onestep-elasticsearch" }
 dependencies = [
     { name = "httpx" },
@@ -1557,7 +1557,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-mongodb"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "plugins/onestep-mongodb" }
 dependencies = [
     { name = "onestep" },


### PR DESCRIPTION
## Summary

**Elasticsearch/OpenSearch correctness**

- Stops internal replay of ambiguous request-level 502/503/504 responses when bulk documents have no stable IDs.
- Keeps bounded retry behavior for replay-safe `index` writes and explicit 429 rejections.
- Classifies missing, malformed, and contradictory bulk acknowledgements by replay safety so auto-ID outcomes are reported as `UNCERTAIN`.

**MongoDB cursor correctness**

- Validates direct Python numeric options during construction and rejects polling projections that omit or rewrite effective cursor fields.
- Persists cursor state before mutating in-memory state, with rollback on persistence failure or cancellation.
- Prevents later acknowledgements from advancing an invalidated generation and keeps delivery callbacks reinvocable after failed terminal work.
- Detaches failed change streams before best-effort close cleanup so retry and release callbacks cannot permanently block fetching.

**Documentation and release metadata**

- Defines the ordered framework evolution roadmap and the P0 implementation plan.
- Documents gateway retry semantics, MongoDB projection/state guarantees, and the YAML projection constraint.
- Bumps `onestep-elasticsearch` and `onestep-mongodb` to `0.1.2` and updates `uv.lock` and `CHANGELOG.md`.

## Test Coverage

P0 connector correctness paths: **30/30 covered (100%)**.

- Elasticsearch: request replay safety, retry exhaustion, non-replay-safe operations, partial commits, and malformed/missing acknowledgements.
- MongoDB: numeric and projection validation, ordered cursor commits, invalidation gaps, persistence exceptions/cancellation, and every delivery terminal callback.
- No E2E or eval coverage is required for these connector-internal contracts.

## Pre-Landing Review

No open findings. The review fixed all identified cancellation rollback, projection rewrite, stream cleanup, malformed acknowledgement, and documentation accuracy issues before push.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN. Changes are limited to Elasticsearch/MongoDB connector correctness, their tests, documentation, and plugin patch metadata. Reporter payloads, task lifecycle events, WebSocket behavior, runtime identity, remote controls, and control-plane code are unchanged.

## Plan Completion

`docs/superpowers/plans/2026-07-29-connector-correctness-patches.md`: **28/28 items complete**.

## Verification Results

- Core: `198 passed`
- ClickHouse: `47 passed, 1 deselected`
- Control plane plugin: `157 passed`
- Elasticsearch: `58 passed, 1 deselected`
- Feishu Bitable: `24 passed`
- MongoDB: `97 passed, 4 deselected`
- MySQL: `20 passed, 1 skipped`
- Postgres: `17 passed, 1 skipped`
- RabbitMQ: `7 passed, 1 skipped`
- Redis: `22 passed, 1 skipped`
- SQS: `18 passed, 1 skipped`
- Kafka on isolated Python 3.12: `21 passed, 1 deselected`
- Critical Ruff checks, `git diff --check`, and `uv lock --check`: passed
- Elasticsearch and MongoDB wheel/sdist builds: passed

## Documentation

- Plugin READMEs describe Elasticsearch gateway ambiguity and MongoDB projection/state guarantees.
- Root English and Chinese READMEs link the framework evolution roadmap.
- The YAML reference documents MongoDB cursor projection preservation.
- `CHANGELOG.md` describes the two `0.1.2` plugin releases without claiming full Python/YAML validation parity.

## Test plan

- [x] Run every core and plugin non-integration reliability suite.
- [x] Run Kafka tests in an isolated Python 3.12 environment.
- [x] Build both changed plugin distributions.
- [x] Validate critical Ruff rules, lockfile consistency, and patch whitespace.
