### PR TITLE
v1.7.3 feat: add official connector conformance kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@
 
 - Adds `elasticsearch`, `clickhouse`, and `mongodb` optional extras for the three independently published connector plugins.
 - Bundles the three plugins in the worker image and adds isolated reliability/live compatibility gates.
-- Does not change core runtime, delivery, retry, reporter, or control-plane behavior.
+- Adds a pytest-independent `onestep.testing` connector conformance toolkit without changing runtime, reporter, or control-plane behavior.
+
+## 1.7.3
+
+- Adds test-side connector capability profiles with explicit contract evidence and dependency validation.
+- Adds reusable claimed-source stop-control and acknowledged-sink ordering contract runners.
+
+## onestep-kafka 0.1.3
+
+- Declares the Kafka connector's source, checkpoint, claim-release, acknowledged-sink, and public-error conformance evidence.
+- Uses the shared runners to verify claim release under drain, pause, and shutdown and runtime acknowledgement ordering after producer acknowledgement.
 
 ## onestep-mongodb 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,13 @@
 ## onestep-postgres 0.1.3
 
 - Adopts the shared claimed-source runner for drain, pause, and shutdown release semantics.
-- Proves table-sink upsert replay safety with the shared replay contract.
+- Exercises repeated upserts through the shared replay runner against the SQLite unit-test fallback.
 - Replaces timing-based table queue tests with deterministic fetch/release event handshakes.
 
 ## onestep-mysql 0.3.3
 
 - Adopts the shared claimed-source runner for drain, pause, and shutdown release semantics.
-- Proves table-sink upsert replay safety with the shared replay contract.
+- Exercises repeated upserts through the shared replay runner against the SQLite unit-test fallback.
 - Replaces timing-based table queue tests with deterministic fetch/release event handshakes.
 
 ## onestep-kafka 0.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,20 @@
 ## 1.7.3
 
 - Adds test-side connector capability profiles with explicit contract evidence and dependency validation.
-- Adds reusable claimed-source stop-control and acknowledged-sink ordering contract runners.
+- Adds reusable claimed-source stop-control, acknowledged-sink ordering, and replay-safe sink contract runners.
+- Adds a repository gate covering the capability evidence of all ten official connector plugins.
+
+## onestep-postgres 0.1.3
+
+- Adopts the shared claimed-source runner for drain, pause, and shutdown release semantics.
+- Proves table-sink upsert replay safety with the shared replay contract.
+- Replaces timing-based table queue tests with deterministic fetch/release event handshakes.
+
+## onestep-mysql 0.3.3
+
+- Adopts the shared claimed-source runner for drain, pause, and shutdown release semantics.
+- Proves table-sink upsert replay safety with the shared replay contract.
+- Replaces timing-based table queue tests with deterministic fetch/release event handshakes.
 
 ## onestep-kafka 0.1.3
 

--- a/docs/connector-conformance.md
+++ b/docs/connector-conformance.md
@@ -56,7 +56,26 @@ fetch returns a claimed delivery        backend acknowledgement returns
 runtime calls release_unstarted         runtime calls Delivery.ack
 ```
 
+`run_replay_safe_sink_contract` exercises the other shared sink invariant by sending the same logical envelope twice and requiring the backend probe to observe one record.
+
 Connector-specific tests still own backend setup and backend assertions. The toolkit owns only the shared `OneStepApp` orchestration, so connector behavior remains explicit rather than hidden behind a generic fake backend.
+
+## Official Plugin Matrix
+
+The repository-level conformance manifest covers every official connector plugin. Each declaration names concrete non-integration test evidence, and the core contract suite rejects missing plugins, missing files, misspelled test names, and capability dependency gaps.
+
+| Connector | Source | Checkpoint | Claim release | Acknowledged sink | Chunked | Replay-safe mode | Public errors |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| ClickHouse |  |  |  | yes | yes |  | yes |
+| Elasticsearch / OpenSearch |  |  |  | yes | yes | yes | yes |
+| Feishu Bitable | yes | yes |  | yes |  | yes | yes |
+| Kafka | yes | yes | yes | yes |  |  | yes |
+| MongoDB | yes | yes | yes | yes | yes | yes | yes |
+| MySQL | yes | yes | yes | yes |  | yes | yes |
+| PostgreSQL | yes | yes | yes | yes |  | yes | yes |
+| RabbitMQ | yes | yes |  | yes |  |  | yes |
+| Redis Streams | yes | yes |  | yes |  |  | yes |
+| SQS | yes | yes | yes | yes |  |  | yes |
 
 ## Scope
 

--- a/docs/connector-conformance.md
+++ b/docs/connector-conformance.md
@@ -1,0 +1,63 @@
+# Connector Conformance
+
+`onestep.testing` provides a small, pytest-independent toolkit for proving connector delivery semantics against the real runtime.
+
+Capability profiles belong in connector tests. They are not resource catalog fields, reporter payloads, or runtime feature negotiation.
+
+## Capability Profiles
+
+| Capability | Contract |
+| --- | --- |
+| `basic_source` | Fetch returns valid deliveries and respects the source lifecycle. |
+| `checkpoint_source` | Progress advances from delivery completion, never merely from fetch. |
+| `claimed_source` | Intake stop controls release work fetched but not started. |
+| `acknowledged_sink` | `send()` returns only after the backend acknowledges the write. |
+| `chunked_sink` | A logical batch is split into bounded writes and every chunk is awaited. |
+| `replay_safe_sink` | The documented stable-key or upsert mode tolerates replay without creating a second logical record. |
+| `public_errors` | Backend failures use public connector errors without exposing configured secrets. |
+
+Profiles map each declared capability to the test node IDs that prove it:
+
+```python
+from onestep.testing import ConnectorCapability, ConnectorConformanceProfile
+
+
+PROFILE = ConnectorConformanceProfile(
+    name="example",
+    contracts={
+        ConnectorCapability.BASIC_SOURCE: ("test_fetches_delivery",),
+        ConnectorCapability.CLAIMED_SOURCE: ("test_stop_controls_release_claim",),
+    },
+)
+```
+
+The profile validates capability dependencies. For example, `claimed_source` requires `basic_source`, while `chunked_sink` and `replay_safe_sink` require `acknowledged_sink`.
+
+## Data Flow
+
+```text
+source backend -> fetch -> Delivery -> handler -> sink.send -> backend ack -> Delivery.ack
+                         |                         |
+                         |                         +-- send error: retry/fail policy
+                         +-- intake stops before handler: release_unstarted
+```
+
+The reusable runners exercise the two cross-runtime ordering boundaries:
+
+```text
+claimed source                          acknowledged sink
+
+fetch starts and blocks                 sink.send starts and blocks
+        |                                       |
+drain / pause / shutdown                Delivery.ack must still be false
+        |                                       |
+fetch returns a claimed delivery        backend acknowledgement returns
+        |                                       |
+runtime calls release_unstarted         runtime calls Delivery.ack
+```
+
+Connector-specific tests still own backend setup and backend assertions. The toolkit owns only the shared `OneStepApp` orchestration, so connector behavior remains explicit rather than hidden behind a generic fake backend.
+
+## Scope
+
+The toolkit does not add runtime capability discovery, catalog fields, reporter fields, YAML syntax, or control-plane protocol changes. It also does not claim exactly-once delivery: onestep remains at-least-once, and replay safety is an explicit connector mode backed by a stable key or upsert contract.

--- a/docs/connector-conformance.md
+++ b/docs/connector-conformance.md
@@ -62,20 +62,20 @@ Connector-specific tests still own backend setup and backend assertions. The too
 
 ## Official Plugin Matrix
 
-The repository-level conformance manifest covers every official connector plugin. Each declaration names concrete non-integration test evidence, and the core contract suite rejects missing plugins, missing files, misspelled test names, and capability dependency gaps.
+The repository-level conformance manifest covers every plugin that registers an `onestep.resources` entry point. Each declaration names concrete non-integration test evidence, and the core contract suite rejects missing or duplicate profiles, missing files, inexact test node IDs, skipped evidence, and capability dependency gaps.
 
 | Connector | Source | Checkpoint | Claim release | Acknowledged sink | Chunked | Replay-safe mode | Public errors |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | ClickHouse |  |  |  | yes | yes |  | yes |
-| Elasticsearch / OpenSearch |  |  |  | yes | yes | yes | yes |
+| Elasticsearch / OpenSearch |  |  |  | yes | yes |  | yes |
 | Feishu Bitable | yes | yes |  | yes |  | yes | yes |
 | Kafka | yes | yes | yes | yes |  |  | yes |
-| MongoDB | yes | yes | yes | yes | yes | yes | yes |
-| MySQL | yes | yes | yes | yes |  | yes | yes |
-| PostgreSQL | yes | yes | yes | yes |  | yes | yes |
+| MongoDB | yes | yes | yes | yes | yes |  | yes |
+| MySQL | yes | yes | yes | yes |  |  | yes |
+| PostgreSQL | yes | yes | yes | yes |  |  | yes |
 | RabbitMQ | yes | yes |  | yes |  |  | yes |
 | Redis Streams | yes | yes |  | yes |  |  | yes |
-| SQS | yes | yes | yes | yes |  |  | yes |
+| SQS | yes | yes |  | yes |  |  | yes |
 
 ## Scope
 

--- a/plugins/onestep-kafka/pyproject.toml
+++ b/plugins/onestep-kafka/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "onestep-kafka"
-version = "0.1.2"
+version = "0.1.3"
 description = "Kafka connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 dependencies = [
-    "onestep>=1.7.1",
+    "onestep>=1.7.3",
     "aiokafka>=0.14.0",
 ]
 

--- a/plugins/onestep-kafka/tests/test_kafka_runtime_contract.py
+++ b/plugins/onestep-kafka/tests/test_kafka_runtime_contract.py
@@ -8,8 +8,6 @@ import pytest
 from onestep.testing import (
     AcknowledgedSinkHarness,
     ClaimedSourceHarness,
-    ConnectorCapability,
-    ConnectorConformanceProfile,
     StopControl,
     run_acknowledged_sink_contract,
     run_claimed_source_stop_contract,
@@ -19,42 +17,10 @@ from onestep_kafka import KafkaConnector
 from test_kafka_connector import FakeDriver, FakeProducer, FakeRecord, FakeTopicPartition
 
 
-KAFKA_CONFORMANCE_PROFILE = ConnectorConformanceProfile(
-    name="kafka",
-    contracts={
-        ConnectorCapability.BASIC_SOURCE: (
-            "test_kafka_topic_fetch_decodes_envelopes_and_injects_metadata",
-        ),
-        ConnectorCapability.CHECKPOINT_SOURCE: (
-            "test_ack_commits_only_after_contiguous_offsets_complete",
-        ),
-        ConnectorCapability.CLAIMED_SOURCE: (
-            "test_stop_controls_release_fetched_unstarted_kafka_delivery",
-        ),
-        ConnectorCapability.ACKNOWLEDGED_SINK: (
-            "test_runtime_ack_follows_kafka_producer_acknowledgement",
-        ),
-        ConnectorCapability.PUBLIC_ERRORS: (
-            "test_kafka_topic_redacts_consumer_and_producer_passwords",
-        ),
-    },
-)
-
-
 def test_kafka_topic_fetch_is_not_cancel_safe() -> None:
     topic = KafkaConnector("localhost:9092", driver=FakeDriver()).topic("orders", group_id="workers")
 
     assert topic.fetch_is_cancel_safe is False
-
-
-def test_kafka_conformance_profile() -> None:
-    assert KAFKA_CONFORMANCE_PROFILE.capabilities == {
-        ConnectorCapability.BASIC_SOURCE,
-        ConnectorCapability.CHECKPOINT_SOURCE,
-        ConnectorCapability.CLAIMED_SOURCE,
-        ConnectorCapability.ACKNOWLEDGED_SINK,
-        ConnectorCapability.PUBLIC_ERRORS,
-    }
 
 
 @pytest.mark.parametrize("control", list(StopControl))

--- a/plugins/onestep-kafka/tests/test_kafka_runtime_contract.py
+++ b/plugins/onestep-kafka/tests/test_kafka_runtime_contract.py
@@ -1,11 +1,44 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
-from onestep import OneStepApp
+import pytest
+
+from onestep.testing import (
+    AcknowledgedSinkHarness,
+    ClaimedSourceHarness,
+    ConnectorCapability,
+    ConnectorConformanceProfile,
+    StopControl,
+    run_acknowledged_sink_contract,
+    run_claimed_source_stop_contract,
+)
 from onestep_kafka import KafkaConnector
 
-from test_kafka_connector import FakeDriver, FakeRecord, FakeTopicPartition
+from test_kafka_connector import FakeDriver, FakeProducer, FakeRecord, FakeTopicPartition
+
+
+KAFKA_CONFORMANCE_PROFILE = ConnectorConformanceProfile(
+    name="kafka",
+    contracts={
+        ConnectorCapability.BASIC_SOURCE: (
+            "test_kafka_topic_fetch_decodes_envelopes_and_injects_metadata",
+        ),
+        ConnectorCapability.CHECKPOINT_SOURCE: (
+            "test_ack_commits_only_after_contiguous_offsets_complete",
+        ),
+        ConnectorCapability.CLAIMED_SOURCE: (
+            "test_stop_controls_release_fetched_unstarted_kafka_delivery",
+        ),
+        ConnectorCapability.ACKNOWLEDGED_SINK: (
+            "test_runtime_ack_follows_kafka_producer_acknowledgement",
+        ),
+        ConnectorCapability.PUBLIC_ERRORS: (
+            "test_kafka_topic_redacts_consumer_and_producer_passwords",
+        ),
+    },
+)
 
 
 def test_kafka_topic_fetch_is_not_cancel_safe() -> None:
@@ -14,7 +47,18 @@ def test_kafka_topic_fetch_is_not_cancel_safe() -> None:
     assert topic.fetch_is_cancel_safe is False
 
 
-def test_shutdown_releases_fetched_unstarted_kafka_delivery() -> None:
+def test_kafka_conformance_profile() -> None:
+    assert KAFKA_CONFORMANCE_PROFILE.capabilities == {
+        ConnectorCapability.BASIC_SOURCE,
+        ConnectorCapability.CHECKPOINT_SOURCE,
+        ConnectorCapability.CLAIMED_SOURCE,
+        ConnectorCapability.ACKNOWLEDGED_SINK,
+        ConnectorCapability.PUBLIC_ERRORS,
+    }
+
+
+@pytest.mark.parametrize("control", list(StopControl))
+def test_stop_controls_release_fetched_unstarted_kafka_delivery(control: StopControl) -> None:
     async def scenario() -> None:
         driver = FakeDriver()
         topic = KafkaConnector("localhost:9092", driver=driver).topic(
@@ -27,25 +71,65 @@ def test_shutdown_releases_fetched_unstarted_kafka_delivery() -> None:
         consumer.records[tp] = [FakeRecord("orders", 0, 10, b'{"id": 10}')]
         consumer.block_next_getmany()
 
-        app = OneStepApp("kafka-shutdown", shutdown_timeout_s=1.0)
-        handled: list[dict[str, int]] = []
-
-        @app.task(source=topic, concurrency=1)
-        async def consume(ctx, item):
-            handled.append(item)
-
-        serve_task = asyncio.create_task(app.serve())
         assert consumer.getmany_started is not None
         assert consumer.release_getmany is not None
-        await asyncio.wait_for(consumer.getmany_started.wait(), timeout=1.0)
-        app.request_shutdown()
-        await asyncio.sleep(0.02)
-        assert serve_task.done() is False
-        consumer.release_getmany.set()
-        await asyncio.wait_for(serve_task, timeout=2.0)
 
-        assert handled == []
-        assert consumer.commits == []
-        assert consumer.seeks == [(tp, 10)]
+        def assert_released() -> None:
+            assert consumer.commits == []
+            assert consumer.seeks == [(tp, 10)]
+
+        await run_claimed_source_stop_contract(
+            ClaimedSourceHarness(
+                source=topic,
+                wait_for_fetch_started=consumer.getmany_started.wait,
+                release_fetch=consumer.release_getmany.set,
+                assert_released=assert_released,
+            ),
+            control,
+        )
 
     asyncio.run(scenario())
+
+
+def test_runtime_ack_follows_kafka_producer_acknowledgement() -> None:
+    async def scenario() -> None:
+        producer = _BlockingProducer()
+        driver = _BlockingProducerDriver(producer)
+        topic = KafkaConnector("localhost:9092", driver=driver).topic("orders.out")
+
+        await run_acknowledged_sink_contract(
+            AcknowledgedSinkHarness(
+                sink=topic,
+                wait_for_send_started=producer.send_started.wait,
+                release_send=producer.release_send.set,
+            ),
+            body={"id": 1},
+        )
+
+        assert len(producer.sent) == 1
+        assert producer.sent[0]["topic"] == "orders.out"
+
+    asyncio.run(scenario())
+
+
+class _BlockingProducer(FakeProducer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.send_started = asyncio.Event()
+        self.release_send = asyncio.Event()
+
+    async def send_and_wait(self, topic: str, **kwargs: Any) -> None:
+        self.send_started.set()
+        await self.release_send.wait()
+        await super().send_and_wait(topic, **kwargs)
+
+
+class _BlockingProducerDriver(FakeDriver):
+    def __init__(self, producer: _BlockingProducer) -> None:
+        super().__init__()
+        self.producer = producer
+
+    def AIOKafkaProducer(self, **kwargs: Any) -> FakeProducer:
+        self.producer.kwargs = kwargs
+        self.producers.append(self.producer)
+        return self.producer

--- a/plugins/onestep-mysql/pyproject.toml
+++ b/plugins/onestep-mysql/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "onestep-mysql"
-version = "0.3.2"
+version = "0.3.3"
 description = "MySQL connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }
 dependencies = [
-    "onestep>=1.7.1",
+    "onestep>=1.7.3",
     "SQLAlchemy>=2.0.0",
     "PyMySQL>=1.1.0",
     "mysql-replication>=1.0.15",

--- a/plugins/onestep-mysql/tests/test_mysql_runtime_contract.py
+++ b/plugins/onestep-mysql/tests/test_mysql_runtime_contract.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import asyncio
-import time
+import threading
 from pathlib import Path
 
+import pytest
 import sqlalchemy as sa
 
-from onestep import OneStepApp
+from onestep.testing import (
+    ClaimedSourceHarness,
+    StopControl,
+    run_claimed_source_stop_contract,
+)
 from onestep_mysql import MySQLConnector
 
 
@@ -36,11 +41,14 @@ def _load_order_rows(db_url: str, orders: sa.Table) -> list[tuple[int, int]]:
     return list(rows)
 
 
-def test_table_queue_drain_releases_claimed_rows_when_fetch_is_stopped_contract(tmp_path: Path) -> None:
+@pytest.mark.parametrize("control", list(StopControl))
+def test_table_queue_stop_controls_release_claimed_rows(
+    tmp_path: Path,
+    control: StopControl,
+) -> None:
     db_url, orders = _build_table_queue_db(tmp_path)
 
-    async def scenario() -> list[int]:
-        app = OneStepApp("table-queue-drain-contract", shutdown_timeout_s=1.0)
+    async def scenario() -> None:
         db = MySQLConnector(db_url)
         source = db.table_queue(
             table="orders",
@@ -52,121 +60,43 @@ def test_table_queue_drain_releases_claimed_rows_when_fetch_is_stopped_contract(
             batch_size=1,
             poll_interval_s=0.01,
         )
+        fetch_started = threading.Event()
+        release_fetch = threading.Event()
         original_fetch = source._fetch_sync
 
-        def slow_fetch(limit: int):
+        def blocking_fetch(limit: int):
             rows = original_fetch(limit)
-            time.sleep(0.2)
+            fetch_started.set()
+            if not release_fetch.wait(timeout=1.0):
+                raise TimeoutError("test did not release the MySQL table queue fetch")
             return rows
 
-        source._fetch_sync = slow_fetch
-        seen: list[int] = []
+        source._fetch_sync = blocking_fetch
 
-        @app.task(source=source, concurrency=1)
-        async def consume(ctx, row):
-            seen.append(row["id"])
+        def assert_released() -> None:
+            assert _load_order_rows(db_url, orders) == [(1, 0)]
 
-        async def controller() -> None:
-            await asyncio.sleep(0.05)
-            app.request_drain()
-            await asyncio.wait_for(app.wait_for_drain(), timeout=1.0)
-            app.request_shutdown()
+        try:
+            await run_claimed_source_stop_contract(
+                ClaimedSourceHarness(
+                    source=source,
+                    wait_for_fetch_started=lambda: _wait_for_thread_event(fetch_started),
+                    release_fetch=release_fetch.set,
+                    assert_released=assert_released,
+                ),
+                control,
+            )
+        finally:
+            release_fetch.set()
+            await db.close()
 
-        await asyncio.wait_for(asyncio.gather(app.serve(), controller()), timeout=2.0)
-        await db.close()
-        return seen
-
-    seen = asyncio.run(scenario())
-
-    assert seen == []
-    assert _load_order_rows(db_url, orders) == [(1, 0)]
-
-
-def test_table_queue_pause_releases_claimed_rows_when_fetch_is_stopped_contract(tmp_path: Path) -> None:
-    db_url, orders = _build_table_queue_db(tmp_path)
-
-    async def scenario() -> list[int]:
-        app = OneStepApp("table-queue-pause-contract", shutdown_timeout_s=1.0)
-        db = MySQLConnector(db_url)
-        source = db.table_queue(
-            table="orders",
-            key="id",
-            where="status = 0",
-            claim={"status": 9},
-            ack={"status": 1},
-            nack={"status": 0},
-            batch_size=1,
-            poll_interval_s=0.01,
-        )
-        original_fetch = source._fetch_sync
-
-        def slow_fetch(limit: int):
-            rows = original_fetch(limit)
-            time.sleep(0.2)
-            return rows
-
-        source._fetch_sync = slow_fetch
-        seen: list[int] = []
-
-        @app.task(source=source, concurrency=1)
-        async def consume(ctx, row):
-            seen.append(row["id"])
-
-        async def controller() -> None:
-            await asyncio.sleep(0.05)
-            app.request_task_pause("consume")
-            await asyncio.wait_for(app.wait_for_task_pause("consume"), timeout=1.0)
-            app.request_shutdown()
-
-        await asyncio.wait_for(asyncio.gather(app.serve(), controller()), timeout=2.0)
-        await db.close()
-        return seen
-
-    seen = asyncio.run(scenario())
-
-    assert seen == []
-    assert _load_order_rows(db_url, orders) == [(1, 0)]
+    asyncio.run(scenario())
 
 
-def test_table_queue_shutdown_releases_claimed_rows_when_fetch_is_stopped_contract(tmp_path: Path) -> None:
-    db_url, orders = _build_table_queue_db(tmp_path)
-
-    async def scenario() -> list[int]:
-        app = OneStepApp("table-queue-shutdown-contract", shutdown_timeout_s=1.0)
-        db = MySQLConnector(db_url)
-        source = db.table_queue(
-            table="orders",
-            key="id",
-            where="status = 0",
-            claim={"status": 9},
-            ack={"status": 1},
-            nack={"status": 0},
-            batch_size=1,
-            poll_interval_s=0.01,
-        )
-        original_fetch = source._fetch_sync
-
-        def slow_fetch(limit: int):
-            rows = original_fetch(limit)
-            time.sleep(0.2)
-            return rows
-
-        source._fetch_sync = slow_fetch
-        seen: list[int] = []
-
-        @app.task(source=source, concurrency=1)
-        async def consume(ctx, row):
-            seen.append(row["id"])
-
-        async def controller() -> None:
-            await asyncio.sleep(0.05)
-            app.request_shutdown()
-
-        await asyncio.wait_for(asyncio.gather(app.serve(), controller()), timeout=2.0)
-        await db.close()
-        return seen
-
-    seen = asyncio.run(scenario())
-
-    assert seen == []
-    assert _load_order_rows(db_url, orders) == [(1, 0)]
+async def _wait_for_thread_event(event: threading.Event) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 1.0
+    while not event.is_set():
+        if loop.time() >= deadline:
+            raise TimeoutError("table queue fetch did not start")
+        await asyncio.sleep(0.001)

--- a/plugins/onestep-mysql/tests/test_mysql_table_queue.py
+++ b/plugins/onestep-mysql/tests/test_mysql_table_queue.py
@@ -83,7 +83,7 @@ def test_mysql_table_queue_round_trip(tmp_path: Path) -> None:
     assert processed_rows == [(1, "A", "done"), (2, "B", "done")]
 
 
-def test_mysql_table_sink_upsert_is_replay_safe(tmp_path: Path) -> None:
+def test_mysql_table_sink_sqlite_fallback_handles_replayed_upsert(tmp_path: Path) -> None:
     db_url = f"sqlite:///{tmp_path / 'sink.db'}"
     engine = sa.create_engine(db_url, future=True)
     metadata = sa.MetaData()

--- a/plugins/onestep-mysql/tests/test_mysql_table_queue.py
+++ b/plugins/onestep-mysql/tests/test_mysql_table_queue.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import sqlalchemy as sa
 
 from onestep import OneStepApp
+from onestep.testing import ReplaySafeSinkHarness, run_replay_safe_sink_contract
 from onestep_mysql import MySQLConnector
 
 
@@ -80,3 +81,38 @@ def test_mysql_table_queue_round_trip(tmp_path: Path) -> None:
     assert sorted(seen_scores) == [(1, 10), (2, 20)]
     assert order_rows == [(1, 1, 10), (2, 1, 20)]
     assert processed_rows == [(1, "A", "done"), (2, "B", "done")]
+
+
+def test_mysql_table_sink_upsert_is_replay_safe(tmp_path: Path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'sink.db'}"
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    processed = sa.Table(
+        "processed_orders",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("payload", sa.String, nullable=False),
+    )
+    metadata.create_all(engine)
+    engine.dispose()
+
+    async def scenario() -> None:
+        db = MySQLConnector(db_url)
+        sink = db.table_sink(table="processed_orders", mode="upsert", keys=("id",))
+
+        def assert_single_record() -> None:
+            verify_engine = sa.create_engine(db_url, future=True)
+            with verify_engine.begin() as conn:
+                rows = conn.execute(sa.select(processed.c.id, processed.c.payload)).all()
+            verify_engine.dispose()
+            assert rows == [(1, "A")]
+
+        try:
+            await run_replay_safe_sink_contract(
+                ReplaySafeSinkHarness(sink=sink, assert_single_record=assert_single_record),
+                body={"id": 1, "payload": "A"},
+            )
+        finally:
+            await db.close()
+
+    asyncio.run(scenario())

--- a/plugins/onestep-postgres/pyproject.toml
+++ b/plugins/onestep-postgres/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "onestep-postgres"
-version = "0.1.2"
+version = "0.1.3"
 description = "PostgreSQL connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }
 dependencies = [
-    "onestep>=1.7.1",
+    "onestep>=1.7.3",
     "SQLAlchemy>=2.0.0",
     "psycopg[binary]>=3.2.0",
 ]

--- a/plugins/onestep-postgres/tests/test_postgres_runtime_contract.py
+++ b/plugins/onestep-postgres/tests/test_postgres_runtime_contract.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import asyncio
-import time
+import threading
 from pathlib import Path
 
+import pytest
 import sqlalchemy as sa
 
-from onestep import OneStepApp
+from onestep.testing import (
+    ClaimedSourceHarness,
+    StopControl,
+    run_claimed_source_stop_contract,
+)
 from onestep_postgres import PostgresConnector
 
 
@@ -36,123 +41,62 @@ def _load_order_rows(db_url: str, orders: sa.Table) -> list[tuple[int, int]]:
     return list(rows)
 
 
-def test_table_queue_drain_releases_claimed_rows_when_fetch_is_stopped_contract(tmp_path: Path) -> None:
+@pytest.mark.parametrize("control", list(StopControl))
+def test_table_queue_stop_controls_release_claimed_rows(
+    tmp_path: Path,
+    control: StopControl,
+) -> None:
     db_url, orders = _build_table_queue_db(tmp_path)
 
-    async def scenario() -> list[int]:
-        app = OneStepApp("table-queue-drain-contract", shutdown_timeout_s=1.0)
+    async def scenario() -> None:
         db = PostgresConnector(db_url)
-        source = _source(db)
+        source = db.table_queue(
+            table="orders",
+            key="id",
+            where="status = 0",
+            claim={"status": 9},
+            ack={"status": 1},
+            nack={"status": 0},
+            batch_size=1,
+            poll_interval_s=0.01,
+        )
+        fetch_started = threading.Event()
+        release_fetch = threading.Event()
         original_fetch = source._fetch_sync
 
-        def slow_fetch(limit: int):
+        def blocking_fetch(limit: int):
             rows = original_fetch(limit)
-            time.sleep(0.2)
+            fetch_started.set()
+            if not release_fetch.wait(timeout=1.0):
+                raise TimeoutError("test did not release the PostgreSQL table queue fetch")
             return rows
 
-        source._fetch_sync = slow_fetch
-        seen: list[int] = []
+        source._fetch_sync = blocking_fetch
 
-        @app.task(source=source, concurrency=1)
-        async def consume(ctx, row):
-            seen.append(row["id"])
+        def assert_released() -> None:
+            assert _load_order_rows(db_url, orders) == [(1, 0)]
 
-        async def controller() -> None:
-            await asyncio.sleep(0.05)
-            app.request_drain()
-            await asyncio.wait_for(app.wait_for_drain(), timeout=1.0)
-            app.request_shutdown()
+        try:
+            await run_claimed_source_stop_contract(
+                ClaimedSourceHarness(
+                    source=source,
+                    wait_for_fetch_started=lambda: _wait_for_thread_event(fetch_started),
+                    release_fetch=release_fetch.set,
+                    assert_released=assert_released,
+                ),
+                control,
+            )
+        finally:
+            release_fetch.set()
+            await db.close()
 
-        await asyncio.wait_for(asyncio.gather(app.serve(), controller()), timeout=2.0)
-        await db.close()
-        return seen
-
-    seen = asyncio.run(scenario())
-
-    assert seen == []
-    assert _load_order_rows(db_url, orders) == [(1, 0)]
-
-
-def test_table_queue_pause_releases_claimed_rows_when_fetch_is_stopped_contract(tmp_path: Path) -> None:
-    db_url, orders = _build_table_queue_db(tmp_path)
-
-    async def scenario() -> list[int]:
-        app = OneStepApp("table-queue-pause-contract", shutdown_timeout_s=1.0)
-        db = PostgresConnector(db_url)
-        source = _source(db)
-        original_fetch = source._fetch_sync
-
-        def slow_fetch(limit: int):
-            rows = original_fetch(limit)
-            time.sleep(0.2)
-            return rows
-
-        source._fetch_sync = slow_fetch
-        seen: list[int] = []
-
-        @app.task(source=source, concurrency=1)
-        async def consume(ctx, row):
-            seen.append(row["id"])
-
-        async def controller() -> None:
-            await asyncio.sleep(0.05)
-            app.request_task_pause("consume")
-            await asyncio.wait_for(app.wait_for_task_pause("consume"), timeout=1.0)
-            app.request_shutdown()
-
-        await asyncio.wait_for(asyncio.gather(app.serve(), controller()), timeout=2.0)
-        await db.close()
-        return seen
-
-    seen = asyncio.run(scenario())
-
-    assert seen == []
-    assert _load_order_rows(db_url, orders) == [(1, 0)]
+    asyncio.run(scenario())
 
 
-def test_table_queue_shutdown_releases_claimed_rows_when_fetch_is_stopped_contract(tmp_path: Path) -> None:
-    db_url, orders = _build_table_queue_db(tmp_path)
-
-    async def scenario() -> list[int]:
-        app = OneStepApp("table-queue-shutdown-contract", shutdown_timeout_s=1.0)
-        db = PostgresConnector(db_url)
-        source = _source(db)
-        original_fetch = source._fetch_sync
-
-        def slow_fetch(limit: int):
-            rows = original_fetch(limit)
-            time.sleep(0.2)
-            return rows
-
-        source._fetch_sync = slow_fetch
-        seen: list[int] = []
-
-        @app.task(source=source, concurrency=1)
-        async def consume(ctx, row):
-            seen.append(row["id"])
-
-        async def controller() -> None:
-            await asyncio.sleep(0.05)
-            app.request_shutdown()
-
-        await asyncio.wait_for(asyncio.gather(app.serve(), controller()), timeout=2.0)
-        await db.close()
-        return seen
-
-    seen = asyncio.run(scenario())
-
-    assert seen == []
-    assert _load_order_rows(db_url, orders) == [(1, 0)]
-
-
-def _source(db: PostgresConnector):
-    return db.table_queue(
-        table="orders",
-        key="id",
-        where="status = 0",
-        claim={"status": 9},
-        ack={"status": 1},
-        nack={"status": 0},
-        batch_size=1,
-        poll_interval_s=0.01,
-    )
+async def _wait_for_thread_event(event: threading.Event) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 1.0
+    while not event.is_set():
+        if loop.time() >= deadline:
+            raise TimeoutError("table queue fetch did not start")
+        await asyncio.sleep(0.001)

--- a/plugins/onestep-postgres/tests/test_postgres_table_queue.py
+++ b/plugins/onestep-postgres/tests/test_postgres_table_queue.py
@@ -83,7 +83,7 @@ def test_postgres_table_queue_round_trip(tmp_path: Path) -> None:
     assert processed_rows == [(1, "A", "done"), (2, "B", "done")]
 
 
-def test_postgres_table_sink_upsert_is_replay_safe(tmp_path: Path) -> None:
+def test_postgres_table_sink_sqlite_fallback_handles_replayed_upsert(tmp_path: Path) -> None:
     db_url = f"sqlite:///{tmp_path / 'sink.db'}"
     engine = sa.create_engine(db_url, future=True)
     metadata = sa.MetaData()

--- a/plugins/onestep-postgres/tests/test_postgres_table_queue.py
+++ b/plugins/onestep-postgres/tests/test_postgres_table_queue.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import sqlalchemy as sa
 
 from onestep import OneStepApp
+from onestep.testing import ReplaySafeSinkHarness, run_replay_safe_sink_contract
 from onestep_postgres import PostgresConnector
 
 
@@ -80,3 +81,38 @@ def test_postgres_table_queue_round_trip(tmp_path: Path) -> None:
     assert sorted(seen_scores) == [(1, 10), (2, 20)]
     assert order_rows == [(1, 1, 10), (2, 1, 20)]
     assert processed_rows == [(1, "A", "done"), (2, "B", "done")]
+
+
+def test_postgres_table_sink_upsert_is_replay_safe(tmp_path: Path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'sink.db'}"
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    processed = sa.Table(
+        "processed_orders",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("payload", sa.String, nullable=False),
+    )
+    metadata.create_all(engine)
+    engine.dispose()
+
+    async def scenario() -> None:
+        db = PostgresConnector(db_url)
+        sink = db.table_sink(table="processed_orders", mode="upsert", keys=("id",))
+
+        def assert_single_record() -> None:
+            verify_engine = sa.create_engine(db_url, future=True)
+            with verify_engine.begin() as conn:
+                rows = conn.execute(sa.select(processed.c.id, processed.c.payload)).all()
+            verify_engine.dispose()
+            assert rows == [(1, "A")]
+
+        try:
+            await run_replay_safe_sink_contract(
+                ReplaySafeSinkHarness(sink=sink, assert_single_record=assert_single_record),
+                body={"id": 1, "payload": "A"},
+            )
+        finally:
+            await db.close()
+
+    asyncio.run(scenario())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep"
-version = "1.7.2"
+version = "1.7.3"
 description = "Async task runtime for queue, polling, schedule, and webhook workloads."
 authors = [
     { name = "miclon", email = "jcnd@163.com" }
@@ -46,7 +46,7 @@ sqs = [
     "onestep-sqs>=0.2.2",
 ]
 kafka = [
-    "onestep-kafka>=0.1.1; python_version >= '3.10'",
+    "onestep-kafka>=0.1.3; python_version >= '3.10'",
 ]
 elasticsearch = [
     "onestep-elasticsearch>=0.1.0",
@@ -71,7 +71,7 @@ integration = [
     "onestep-mysql>=0.3.1",
     "onestep-postgres>=0.1.1",
     "onestep-sqs>=0.2.2",
-    "onestep-kafka>=0.1.1; python_version >= '3.10'",
+    "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
     "onestep-clickhouse>=0.1.0",
     "onestep-mongodb>=0.1.0",
@@ -84,7 +84,7 @@ all = [
     "onestep-mysql>=0.3.1",
     "onestep-postgres>=0.1.1",
     "onestep-sqs>=0.2.2",
-    "onestep-kafka>=0.1.1; python_version >= '3.10'",
+    "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
     "onestep-clickhouse>=0.1.0",
     "onestep-mongodb>=0.1.0",
@@ -99,7 +99,7 @@ dev = [
     "onestep-mysql>=0.3.1",
     "onestep-postgres>=0.1.1",
     "onestep-sqs>=0.2.2",
-    "onestep-kafka>=0.1.1; python_version >= '3.10'",
+    "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
     "onestep-clickhouse>=0.1.0",
     "onestep-mongodb>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,10 @@ yaml = [
     "PyYAML>=6.0",
 ]
 mysql = [
-    "onestep-mysql>=0.3.1",
+    "onestep-mysql>=0.3.3",
 ]
 postgres = [
-    "onestep-postgres>=0.1.1",
+    "onestep-postgres>=0.1.3",
 ]
 rabbitmq = [
     "onestep-mq>=0.2.1",
@@ -68,8 +68,8 @@ integration = [
     "PyYAML>=6.0",
     "onestep-mq>=0.2.1",
     "onestep-redis>=0.2.1",
-    "onestep-mysql>=0.3.1",
-    "onestep-postgres>=0.1.1",
+    "onestep-mysql>=0.3.3",
+    "onestep-postgres>=0.1.3",
     "onestep-sqs>=0.2.2",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
@@ -81,8 +81,8 @@ all = [
     "PyYAML>=6.0",
     "onestep-mq>=0.2.1",
     "onestep-redis>=0.2.1",
-    "onestep-mysql>=0.3.1",
-    "onestep-postgres>=0.1.1",
+    "onestep-mysql>=0.3.3",
+    "onestep-postgres>=0.1.3",
     "onestep-sqs>=0.2.2",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
@@ -96,8 +96,8 @@ dev = [
     "PyYAML>=6.0",
     "onestep-mq>=0.2.1",
     "onestep-redis>=0.2.1",
-    "onestep-mysql>=0.3.1",
-    "onestep-postgres>=0.1.1",
+    "onestep-mysql>=0.3.3",
+    "onestep-postgres>=0.1.3",
     "onestep-sqs>=0.2.2",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",

--- a/src/onestep/testing/__init__.py
+++ b/src/onestep/testing/__init__.py
@@ -1,0 +1,19 @@
+from .connector_conformance import (
+    AcknowledgedSinkHarness,
+    ClaimedSourceHarness,
+    ConnectorCapability,
+    ConnectorConformanceProfile,
+    StopControl,
+    run_acknowledged_sink_contract,
+    run_claimed_source_stop_contract,
+)
+
+__all__ = [
+    "AcknowledgedSinkHarness",
+    "ClaimedSourceHarness",
+    "ConnectorCapability",
+    "ConnectorConformanceProfile",
+    "StopControl",
+    "run_acknowledged_sink_contract",
+    "run_claimed_source_stop_contract",
+]

--- a/src/onestep/testing/__init__.py
+++ b/src/onestep/testing/__init__.py
@@ -3,9 +3,11 @@ from .connector_conformance import (
     ClaimedSourceHarness,
     ConnectorCapability,
     ConnectorConformanceProfile,
+    ReplaySafeSinkHarness,
     StopControl,
     run_acknowledged_sink_contract,
     run_claimed_source_stop_contract,
+    run_replay_safe_sink_contract,
 )
 
 __all__ = [
@@ -13,7 +15,9 @@ __all__ = [
     "ClaimedSourceHarness",
     "ConnectorCapability",
     "ConnectorConformanceProfile",
+    "ReplaySafeSinkHarness",
     "StopControl",
     "run_acknowledged_sink_contract",
     "run_claimed_source_stop_contract",
+    "run_replay_safe_sink_contract",
 ]

--- a/src/onestep/testing/connector_conformance.py
+++ b/src/onestep/testing/connector_conformance.py
@@ -145,7 +145,9 @@ async def run_claimed_source_stop_contract(
     serving = asyncio.create_task(app.serve())
     fetch_released = False
     try:
-        await asyncio.wait_for(_invoke(harness.wait_for_fetch_started), timeout=timeout_s)
+        await asyncio.wait_for(
+            _invoke_wait_action(harness.wait_for_fetch_started), timeout=timeout_s
+        )
 
         if control is StopControl.DRAIN:
             app.request_drain()
@@ -210,7 +212,9 @@ async def run_acknowledged_sink_contract(
     serving = asyncio.create_task(app.serve())
     send_released = False
     try:
-        await asyncio.wait_for(_invoke(harness.wait_for_send_started), timeout=timeout_s)
+        await asyncio.wait_for(
+            _invoke_wait_action(harness.wait_for_send_started), timeout=timeout_s
+        )
         if delivery.acked:
             raise AssertionError("delivery was acked before the sink backend acknowledged the send")
         if serving.done():
@@ -252,6 +256,16 @@ async def run_replay_safe_sink_contract(
 
 async def _invoke(action: _Action) -> None:
     result = action()
+    if inspect.isawaitable(result):
+        await result
+
+
+async def _invoke_wait_action(action: _Action) -> None:
+    if inspect.iscoroutinefunction(action):
+        await action()
+        return
+
+    result = await asyncio.to_thread(action)
     if inspect.isawaitable(result):
         await result
 

--- a/src/onestep/testing/connector_conformance.py
+++ b/src/onestep/testing/connector_conformance.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import inspect
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Any
+
+from onestep.app import OneStepApp
+from onestep.connectors.base import Delivery, Sink, Source
+from onestep.envelope import Envelope
+
+
+class ConnectorCapability(str, Enum):
+    BASIC_SOURCE = "basic_source"
+    CHECKPOINT_SOURCE = "checkpoint_source"
+    CLAIMED_SOURCE = "claimed_source"
+    ACKNOWLEDGED_SINK = "acknowledged_sink"
+    CHUNKED_SINK = "chunked_sink"
+    REPLAY_SAFE_SINK = "replay_safe_sink"
+    PUBLIC_ERRORS = "public_errors"
+
+
+_CAPABILITY_DEPENDENCIES = {
+    ConnectorCapability.CHECKPOINT_SOURCE: frozenset({ConnectorCapability.BASIC_SOURCE}),
+    ConnectorCapability.CLAIMED_SOURCE: frozenset({ConnectorCapability.BASIC_SOURCE}),
+    ConnectorCapability.CHUNKED_SINK: frozenset({ConnectorCapability.ACKNOWLEDGED_SINK}),
+    ConnectorCapability.REPLAY_SAFE_SINK: frozenset({ConnectorCapability.ACKNOWLEDGED_SINK}),
+}
+
+
+@dataclass(frozen=True)
+class ConnectorConformanceProfile:
+    """Test-side declaration of connector capabilities and their evidence."""
+
+    name: str
+    contracts: Mapping[ConnectorCapability, tuple[str, ...]]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError("connector profile name must not be empty")
+        if not isinstance(self.contracts, Mapping) or not self.contracts:
+            raise ValueError("connector profile contracts must not be empty")
+
+        normalized: dict[ConnectorCapability, tuple[str, ...]] = {}
+        for raw_capability, raw_contract_ids in self.contracts.items():
+            try:
+                capability = ConnectorCapability(raw_capability)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"unknown connector capability: {raw_capability!r}") from exc
+
+            if isinstance(raw_contract_ids, str):
+                contract_ids = (raw_contract_ids,)
+            else:
+                contract_ids = tuple(raw_contract_ids)
+            if not contract_ids or any(
+                not isinstance(contract_id, str) or not contract_id.strip()
+                for contract_id in contract_ids
+            ):
+                raise ValueError(f"{capability.value} must name at least one contract test")
+            if len(set(contract_ids)) != len(contract_ids):
+                raise ValueError(f"{capability.value} contract test IDs must be unique")
+            normalized[capability] = contract_ids
+
+        capabilities = frozenset(normalized)
+        for capability, dependencies in _CAPABILITY_DEPENDENCIES.items():
+            if capability not in capabilities:
+                continue
+            missing = dependencies - capabilities
+            if missing:
+                names = ", ".join(sorted(item.value for item in missing))
+                raise ValueError(f"{capability.value} requires: {names}")
+
+        object.__setattr__(self, "name", self.name.strip())
+        object.__setattr__(self, "contracts", MappingProxyType(normalized))
+
+    @property
+    def capabilities(self) -> frozenset[ConnectorCapability]:
+        return frozenset(self.contracts)
+
+    def supports(self, capability: ConnectorCapability) -> bool:
+        return capability in self.contracts
+
+    def contract_ids(self, capability: ConnectorCapability) -> tuple[str, ...]:
+        try:
+            return self.contracts[capability]
+        except KeyError as exc:
+            raise ValueError(
+                f"connector profile {self.name!r} does not declare {capability.value}"
+            ) from exc
+
+
+class StopControl(str, Enum):
+    DRAIN = "drain"
+    PAUSE = "pause"
+    SHUTDOWN = "shutdown"
+
+
+_Action = Callable[[], object]
+
+
+@dataclass(frozen=True)
+class ClaimedSourceHarness:
+    source: Source
+    wait_for_fetch_started: _Action
+    release_fetch: _Action
+    assert_released: _Action
+
+
+@dataclass(frozen=True)
+class AcknowledgedSinkHarness:
+    sink: Sink
+    wait_for_send_started: _Action
+    release_send: _Action
+
+
+async def run_claimed_source_stop_contract(
+    harness: ClaimedSourceHarness,
+    control: StopControl,
+    *,
+    timeout_s: float = 2.0,
+) -> None:
+    """Prove a claimed delivery is released when intake stops before handling."""
+
+    if harness.source.fetch_is_cancel_safe:
+        raise AssertionError("claimed source must set fetch_is_cancel_safe = False")
+
+    app = OneStepApp(f"claimed-source-{control.value}-contract", shutdown_timeout_s=timeout_s)
+    handled: list[Any] = []
+
+    @app.task(source=harness.source, name="connector_contract", concurrency=1)
+    async def consume(ctx, item):
+        handled.append(item)
+
+    serving = asyncio.create_task(app.serve())
+    fetch_released = False
+    try:
+        await asyncio.wait_for(_invoke(harness.wait_for_fetch_started), timeout=timeout_s)
+
+        if control is StopControl.DRAIN:
+            app.request_drain()
+        elif control is StopControl.PAUSE:
+            app.request_task_pause("connector_contract")
+        elif control is StopControl.SHUTDOWN:
+            app.request_shutdown()
+        else:
+            raise ValueError(f"unsupported stop control: {control!r}")
+
+        await asyncio.sleep(0)
+        if serving.done():
+            raise AssertionError("worker stopped before the non-cancel-safe fetch completed")
+
+        await _invoke(harness.release_fetch)
+        fetch_released = True
+
+        if control is StopControl.DRAIN:
+            status = await asyncio.wait_for(app.wait_for_drain(), timeout=timeout_s)
+            if not status["drained"]:
+                raise AssertionError("worker did not drain after releasing the claimed delivery")
+            app.request_shutdown()
+        elif control is StopControl.PAUSE:
+            status = await asyncio.wait_for(
+                app.wait_for_task_pause("connector_contract"), timeout=timeout_s
+            )
+            if not status["paused"]:
+                raise AssertionError("task did not pause after releasing the claimed delivery")
+            app.request_shutdown()
+
+        await asyncio.wait_for(serving, timeout=timeout_s)
+        if handled:
+            raise AssertionError(f"claimed deliveries reached the handler after {control.value}")
+        await _invoke(harness.assert_released)
+    finally:
+        if not fetch_released:
+            with contextlib.suppress(Exception):
+                await _invoke(harness.release_fetch)
+        app.request_shutdown()
+        if not serving.done():
+            serving.cancel()
+        await asyncio.gather(serving, return_exceptions=True)
+
+
+async def run_acknowledged_sink_contract(
+    harness: AcknowledgedSinkHarness,
+    *,
+    body: Any,
+    timeout_s: float = 2.0,
+) -> None:
+    """Prove runtime ack happens only after the sink's backend ack returns."""
+
+    delivery = _ContractDelivery(Envelope(body=body))
+    source = _OneShotSource(delivery)
+    app = OneStepApp("acknowledged-sink-contract", shutdown_timeout_s=timeout_s)
+
+    @app.task(source=source, emit=harness.sink, concurrency=1)
+    async def forward(ctx, item):
+        ctx.app.request_shutdown()
+        return item
+
+    serving = asyncio.create_task(app.serve())
+    send_released = False
+    try:
+        await asyncio.wait_for(_invoke(harness.wait_for_send_started), timeout=timeout_s)
+        if delivery.acked:
+            raise AssertionError("delivery was acked before the sink backend acknowledged the send")
+        if serving.done():
+            raise AssertionError("worker stopped before the sink backend acknowledged the send")
+
+        await _invoke(harness.release_send)
+        send_released = True
+        await asyncio.wait_for(serving, timeout=timeout_s)
+
+        if not delivery.acked:
+            raise AssertionError("delivery was not acked after the sink backend acknowledged the send")
+        if delivery.retried or delivery.failed:
+            raise AssertionError("successful acknowledged sink send entered a failure path")
+    finally:
+        if not send_released:
+            with contextlib.suppress(Exception):
+                await _invoke(harness.release_send)
+        app.request_shutdown()
+        if not serving.done():
+            serving.cancel()
+        await asyncio.gather(serving, return_exceptions=True)
+
+
+async def _invoke(action: _Action) -> None:
+    result = action()
+    if inspect.isawaitable(result):
+        await result
+
+
+class _ContractDelivery(Delivery):
+    def __init__(self, envelope: Envelope) -> None:
+        super().__init__(envelope)
+        self.acked = False
+        self.retried = False
+        self.failed = False
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        self.retried = True
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        self.failed = True
+
+
+class _OneShotSource(Source):
+    poll_interval_s = 0.01
+
+    def __init__(self, delivery: Delivery) -> None:
+        super().__init__("connector-contract-source")
+        self.delivery = delivery
+        self.sent = False
+
+    async def fetch(self, limit: int) -> list[Delivery]:
+        if self.sent:
+            return []
+        self.sent = True
+        return [self.delivery]

--- a/src/onestep/testing/connector_conformance.py
+++ b/src/onestep/testing/connector_conformance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import copy
 import inspect
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -117,6 +118,12 @@ class AcknowledgedSinkHarness:
     release_send: _Action
 
 
+@dataclass(frozen=True)
+class ReplaySafeSinkHarness:
+    sink: Sink
+    assert_single_record: _Action
+
+
 async def run_claimed_source_stop_contract(
     harness: ClaimedSourceHarness,
     control: StopControl,
@@ -225,6 +232,22 @@ async def run_acknowledged_sink_contract(
         if not serving.done():
             serving.cancel()
         await asyncio.gather(serving, return_exceptions=True)
+
+
+async def run_replay_safe_sink_contract(
+    harness: ReplaySafeSinkHarness,
+    *,
+    body: Any,
+) -> None:
+    """Prove replaying the same logical write leaves one backend record."""
+
+    await harness.sink.open()
+    try:
+        await harness.sink.send(Envelope(body=copy.deepcopy(body)))
+        await harness.sink.send(Envelope(body=copy.deepcopy(body)))
+        await _invoke(harness.assert_single_record)
+    finally:
+        await harness.sink.close()
 
 
 async def _invoke(action: _Action) -> None:

--- a/tests/contract/test_official_connector_conformance.py
+++ b/tests/contract/test_official_connector_conformance.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from onestep.testing import ConnectorCapability as Capability
+from onestep.testing import ConnectorConformanceProfile
+
+
+PROFILES = (
+    ConnectorConformanceProfile(
+        name="clickhouse",
+        contracts={
+            Capability.ACKNOWLEDGED_SINK: (
+                "plugins/onestep-clickhouse/tests/test_clickhouse_connector.py::test_runtime_ack_follows_clickhouse_insert_acknowledgement",
+            ),
+            Capability.CHUNKED_SINK: (
+                "plugins/onestep-clickhouse/tests/test_clickhouse_connector.py::test_send_awaits_each_chunk_in_order",
+            ),
+            Capability.PUBLIC_ERRORS: (
+                "plugins/onestep-clickhouse/tests/test_clickhouse_connector.py::test_send_failure_does_not_leak_dsn_credentials",
+            ),
+        },
+    ),
+    ConnectorConformanceProfile(
+        name="elasticsearch",
+        contracts={
+            Capability.ACKNOWLEDGED_SINK: (
+                "plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py::test_runtime_ack_follows_backend_bulk_acknowledgement",
+            ),
+            Capability.CHUNKED_SINK: (
+                "plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py::test_send_waits_for_every_success_item",
+            ),
+            Capability.REPLAY_SAFE_SINK: (
+                "plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py::test_mapping_becomes_one_newline_terminated_bulk_action",
+                "plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py::test_429_retries_only_failed_subset",
+            ),
+            Capability.PUBLIC_ERRORS: (
+                "plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py::test_transport_errors_redact_hosts_headers_and_generated_auth",
+            ),
+        },
+    ),
+    ConnectorConformanceProfile(
+        name="feishu-bitable",
+        contracts={
+            Capability.BASIC_SOURCE: (
+                "plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py::test_feishu_incremental_source_advances_cursor_in_ack_order_and_resumes",
+            ),
+            Capability.CHECKPOINT_SOURCE: (
+                "plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py::test_feishu_incremental_source_advances_cursor_in_ack_order_and_resumes",
+            ),
+            Capability.ACKNOWLEDGED_SINK: (
+                "plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py::test_feishu_connector_fetches_and_reuses_tenant_token_for_create_sink",
+            ),
+            Capability.REPLAY_SAFE_SINK: (
+                "plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py::test_feishu_table_sink_upsert_creates_updates_and_rejects_duplicates",
+            ),
+            Capability.PUBLIC_ERRORS: (
+                "plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py::test_feishu_descriptors_redact_app_token_and_omit_credentials",
+                "plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py::test_feishu_http_error_classifies_rate_limit_as_throttled",
+            ),
+        },
+    ),
+    ConnectorConformanceProfile(
+        name="kafka",
+        contracts={
+            Capability.BASIC_SOURCE: (
+                "plugins/onestep-kafka/tests/test_kafka_connector.py::test_kafka_topic_fetch_decodes_envelopes_and_injects_metadata",
+            ),
+            Capability.CHECKPOINT_SOURCE: (
+                "plugins/onestep-kafka/tests/test_kafka_connector.py::test_ack_commits_only_after_contiguous_offsets_complete",
+            ),
+            Capability.CLAIMED_SOURCE: (
+                "plugins/onestep-kafka/tests/test_kafka_runtime_contract.py::test_stop_controls_release_fetched_unstarted_kafka_delivery",
+            ),
+            Capability.ACKNOWLEDGED_SINK: (
+                "plugins/onestep-kafka/tests/test_kafka_runtime_contract.py::test_runtime_ack_follows_kafka_producer_acknowledgement",
+            ),
+            Capability.PUBLIC_ERRORS: (
+                "plugins/onestep-kafka/tests/test_kafka_connector.py::test_kafka_topic_redacts_consumer_and_producer_passwords",
+            ),
+        },
+    ),
+    ConnectorConformanceProfile(
+        name="mongodb",
+        contracts={
+            Capability.BASIC_SOURCE: (
+                "plugins/onestep-mongodb/tests/test_mongodb_change_stream.py::test_default_watch_emits_complete_raw_delete_event",
+            ),
+            Capability.CHECKPOINT_SOURCE: (
+                "plugins/onestep-mongodb/tests/test_mongodb_polling.py::test_polling_persists_only_the_contiguous_ack_prefix",
+                "plugins/onestep-mongodb/tests/test_mongodb_change_stream.py::test_change_tokens_persist_only_after_contiguous_ack",
+            ),
+            Capability.CLAIMED_SOURCE: (
+                "plugins/onestep-mongodb/tests/test_mongodb_runtime_contract.py::test_stop_controls_release_unstarted_without_committing",
+            ),
+            Capability.ACKNOWLEDGED_SINK: (
+                "plugins/onestep-mongodb/tests/test_mongodb_runtime_contract.py::test_runtime_ack_follows_mongodb_write_acknowledgement",
+            ),
+            Capability.CHUNKED_SINK: (
+                "plugins/onestep-mongodb/tests/test_mongodb_sink.py::test_insert_mapping_and_chunked_sequence",
+            ),
+            Capability.REPLAY_SAFE_SINK: (
+                "plugins/onestep-mongodb/tests/test_mongodb_sink.py::test_upsert_uses_all_keys_and_excludes_keys_and_id_from_set",
+            ),
+            Capability.PUBLIC_ERRORS: (
+                "plugins/onestep-mongodb/tests/test_mongodb_resilience.py::test_redacted_cause_does_not_retain_credentials_or_invalid_documents",
+            ),
+        },
+    ),
+    ConnectorConformanceProfile(
+        name="mysql",
+        contracts={
+            Capability.BASIC_SOURCE: (
+                "plugins/onestep-mysql/tests/test_mysql_table_queue.py::test_mysql_table_queue_round_trip",
+            ),
+            Capability.CHECKPOINT_SOURCE: (
+                "plugins/onestep-mysql/tests/test_mysql_incremental.py::test_mysql_incremental_cursor_advances_in_order",
+                "plugins/onestep-mysql/tests/test_mysql_binlog.py::test_mysql_binlog_cursor_advances_in_order",
+            ),
+            Capability.CLAIMED_SOURCE: (
+                "plugins/onestep-mysql/tests/test_mysql_runtime_contract.py::test_table_queue_stop_controls_release_claimed_rows",
+            ),
+            Capability.ACKNOWLEDGED_SINK: (
+                "plugins/onestep-mysql/tests/test_mysql_table_queue.py::test_mysql_table_queue_round_trip",
+            ),
+            Capability.REPLAY_SAFE_SINK: (
+                "plugins/onestep-mysql/tests/test_mysql_table_queue.py::test_mysql_table_sink_upsert_is_replay_safe",
+            ),
+            Capability.PUBLIC_ERRORS: (
+                "plugins/onestep-mysql/tests/test_mysql_plugin.py::test_mysql_connector_error_does_not_leak_dsn_credentials",
+            ),
+        },
+    ),
+    ConnectorConformanceProfile(
+        name="postgres",
+        contracts={
+            Capability.BASIC_SOURCE: (
+                "plugins/onestep-postgres/tests/test_postgres_table_queue.py::test_postgres_table_queue_round_trip",
+            ),
+            Capability.CHECKPOINT_SOURCE: (
+                "plugins/onestep-postgres/tests/test_postgres_incremental.py::test_postgres_incremental_cursor_advances_in_order",
+            ),
+            Capability.CLAIMED_SOURCE: (
+                "plugins/onestep-postgres/tests/test_postgres_runtime_contract.py::test_table_queue_stop_controls_release_claimed_rows",
+            ),
+            Capability.ACKNOWLEDGED_SINK: (
+                "plugins/onestep-postgres/tests/test_postgres_table_queue.py::test_postgres_table_queue_round_trip",
+            ),
+            Capability.REPLAY_SAFE_SINK: (
+                "plugins/onestep-postgres/tests/test_postgres_table_queue.py::test_postgres_table_sink_upsert_is_replay_safe",
+            ),
+            Capability.PUBLIC_ERRORS: (
+                "plugins/onestep-postgres/tests/test_postgres_plugin.py::test_postgres_connector_error_does_not_leak_dsn_credentials",
+            ),
+        },
+    ),
+    ConnectorConformanceProfile(
+        name="rabbitmq",
+        contracts={
+            Capability.BASIC_SOURCE: (
+                "plugins/onestep-rabbitmq/tests/test_rabbitmq_connector.py::test_rabbitmq_queue_send_fetch_retry_fail_and_exchange_binding",
+            ),
+            Capability.CHECKPOINT_SOURCE: (
+                "plugins/onestep-rabbitmq/tests/test_rabbitmq_connector.py::test_rabbitmq_queue_send_fetch_retry_fail_and_exchange_binding",
+            ),
+            Capability.ACKNOWLEDGED_SINK: (
+                "plugins/onestep-rabbitmq/tests/test_rabbitmq_connector.py::test_rabbitmq_queue_send_fetch_retry_fail_and_exchange_binding",
+            ),
+            Capability.PUBLIC_ERRORS: (
+                "plugins/onestep-rabbitmq/tests/test_rabbitmq_connector.py::test_rabbitmq_open_failure_does_not_leak_url_credentials",
+            ),
+        },
+    ),
+    ConnectorConformanceProfile(
+        name="redis",
+        contracts={
+            Capability.BASIC_SOURCE: (
+                "plugins/onestep-redis/tests/test_redis_connector.py::TestRedisStreamQueue::test_send_and_fetch_mock",
+            ),
+            Capability.CHECKPOINT_SOURCE: (
+                "plugins/onestep-redis/tests/test_redis_connector.py::TestRedisStreamQueue::test_send_and_fetch_mock",
+            ),
+            Capability.ACKNOWLEDGED_SINK: (
+                "plugins/onestep-redis/tests/test_redis_connector.py::TestRedisStreamQueue::test_send_with_maxlen",
+            ),
+            Capability.PUBLIC_ERRORS: (
+                "plugins/onestep-redis/tests/test_redis_resilience.py::test_send_failure_does_not_leak_url_credentials",
+            ),
+        },
+    ),
+    ConnectorConformanceProfile(
+        name="sqs",
+        contracts={
+            Capability.BASIC_SOURCE: (
+                "plugins/onestep-sqs/tests/test_sqs_connector.py::test_sqs_queue_send_fetch_batch_delete_and_fail_delete",
+            ),
+            Capability.CHECKPOINT_SOURCE: (
+                "plugins/onestep-sqs/tests/test_sqs_connector.py::test_sqs_queue_send_fetch_batch_delete_and_fail_delete",
+            ),
+            Capability.CLAIMED_SOURCE: (
+                "plugins/onestep-sqs/tests/test_sqs_runtime_contract.py::test_shutdown_waits_for_sqs_long_poll_and_releases_unstarted_delivery",
+            ),
+            Capability.ACKNOWLEDGED_SINK: (
+                "plugins/onestep-sqs/tests/test_sqs_connector.py::test_sqs_queue_send_fetch_batch_delete_and_fail_delete",
+            ),
+            Capability.PUBLIC_ERRORS: (
+                "plugins/onestep-sqs/tests/test_sqs_plugin.py::test_sqs_connector_error_does_not_leak_option_secrets",
+            ),
+        },
+    ),
+)
+
+
+EXPECTED_OFFICIAL_CONNECTORS = {
+    "clickhouse",
+    "elasticsearch",
+    "feishu-bitable",
+    "kafka",
+    "mongodb",
+    "mysql",
+    "postgres",
+    "rabbitmq",
+    "redis",
+    "sqs",
+}
+
+
+def test_every_official_connector_declares_a_profile() -> None:
+    assert {profile.name for profile in PROFILES} == EXPECTED_OFFICIAL_CONNECTORS
+
+
+@pytest.mark.parametrize(
+    ("profile", "contract_id"),
+    [
+        (profile, contract_id)
+        for profile in PROFILES
+        for contract_ids in profile.contracts.values()
+        for contract_id in contract_ids
+    ],
+    ids=lambda value: value.name if isinstance(value, ConnectorConformanceProfile) else value,
+)
+def test_official_profile_evidence_names_real_unit_contracts(
+    profile: ConnectorConformanceProfile,
+    contract_id: str,
+) -> None:
+    relative_path, separator, test_qualname = contract_id.partition("::")
+    assert separator, f"{profile.name} contract must include a pytest-style node ID"
+    assert "/integration/" not in relative_path, f"{profile.name} must have unit-level evidence"
+
+    path = Path(__file__).parents[2] / relative_path
+    assert path.is_file(), f"{profile.name} contract file does not exist: {relative_path}"
+
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    function_name = test_qualname.rsplit("::", 1)[-1]
+    collected_names = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    assert function_name in collected_names, (
+        f"{profile.name} contract test does not exist: {contract_id}"
+    )

--- a/tests/contract/test_official_connector_conformance.py
+++ b/tests/contract/test_official_connector_conformance.py
@@ -33,10 +33,6 @@ PROFILES = (
             Capability.CHUNKED_SINK: (
                 "plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py::test_send_waits_for_every_success_item",
             ),
-            Capability.REPLAY_SAFE_SINK: (
-                "plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py::test_mapping_becomes_one_newline_terminated_bulk_action",
-                "plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py::test_429_retries_only_failed_subset",
-            ),
             Capability.PUBLIC_ERRORS: (
                 "plugins/onestep-elasticsearch/tests/test_elasticsearch_connector.py::test_transport_errors_redact_hosts_headers_and_generated_auth",
             ),
@@ -102,9 +98,6 @@ PROFILES = (
             Capability.CHUNKED_SINK: (
                 "plugins/onestep-mongodb/tests/test_mongodb_sink.py::test_insert_mapping_and_chunked_sequence",
             ),
-            Capability.REPLAY_SAFE_SINK: (
-                "plugins/onestep-mongodb/tests/test_mongodb_sink.py::test_upsert_uses_all_keys_and_excludes_keys_and_id_from_set",
-            ),
             Capability.PUBLIC_ERRORS: (
                 "plugins/onestep-mongodb/tests/test_mongodb_resilience.py::test_redacted_cause_does_not_retain_credentials_or_invalid_documents",
             ),
@@ -126,9 +119,6 @@ PROFILES = (
             Capability.ACKNOWLEDGED_SINK: (
                 "plugins/onestep-mysql/tests/test_mysql_table_queue.py::test_mysql_table_queue_round_trip",
             ),
-            Capability.REPLAY_SAFE_SINK: (
-                "plugins/onestep-mysql/tests/test_mysql_table_queue.py::test_mysql_table_sink_upsert_is_replay_safe",
-            ),
             Capability.PUBLIC_ERRORS: (
                 "plugins/onestep-mysql/tests/test_mysql_plugin.py::test_mysql_connector_error_does_not_leak_dsn_credentials",
             ),
@@ -148,9 +138,6 @@ PROFILES = (
             ),
             Capability.ACKNOWLEDGED_SINK: (
                 "plugins/onestep-postgres/tests/test_postgres_table_queue.py::test_postgres_table_queue_round_trip",
-            ),
-            Capability.REPLAY_SAFE_SINK: (
-                "plugins/onestep-postgres/tests/test_postgres_table_queue.py::test_postgres_table_sink_upsert_is_replay_safe",
             ),
             Capability.PUBLIC_ERRORS: (
                 "plugins/onestep-postgres/tests/test_postgres_plugin.py::test_postgres_connector_error_does_not_leak_dsn_credentials",
@@ -200,9 +187,6 @@ PROFILES = (
             Capability.CHECKPOINT_SOURCE: (
                 "plugins/onestep-sqs/tests/test_sqs_connector.py::test_sqs_queue_send_fetch_batch_delete_and_fail_delete",
             ),
-            Capability.CLAIMED_SOURCE: (
-                "plugins/onestep-sqs/tests/test_sqs_runtime_contract.py::test_shutdown_waits_for_sqs_long_poll_and_releases_unstarted_delivery",
-            ),
             Capability.ACKNOWLEDGED_SINK: (
                 "plugins/onestep-sqs/tests/test_sqs_connector.py::test_sqs_queue_send_fetch_batch_delete_and_fail_delete",
             ),
@@ -214,22 +198,109 @@ PROFILES = (
 )
 
 
-EXPECTED_OFFICIAL_CONNECTORS = {
-    "clickhouse",
-    "elasticsearch",
-    "feishu-bitable",
-    "kafka",
-    "mongodb",
-    "mysql",
-    "postgres",
-    "rabbitmq",
-    "redis",
-    "sqs",
-}
+REPO_ROOT = Path(__file__).parents[2]
+RESOURCE_ENTRY_POINT = '[project.entry-points."onestep.resources"]'
+
+
+def _official_connector_names() -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            pyproject.parent.name.removeprefix("onestep-")
+            for pyproject in (REPO_ROOT / "plugins").glob("*/pyproject.toml")
+            if RESOURCE_ENTRY_POINT in pyproject.read_text(encoding="utf-8")
+        )
+    )
+
+
+def _find_contract_test(
+    tree: ast.Module,
+    qualname: str,
+) -> tuple[ast.FunctionDef | ast.AsyncFunctionDef, ast.ClassDef | None] | None:
+    parts = qualname.split("::")
+    if len(parts) == 1:
+        function = next(
+            (
+                node
+                for node in tree.body
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == parts[0]
+            ),
+            None,
+        )
+        return (function, None) if function is not None else None
+
+    if len(parts) != 2:
+        return None
+
+    class_name, function_name = parts
+    test_class = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == class_name
+        ),
+        None,
+    )
+    if test_class is None or not test_class.name.startswith("Test"):
+        return None
+
+    function = next(
+        (
+            node
+            for node in test_class.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == function_name
+        ),
+        None,
+    )
+    return (function, test_class) if function is not None else None
+
+
+def _decorator_name(decorator: ast.expr) -> str:
+    if isinstance(decorator, ast.Call):
+        return _decorator_name(decorator.func)
+    if isinstance(decorator, ast.Attribute):
+        prefix = _decorator_name(decorator.value)
+        return f"{prefix}.{decorator.attr}" if prefix else decorator.attr
+    if isinstance(decorator, ast.Name):
+        return decorator.id
+    return ""
+
+
+def _has_skip_marker(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) -> bool:
+    return any(
+        _decorator_name(decorator).split(".")[-1] in {"skip", "skipif"}
+        for decorator in node.decorator_list
+    )
 
 
 def test_every_official_connector_declares_a_profile() -> None:
-    assert {profile.name for profile in PROFILES} == EXPECTED_OFFICIAL_CONNECTORS
+    profile_names = tuple(profile.name for profile in PROFILES)
+    assert len(profile_names) == len(set(profile_names)), "connector profile names must be unique"
+    assert set(profile_names) == set(_official_connector_names())
+
+
+def test_contract_lookup_requires_an_exact_collectable_qualname() -> None:
+    tree = ast.parse(
+        """
+def test_top_level():
+    pass
+
+class TestContract:
+    def test_method(self):
+        pass
+
+def helper():
+    def test_nested():
+        pass
+"""
+    )
+
+    assert _find_contract_test(tree, "test_top_level") is not None
+    assert _find_contract_test(tree, "TestContract::test_method") is not None
+    assert _find_contract_test(tree, "WrongClass::test_method") is None
+    assert _find_contract_test(tree, "test_nested") is None
+    assert _find_contract_test(tree, "helper::test_nested") is None
 
 
 @pytest.mark.parametrize(
@@ -250,16 +321,16 @@ def test_official_profile_evidence_names_real_unit_contracts(
     assert separator, f"{profile.name} contract must include a pytest-style node ID"
     assert "/integration/" not in relative_path, f"{profile.name} must have unit-level evidence"
 
-    path = Path(__file__).parents[2] / relative_path
+    path = REPO_ROOT / relative_path
     assert path.is_file(), f"{profile.name} contract file does not exist: {relative_path}"
 
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    function_name = test_qualname.rsplit("::", 1)[-1]
-    collected_names = {
-        node.name
-        for node in ast.walk(tree)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-    }
-    assert function_name in collected_names, (
-        f"{profile.name} contract test does not exist: {contract_id}"
-    )
+    located = _find_contract_test(tree, test_qualname)
+    assert located is not None, f"{profile.name} contract test does not exist: {contract_id}"
+
+    function, test_class = located
+    assert function.name.startswith("test_"), f"{profile.name} evidence is not a pytest test"
+    assert not _has_skip_marker(function), f"{profile.name} evidence is marked skipped"
+    assert test_class is None or not _has_skip_marker(
+        test_class
+    ), f"{profile.name} evidence class is marked skipped"

--- a/tests/test_connector_conformance.py
+++ b/tests/test_connector_conformance.py
@@ -151,7 +151,7 @@ def test_claimed_source_runner_times_out_a_blocking_sync_wait_callback() -> None
         callback_gate = threading.Event()
 
         try:
-            with pytest.raises(TimeoutError):
+            with pytest.raises(asyncio.TimeoutError):
                 await run_claimed_source_stop_contract(
                     ClaimedSourceHarness(
                         source=source,

--- a/tests/test_connector_conformance.py
+++ b/tests/test_connector_conformance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 
 import pytest
 
@@ -34,6 +35,33 @@ def test_profile_normalizes_and_freezes_contract_evidence() -> None:
     }
     assert profile.contract_ids(ConnectorCapability.BASIC_SOURCE) == ("test_fetch",)
     assert profile.supports(ConnectorCapability.CHECKPOINT_SOURCE) is True
+    assert profile.supports(ConnectorCapability.PUBLIC_ERRORS) is False
+
+
+def test_profile_normalizes_a_single_contract_id() -> None:
+    profile = ConnectorConformanceProfile(
+        name="example",
+        contracts={ConnectorCapability.PUBLIC_ERRORS: "test_public_error"},
+    )
+
+    assert profile.contract_ids(ConnectorCapability.PUBLIC_ERRORS) == ("test_public_error",)
+
+
+@pytest.mark.parametrize("name", [None, "", "   "])
+def test_profile_rejects_invalid_names(name) -> None:
+    with pytest.raises(ValueError, match="name must not be empty"):
+        ConnectorConformanceProfile(
+            name=name,
+            contracts={ConnectorCapability.PUBLIC_ERRORS: ("test_error",)},
+        )
+
+
+def test_profile_rejects_unknown_capabilities() -> None:
+    with pytest.raises(ValueError, match="unknown connector capability"):
+        ConnectorConformanceProfile(
+            name="invalid",
+            contracts={"future_capability": ("test_future",)},
+        )
 
 
 @pytest.mark.parametrize(
@@ -53,6 +81,8 @@ def test_profile_rejects_missing_capability_dependencies(capability, dependency)
 @pytest.mark.parametrize(
     "contracts",
     [
+        None,
+        [],
         {},
         {ConnectorCapability.PUBLIC_ERRORS: ()},
         {ConnectorCapability.PUBLIC_ERRORS: ("",)},
@@ -115,6 +145,29 @@ def test_claimed_source_runner_rejects_cancel_safe_source() -> None:
         )
 
 
+def test_claimed_source_runner_times_out_a_blocking_sync_wait_callback() -> None:
+    async def scenario() -> None:
+        source = _BlockingClaimedSource()
+        callback_gate = threading.Event()
+
+        try:
+            with pytest.raises(TimeoutError):
+                await run_claimed_source_stop_contract(
+                    ClaimedSourceHarness(
+                        source=source,
+                        wait_for_fetch_started=callback_gate.wait,
+                        release_fetch=source.release_fetch.set,
+                        assert_released=lambda: None,
+                    ),
+                    StopControl.SHUTDOWN,
+                    timeout_s=0.01,
+                )
+        finally:
+            callback_gate.set()
+
+    asyncio.run(scenario())
+
+
 def test_acknowledged_sink_runner_enforces_runtime_ack_ordering() -> None:
     async def scenario() -> None:
         sink = _BlockingSink()
@@ -146,6 +199,27 @@ def test_replay_safe_sink_runner_sends_twice_and_requires_one_record() -> None:
             ),
             body={"id": "event-1", "value": 3},
         )
+
+    asyncio.run(scenario())
+
+
+def test_replay_safe_sink_runner_closes_after_a_failed_backend_assertion() -> None:
+    async def scenario() -> None:
+        sink = _ReplaySafeSink()
+
+        def reject_duplicate() -> None:
+            raise AssertionError("backend retained two logical records")
+
+        with pytest.raises(AssertionError, match="retained two logical records"):
+            await run_replay_safe_sink_contract(
+                ReplaySafeSinkHarness(
+                    sink=sink,
+                    assert_single_record=reject_duplicate,
+                ),
+                body={"id": "event-1", "value": 3},
+            )
+
+        assert sink.closed is True
 
     asyncio.run(scenario())
 
@@ -210,7 +284,11 @@ class _ReplaySafeSink(Sink):
         super().__init__("replay-safe-sink")
         self.records: dict[str, dict[str, object]] = {}
         self.send_calls = 0
+        self.closed = False
 
     async def send(self, envelope: Envelope) -> None:
         self.send_calls += 1
         self.records[envelope.body["id"]] = dict(envelope.body)
+
+    async def close(self) -> None:
+        self.closed = True

--- a/tests/test_connector_conformance.py
+++ b/tests/test_connector_conformance.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from onestep import Delivery, Envelope, Sink, Source
+from onestep.testing import (
+    AcknowledgedSinkHarness,
+    ClaimedSourceHarness,
+    ConnectorCapability,
+    ConnectorConformanceProfile,
+    StopControl,
+    run_acknowledged_sink_contract,
+    run_claimed_source_stop_contract,
+)
+
+
+def test_profile_normalizes_and_freezes_contract_evidence() -> None:
+    contracts = {
+        ConnectorCapability.BASIC_SOURCE: ("test_fetch",),
+        ConnectorCapability.CHECKPOINT_SOURCE: ("test_ack_checkpoint",),
+    }
+
+    profile = ConnectorConformanceProfile(name="  example  ", contracts=contracts)
+    contracts[ConnectorCapability.BASIC_SOURCE] = ("changed",)
+
+    assert profile.name == "example"
+    assert profile.capabilities == {
+        ConnectorCapability.BASIC_SOURCE,
+        ConnectorCapability.CHECKPOINT_SOURCE,
+    }
+    assert profile.contract_ids(ConnectorCapability.BASIC_SOURCE) == ("test_fetch",)
+    assert profile.supports(ConnectorCapability.CHECKPOINT_SOURCE) is True
+
+
+@pytest.mark.parametrize(
+    ("capability", "dependency"),
+    [
+        (ConnectorCapability.CHECKPOINT_SOURCE, ConnectorCapability.BASIC_SOURCE),
+        (ConnectorCapability.CLAIMED_SOURCE, ConnectorCapability.BASIC_SOURCE),
+        (ConnectorCapability.CHUNKED_SINK, ConnectorCapability.ACKNOWLEDGED_SINK),
+        (ConnectorCapability.REPLAY_SAFE_SINK, ConnectorCapability.ACKNOWLEDGED_SINK),
+    ],
+)
+def test_profile_rejects_missing_capability_dependencies(capability, dependency) -> None:
+    with pytest.raises(ValueError, match=f"{capability.value} requires: {dependency.value}"):
+        ConnectorConformanceProfile(name="invalid", contracts={capability: ("test_case",)})
+
+
+@pytest.mark.parametrize(
+    "contracts",
+    [
+        {},
+        {ConnectorCapability.PUBLIC_ERRORS: ()},
+        {ConnectorCapability.PUBLIC_ERRORS: ("",)},
+        {ConnectorCapability.PUBLIC_ERRORS: ("test_error", "test_error")},
+    ],
+)
+def test_profile_rejects_missing_or_invalid_contract_evidence(contracts) -> None:
+    with pytest.raises(ValueError):
+        ConnectorConformanceProfile(name="invalid", contracts=contracts)
+
+
+def test_profile_reports_undeclared_capability() -> None:
+    profile = ConnectorConformanceProfile(
+        name="errors-only",
+        contracts={ConnectorCapability.PUBLIC_ERRORS: ("test_errors",)},
+    )
+
+    with pytest.raises(ValueError, match="does not declare basic_source"):
+        profile.contract_ids(ConnectorCapability.BASIC_SOURCE)
+
+
+@pytest.mark.parametrize("control", list(StopControl))
+def test_claimed_source_runner_covers_each_stop_control(control: StopControl) -> None:
+    async def scenario() -> None:
+        source = _BlockingClaimedSource()
+
+        def assert_released() -> None:
+            assert source.delivery.released is True
+            assert source.delivery.acked is False
+            assert source.delivery.retried is False
+            assert source.delivery.failed is False
+
+        await run_claimed_source_stop_contract(
+            ClaimedSourceHarness(
+                source=source,
+                wait_for_fetch_started=source.fetch_started.wait,
+                release_fetch=source.release_fetch.set,
+                assert_released=assert_released,
+            ),
+            control,
+        )
+
+    asyncio.run(scenario())
+
+
+def test_claimed_source_runner_rejects_cancel_safe_source() -> None:
+    source = _CancelSafeSource("cancel-safe")
+
+    with pytest.raises(AssertionError, match="fetch_is_cancel_safe"):
+        asyncio.run(
+            run_claimed_source_stop_contract(
+                ClaimedSourceHarness(
+                    source=source,
+                    wait_for_fetch_started=lambda: None,
+                    release_fetch=lambda: None,
+                    assert_released=lambda: None,
+                ),
+                StopControl.SHUTDOWN,
+            )
+        )
+
+
+def test_acknowledged_sink_runner_enforces_runtime_ack_ordering() -> None:
+    async def scenario() -> None:
+        sink = _BlockingSink()
+        await run_acknowledged_sink_contract(
+            AcknowledgedSinkHarness(
+                sink=sink,
+                wait_for_send_started=sink.send_started.wait,
+                release_send=sink.release_send.set,
+            ),
+            body={"id": 1},
+        )
+        assert sink.items == [{"id": 1}]
+
+    asyncio.run(scenario())
+
+
+class _RecordingDelivery(Delivery):
+    def __init__(self) -> None:
+        super().__init__(Envelope(body={"id": 1}))
+        self.released = False
+        self.acked = False
+        self.retried = False
+        self.failed = False
+
+    async def release_unstarted(self) -> None:
+        self.released = True
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        self.retried = True
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        self.failed = True
+
+
+class _BlockingClaimedSource(Source):
+    fetch_is_cancel_safe = False
+    poll_interval_s = 0.01
+
+    def __init__(self) -> None:
+        super().__init__("blocking-claimed-source")
+        self.fetch_started = asyncio.Event()
+        self.release_fetch = asyncio.Event()
+        self.delivery = _RecordingDelivery()
+
+    async def fetch(self, limit: int) -> list[Delivery]:
+        self.fetch_started.set()
+        await self.release_fetch.wait()
+        return [self.delivery]
+
+
+class _BlockingSink(Sink):
+    def __init__(self) -> None:
+        super().__init__("blocking-acknowledged-sink")
+        self.send_started = asyncio.Event()
+        self.release_send = asyncio.Event()
+        self.items: list[object] = []
+
+    async def send(self, envelope: Envelope) -> None:
+        self.send_started.set()
+        await self.release_send.wait()
+        self.items.append(envelope.body)
+
+
+class _CancelSafeSource(Source):
+    async def fetch(self, limit: int) -> list[Delivery]:
+        return []

--- a/tests/test_connector_conformance.py
+++ b/tests/test_connector_conformance.py
@@ -10,9 +10,11 @@ from onestep.testing import (
     ClaimedSourceHarness,
     ConnectorCapability,
     ConnectorConformanceProfile,
+    ReplaySafeSinkHarness,
     StopControl,
     run_acknowledged_sink_contract,
     run_claimed_source_stop_contract,
+    run_replay_safe_sink_contract,
 )
 
 
@@ -129,6 +131,25 @@ def test_acknowledged_sink_runner_enforces_runtime_ack_ordering() -> None:
     asyncio.run(scenario())
 
 
+def test_replay_safe_sink_runner_sends_twice_and_requires_one_record() -> None:
+    async def scenario() -> None:
+        sink = _ReplaySafeSink()
+
+        def assert_single_record() -> None:
+            assert sink.records == {"event-1": {"id": "event-1", "value": 3}}
+            assert sink.send_calls == 2
+
+        await run_replay_safe_sink_contract(
+            ReplaySafeSinkHarness(
+                sink=sink,
+                assert_single_record=assert_single_record,
+            ),
+            body={"id": "event-1", "value": 3},
+        )
+
+    asyncio.run(scenario())
+
+
 class _RecordingDelivery(Delivery):
     def __init__(self) -> None:
         super().__init__(Envelope(body={"id": 1}))
@@ -182,3 +203,14 @@ class _BlockingSink(Sink):
 class _CancelSafeSource(Source):
     async def fetch(self, limit: int) -> list[Delivery]:
         return []
+
+
+class _ReplaySafeSink(Sink):
+    def __init__(self) -> None:
+        super().__init__("replay-safe-sink")
+        self.records: dict[str, dict[str, object]] = {}
+        self.send_calls = 0
+
+    async def send(self, envelope: Envelope) -> None:
+        self.send_calls += 1
+        self.records[envelope.body["id"]] = dict(envelope.body)

--- a/uv.lock
+++ b/uv.lock
@@ -1620,7 +1620,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-mysql"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "plugins/onestep-mysql" }
 dependencies = [
     { name = "mysql-replication" },
@@ -1652,7 +1652,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-postgres"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "plugins/onestep-postgres" }
 dependencies = [
     { name = "onestep" },

--- a/uv.lock
+++ b/uv.lock
@@ -1261,7 +1261,7 @@ wheels = [
 
 [[package]]
 name = "onestep"
-version = "1.7.2"
+version = "1.7.3"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1539,7 +1539,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-kafka"
-version = "0.1.2"
+version = "0.1.3"
 source = { directory = "plugins/onestep-kafka" }
 dependencies = [
     { name = "aiokafka", marker = "python_full_version >= '3.10'" },


### PR DESCRIPTION
## Summary

- add a public, pytest-independent `onestep.testing` connector conformance toolkit
- define explicit source, checkpoint, claim-release, acknowledged-sink, chunking, replay-safety, and public-error capabilities
- derive the official connector set from plugin `onestep.resources` entry points and require exact, non-skipped pytest evidence
- adopt shared claimed-source contracts in Kafka, MySQL, and PostgreSQL, plus acknowledged-sink ordering in Kafka
- replace timing sleeps in MySQL/PostgreSQL stop-control tests with deterministic event handshakes

## Official capability evidence

| Connector | Source | Checkpoint | Claim release | Ack sink | Chunked | Replay-safe | Public errors |
| --- | --- | --- | --- | --- | --- | --- | --- |
| ClickHouse |  |  |  | yes | yes |  | yes |
| Elasticsearch / OpenSearch |  |  |  | yes | yes |  | yes |
| Feishu Bitable | yes | yes |  | yes |  | yes | yes |
| Kafka | yes | yes | yes | yes |  |  | yes |
| MongoDB | yes | yes | yes | yes | yes |  | yes |
| MySQL | yes | yes | yes | yes |  |  | yes |
| PostgreSQL | yes | yes | yes | yes |  |  | yes |
| RabbitMQ | yes | yes |  | yes |  |  | yes |
| Redis Streams | yes | yes |  | yes |  |  | yes |
| SQS | yes | yes |  | yes |  |  | yes |

Capabilities are declared only where current tests prove the documented semantics. The shared replay runner is exercised against the MySQL/PostgreSQL SQLite test fallback, but those production dialects are not advertised as replay-safe until live evidence is part of the gate.

## Versions

- `onestep` 1.7.3
- `onestep-kafka` 0.1.3 with `onestep>=1.7.3`
- `onestep-mysql` 0.3.3 with `onestep>=1.7.3`
- `onestep-postgres` 0.1.3 with `onestep>=1.7.3`

## Verification

- reliability matrix: 709 passed, 5 skipped, 7 deselected
- focused conformance and adoption tests: 78 passed
- core, Kafka, MySQL, and PostgreSQL wheel/sdist builds passed
- built wheel metadata verified for package versions and core dependency lower bounds
- `uv lock --check`, `compileall`, and `git diff --check` passed

This is test/runtime-tooling only. It does not add catalog or YAML fields, change runtime delivery semantics, change reporter payloads, or require control-plane coordination.
