### PR TITLE
v1.8.0 feat: add local handler diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Unreleased
 
+## 1.8.0
+
 - Adds `elasticsearch`, `clickhouse`, and `mongodb` optional extras for the three independently published connector plugins.
 - Bundles the three plugins in the worker image and adds isolated reliability/live compatibility gates.
 - Adds a pytest-independent `onestep.testing` connector conformance toolkit without changing runtime, reporter, or control-plane behavior.
+- Adds opt-in, versioned, lossless failure capture with private atomic persistence, redaction, and strict replay identity validation.
+- Adds `onestep task run` and `onestep task replay` for one-attempt local diagnostics with dry-run sink suppression, opt-in real sends, spawned-process isolation, incremental JSON IPC checkpoints, and an overall timeout.
+- Adds capability-based `onestep check --connect`; lifecycle resources are opened and closed while state/cursor stores without `open()` and `close()` are reported as `not_probeable`.
+- Extracts the internal single-delivery executor while preserving production delivery order, retry/dead-letter behavior, public task events, reporter payloads, remote controls, and control-plane protocols.
 
 ## 1.7.3
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,57 @@ own handler, it also retains ownership of root logger levels.
 Direct `app.run()` and `app.serve()` calls do not modify host logging or install
 task event logging. Embedded applications retain full control of process logging.
 
+## Local task diagnostics
+
+Run exactly one task attempt from JSON, or replay a captured failure, without a
+worker or control plane:
+
+```bash
+onestep task run your_package.tasks:app --task sync_billing --input input.json
+onestep task replay your_package.tasks:app --task sync_billing --envelope captures/failure.json
+onestep check your_package.tasks:app --connect
+```
+
+Diagnostics execute the real handler, task hooks, retry decision, and sink
+routing. Sink I/O is suppressed by default; `--send` opens, sends to, and closes
+the selected sinks. Handler and hook code may still perform external side
+effects in either mode. `--timeout` defaults to 60 seconds and is enforced in a
+spawned process, including for synchronously blocked code.
+
+`delivery_action` is always a prediction because source `ack`/`retry`/`fail`
+methods are synthetic. In dry-run, `would_dead_letter` means dead-lettering
+would occur if the configured dead-letter sink publishes successfully. Use
+`--send` to observe that result. A forced timeout during `--send` can leave a
+partial external write and a later retry can duplicate it.
+
+`check --connect` calls `open()` and `close()` only when both methods are
+callable. State/cursor stores without that lifecycle are reported as
+`not_probeable`; the command never calls `load()`, `save()`, or `delete()` as a
+connectivity probe.
+
+Opt-in failure capture makes production envelopes replayable:
+
+```python
+from onestep import FailureCaptureConfig, OneStepApp
+
+app = OneStepApp(
+    "billing-sync",
+    failure_capture=FailureCaptureConfig(
+        directory="captures",
+        mode="terminal",
+        redact_paths=("/body/customer/token",),
+    ),
+)
+```
+
+Capture files are versioned, private, atomically written, and reject lossy
+serialization. `terminal` records only effective terminal failures; `all` also
+records retryable attempts. Common values including datetime, UUID, bytes,
+Decimal, enum, tuple/namedtuple, set, and frozenset round-trip losslessly.
+Unsupported custom values produce an explicit capture error and no file rather
+than a degraded record. See
+[`docs/yaml-task-definition.md`](docs/yaml-task-definition.md) for YAML policy.
+
 ## What it does
 
 | Capability | Where |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -85,6 +85,51 @@ CLI 自行安装 stdout handler 时，解析后的级别同时适用于任意名
 直接调用 `app.run()` 或 `app.serve()` 不会修改宿主进程日志，也不会自动安装
 任务事件 logger；嵌入式应用仍完全控制自己的日志配置。
 
+## 本地任务诊断
+
+无需启动 worker 或控制面，即可用 JSON 执行一次任务，或重放捕获的失败：
+
+```bash
+onestep task run your_package.tasks:app --task sync_billing --input input.json
+onestep task replay your_package.tasks:app --task sync_billing --envelope captures/failure.json
+onestep check your_package.tasks:app --connect
+```
+
+诊断会执行真实的 handler、任务 hooks、重试决策和 sink 路由。默认不调用 sink；
+传入 `--send` 后才会打开、发送并关闭选中的 sink。无论哪种模式，handler 和 hook
+仍可能产生外部副作用。`--timeout` 默认 60 秒，并通过独立子进程限制整体执行
+时间，同步阻塞代码也在限制范围内。
+
+`delivery_action` 始终是预测，因为 source 的 `ack`/`retry`/`fail` 是合成动作。
+dry-run 中的 `would_dead_letter` 表示“若死信 sink 发布成功，则会进入死信”；使用
+`--send` 才能观察实际发布结果。`--send` 过程中被超时强杀，可能留下部分外部
+写入，后续重试也可能产生重复。
+
+`check --connect` 只对同时具有可调用 `open()` 和 `close()` 的资源执行生命周期
+探测。不具备该生命周期的 state/cursor store 会报告为 `not_probeable`；命令不会
+用 `load()`、`save()` 或 `delete()` 进行连接探测。
+
+失败捕获是显式启用的生产能力：
+
+```python
+from onestep import FailureCaptureConfig, OneStepApp
+
+app = OneStepApp(
+    "billing-sync",
+    failure_capture=FailureCaptureConfig(
+        directory="captures",
+        mode="terminal",
+        redact_paths=("/body/customer/token",),
+    ),
+)
+```
+
+捕获文件带版本、使用私有权限并原子写入，且拒绝有损序列化。`terminal` 只记录
+最终有效的终止失败；`all` 还会记录可重试 attempt。datetime、UUID、bytes、
+Decimal、enum、tuple/namedtuple、set 和 frozenset 等常见值可无损往返。遇到不
+支持的自定义值时会明确记录 capture 错误且不生成有损文件。YAML 策略见
+[`docs/yaml-task-definition.md`](docs/yaml-task-definition.md)。
+
 ## 能做什么
 
 | 能力 | 入口 |

--- a/docs/framework-evolution-roadmap.md
+++ b/docs/framework-evolution-roadmap.md
@@ -78,6 +78,10 @@ blocked by test-kit API design.
 
 ## P2: Local Handler Loop
 
+Status: complete in core 1.8.0 after focused feature tests, production delivery
+contracts, the full non-integration suite, and all repository reliability gates
+passed.
+
 Committed CLI surface:
 
 ```text

--- a/docs/framework-evolution-roadmap.md
+++ b/docs/framework-evolution-roadmap.md
@@ -96,9 +96,19 @@ Design constraints:
 - keep YAML as wiring; do not add transform expressions;
 - generate handler tests and fixtures, not reusable business handlers.
 
-The first P2 design must decide whether `run_task_once()` can be generalized or
-whether a separate diagnostic runner is required. It must not overload the
-existing remote manual-run semantics.
+P2 uses a separate diagnostic runner backed by the production single-delivery
+executor. Diagnostics run in a spawned child process with strict versioned JSON
+IPC, a 60-second default overall timeout, incremental checkpoints, and parent
+report synthesis after forced termination. Existing `run_task_once()`, remote
+manual-run semantics, task events, reporter payloads, and control-plane
+protocols remain unchanged.
+
+Connectivity probes are capability-based: only resources with callable
+`open()` and `close()` are probed. State/cursor stores without those methods are
+reported as `not_probeable` and are never tested through data access methods.
+Dry-run dead-letter actions are explicitly predictions; `--send` observes
+publication but accepts the risk of partial or duplicate external writes if the
+child must be forcibly terminated.
 
 ## P3: Delivery Observability
 

--- a/docs/superpowers/plans/2026-07-30-onestep-local-handler-loop.md
+++ b/docs/superpowers/plans/2026-07-30-onestep-local-handler-loop.md
@@ -460,19 +460,19 @@ def encode_value(value: Any, *, _path: str = "") -> Any:
             name=value.name,
             value=encode_value(value.value, _path=_pointer(_path, "value")),
         )
-    if value is None or isinstance(value, (bool, int, str)):
+    if value is None or type(value) in {bool, int, str}:
         return value
-    if isinstance(value, float):
+    if type(value) is float:
         if not math.isfinite(value):
             raise CaptureEncodingError(path=_path, type_name="builtins.float", reason="non-finite float")
         return value
-    if isinstance(value, datetime):
+    if type(value) is datetime:
         return _tag("datetime", value=value.isoformat(), fold=value.fold)
-    if isinstance(value, UUID):
+    if type(value) is UUID:
         return _tag("uuid", value=str(value))
-    if isinstance(value, bytes):
+    if type(value) is bytes:
         return _tag("bytes", value=base64.b64encode(value).decode("ascii"))
-    if isinstance(value, Decimal):
+    if type(value) is Decimal:
         return _tag("decimal", value=str(value))
     if isinstance(value, tuple) and hasattr(type(value), "_fields"):
         cls = type(value)
@@ -484,15 +484,15 @@ def encode_value(value: Any, *, _path: str = "") -> Any:
             fields=list(fields),
             values=[encode_value(item, _path=_pointer(_path, field)) for field, item in zip(fields, value)],
         )
-    if isinstance(value, tuple):
+    if type(value) is tuple:
         return _tag("tuple", values=[encode_value(item, _path=_pointer(_path, str(i))) for i, item in enumerate(value)])
-    if isinstance(value, (set, frozenset)):
+    if type(value) in {set, frozenset}:
         encoded = [encode_value(item, _path=_pointer(_path, "set")) for item in value]
         encoded.sort(key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":"), ensure_ascii=True))
-        return _tag("frozenset" if isinstance(value, frozenset) else "set", values=encoded)
-    if isinstance(value, list):
+        return _tag("frozenset" if type(value) is frozenset else "set", values=encoded)
+    if type(value) is list:
         return [encode_value(item, _path=_pointer(_path, str(i))) for i, item in enumerate(value)]
-    if isinstance(value, dict):
+    if type(value) is dict:
         for key in value:
             if not isinstance(key, str):
                 raise CaptureEncodingError(path=_path, type_name=_type_name(key), reason="mapping keys must be strings")
@@ -501,6 +501,10 @@ def encode_value(value: Any, *, _path: str = "") -> Any:
         return {key: encode_value(item, _path=_pointer(_path, key)) for key, item in value.items()}
     raise CaptureEncodingError(path=_path, type_name=_type_name(value), reason="unsupported value type")
 ```
+
+Plain JSON branches accept exact built-in types only. Reject subclasses of
+supported built-ins unless they use an explicit lossless extension such as enum
+or namedtuple; decoding a custom subtype as its base type is forbidden.
 
 - [ ] **Step 4: Implement strict decoding and type reconstruction**
 
@@ -1488,18 +1492,25 @@ async def check_connectivity(app: OneStepApp, *, timeout_s: float) -> Connectivi
 
 `_probe_entry()` checks `callable(getattr(resource, "open", None))` and
 `callable(getattr(resource, "close", None))`. Unless both are true, return
-`not_probeable` without calling any other method. Wrap open and close separately
-with the same sync-or-awaitable invocation rule as `app._open_resource()`:
+`not_probeable` without calling any other method. Wrap open and close separately.
+Coroutine functions run on the diagnostic event loop. Invoke synchronous
+methods on a dedicated daemon thread and deliver their result through an
+`asyncio.Future`; use `asyncio.wait(..., timeout=timeout_s)` without the default
+executor so event-loop shutdown cannot wait forever for a blocked method. If a
+synchronous method returns an awaitable, await it with the remaining operation
+budget:
 
 ```python
-async def _invoke_lifecycle(method: Callable[[], Any]) -> None:
-    result = method()
-    if inspect.isawaitable(result):
-        await result
+async def _invoke_lifecycle(
+    method: Callable[[], Any],
+    *,
+    timeout_s: float,
+) -> None:
+    ...
 ```
 
-Call `await asyncio.wait_for(_invoke_lifecycle(method), timeout_s)` and always
-attempt bounded close once open
+Call `await _invoke_lifecycle(method, timeout_s=timeout_s)` and always attempt
+bounded close once open
 was invoked. Continue inventory after all failures. Do not call app hooks,
 fetch, send, `load`, `save`, or `delete`.
 
@@ -1702,7 +1713,10 @@ so enum/namedtuple types are already importable.
 entered/completed checkpoints, loads Python or YAML targets in the child,
 validates replay identity through `load_capture(capture_path,
 expected_app=app.name, expected_task=request.task)`, and invokes
-`DiagnosticRunner`. A daemon control thread blocks on `control_rx.recv_bytes()`,
+`DiagnosticRunner`. Target, request, capture, and exact task-name validation
+occur only in this child. Validation exceptions produce a valid final report
+with `completion="validation_failed"`; execution exceptions after validation
+produce `child_failed`. A daemon control thread blocks on `control_rx.recv_bytes()`,
 validates only `cancel`, and calls `loop.call_soon_threadsafe(task.cancel)`.
 Every child status write is
 `status_tx.send_bytes(encode_frame(kind, sequence=sequence, payload=payload))`;
@@ -1822,7 +1836,13 @@ to parse as exactly one object. Parameterize exit mapping:
 ```python
 @pytest.mark.parametrize(
     "completion,expected",
-    [("succeeded", 0), ("failed", 1), ("timed_out", 1), ("child_failed", 1)],
+    [
+        ("succeeded", 0),
+        ("failed", 1),
+        ("timed_out", 1),
+        ("child_failed", 1),
+        ("validation_failed", 2),
+    ],
 )
 def test_task_exit_codes(completion, expected) -> None:
     report = make_diagnostic_report(completion=completion)
@@ -1875,9 +1895,10 @@ if argv[0].startswith("-") or argv[0] in {
 Before loading an app in `main()`, branch `args.command == "task"`. Read input
 JSON in the parent only to validate it, construct a versioned request for the
 child, call `supervise_diagnostic()`, then render the returned report. Replay
-uses `load_capture()` for early schema/identity validation after resolving the
-target identity, sends `capture_path` rather than a decoded envelope in the
-request, and lets the child repeat validation before execution. Print the
+sends `capture_path` rather than a decoded envelope and performs target loading,
+capture decoding, identity checks, and task validation only in the supervised
+child. This keeps import side effects single-shot and inside the overall
+deadline. Print the
 side-effect warning to stderr for both dry-run and send modes; JSON stdout must
 contain only `json.dumps(report.to_dict(), indent=2)`.
 
@@ -1895,15 +1916,21 @@ Use one `_diagnostic_exit_code()` and one `_connectivity_exit_code()`:
 
 ```python
 def _diagnostic_exit_code(report: DiagnosticReport) -> int:
-    return 0 if report.completion == "succeeded" else 1
+    if report.completion == "succeeded":
+        return 0
+    if report.completion == "validation_failed":
+        return 2
+    return 1
 
 
 def _connectivity_exit_code(report: ConnectivityReport) -> int:
     return 0 if report.ok else 1
 ```
 
-Validation exceptions are caught before these helpers and return `2` with an
-`onestep:` error on stderr. Human diagnostic output includes operation, target,
+Parent-side input/argument validation exceptions return `2`. Child-side target,
+capture, identity, and task validation returns a complete
+`validation_failed` report, which this helper maps to `2`; child validation
+diagnostics remain on stderr. Human diagnostic output includes operation, target,
 app/task, mode, completion, failure stage, selected sinks, predicted delivery
 action, dead-letter attempted/published, cleanup, side-effect outcome, last
 checkpoint, duration, and warning. Human connectivity output prints every

--- a/docs/superpowers/plans/2026-07-30-onestep-local-handler-loop.md
+++ b/docs/superpowers/plans/2026-07-30-onestep-local-handler-loop.md
@@ -1,0 +1,2071 @@
+# onestep Local Handler Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add safe local task run/replay diagnostics, capability-based connectivity checks, and opt-in lossless failure capture without changing production delivery, remote-control, reporter, or Control Plane contracts.
+
+**Architecture:** Extract one-delivery behavior from `TaskRunner` into an internal `DeliveryExecutor` with injected event, sink, delivery-action, checkpoint, and capture collaborators. Build diagnostics as a separate package: an in-child `DiagnosticRunner`, a connectivity checker, a versioned JSON-over-pipe IPC layer, and a parent supervisor that enforces the overall timeout. Keep capture persistence in a focused package with public configuration and internal codec/writer modules.
+
+**Tech Stack:** Python 3.9+, asyncio, multiprocessing `spawn`, standard-library JSON/filesystem primitives, argparse, pytest, pytest-asyncio, uv workspace
+
+---
+
+## File Map
+
+- Create `src/onestep/capture/__init__.py`: capture package exports.
+- Create `src/onestep/capture/config.py`: public `FailureCaptureConfig` validation.
+- Create `src/onestep/capture/codec.py`: collision-safe lossless value encoding and decoding.
+- Create `src/onestep/capture/writer.py`: redaction, versioned capture validation, private atomic persistence, and replay loading.
+- Create `src/onestep/runtime/executor.py`: internal single-delivery execution and production-compatible collaborators.
+- Modify `src/onestep/runtime/runner.py`: retain polling and runner state; delegate `_handle_delivery()` to `DeliveryExecutor`.
+- Modify `src/onestep/app.py`: accept failure-capture policy and preserve `run_task_once()` behavior through the delegated runner path.
+- Modify `src/onestep/config.py`: build and strictly validate `app.failure_capture`.
+- Modify `src/onestep/__init__.py`: export only the stable `FailureCaptureConfig` addition.
+- Create `src/onestep/diagnostics/__init__.py`: internal diagnostic package marker.
+- Create `src/onestep/diagnostics/models.py`: diagnostic request/result/checkpoint models and report serialization.
+- Create `src/onestep/diagnostics/runner.py`: synthetic delivery, dry-run/send policies, local events, and sink cleanup.
+- Create `src/onestep/diagnostics/connectivity.py`: resource inventory and capability-based lifecycle probes.
+- Create `src/onestep/diagnostics/ipc.py`: private versioned JSON frame encoding/validation.
+- Create `src/onestep/diagnostics/targets.py`: shared Python/YAML target loading and local import-path setup for parent and child.
+- Create `src/onestep/diagnostics/worker.py`: spawned child entry point and cooperative cancellation bridge.
+- Create `src/onestep/diagnostics/supervisor.py`: parent process deadline, checkpoint retention, termination, and report synthesis.
+- Modify `src/onestep/cli.py`: nested `task` parsers, argv normalization, `check --connect`, supervision calls, rendering, and exit codes.
+- Create `tests/test_failure_capture.py`: config, codec, redaction, writer, and replay validation tests.
+- Create `tests/test_diagnostics.py`: executor adapters, diagnostic runner, connectivity, IPC, and supervisor tests.
+- Create `tests/assets/diagnostic_app.py`: importable Python target for real spawned-process tests.
+- Modify `tests/contract/test_runtime_contract.py`: characterize production behavior before and after extraction and cover capture timing.
+- Modify `tests/test_cli.py`: parser, normalization, command, report, and exit-code coverage.
+- Modify `tests/test_config_env.py`: strict YAML failure-capture validation.
+- Modify `tests/test_packaging.py`: stable export coverage for `FailureCaptureConfig`.
+- Modify `README.md` and `README.zh-CN.md`: local loop, timeout, side effects, capture, and connectivity documentation.
+- Modify `docs/yaml-task-definition.md`: `app.failure_capture` schema and supported capture values.
+- Modify `docs/framework-evolution-roadmap.md`: mark P2 complete only after all gates pass.
+- Modify `CHANGELOG.md`, `pyproject.toml`, and `uv.lock`: prepare core `1.8.0` release metadata.
+
+## Task 1: Lock Existing Production Delivery Semantics
+
+**Files:**
+- Modify: `tests/contract/test_runtime_contract.py`
+
+- [ ] **Step 1: Add an explicit success-order characterization test**
+
+Add a local delivery and sink that append to one ordered list, then invoke the
+current compatibility entry point directly:
+
+```python
+def test_single_delivery_success_order_is_stable_contract() -> None:
+    class RecordingDelivery(Delivery):
+        def __init__(self, steps: list[str]) -> None:
+            super().__init__(Envelope(body={"value": 2}, meta={"trace": "t-1"}))
+            self.steps = steps
+
+        async def start_processing(self) -> None:
+            self.steps.append("start_processing")
+
+        async def ack(self) -> None:
+            self.steps.append("ack")
+
+        async def retry(self, *, delay_s: float | None = None) -> None:
+            self.steps.append("retry")
+
+        async def fail(self, exc: Exception | None = None) -> None:
+            self.steps.append("fail")
+
+    class RecordingSink(Sink):
+        def __init__(self, steps: list[str]) -> None:
+            super().__init__("recording")
+            self.steps = steps
+
+        async def send(self, envelope: Envelope) -> None:
+            assert envelope.body == {"value": 4}
+            self.steps.append("sink")
+
+    async def scenario() -> None:
+        steps: list[str] = []
+        app = OneStepApp("execution-order")
+        sink = RecordingSink(steps)
+
+        @app.on_event
+        def event(event):
+            steps.append(f"event:{event.kind.value}")
+
+        async def before(ctx, payload):
+            steps.append("before")
+
+        async def after(ctx, payload, result):
+            steps.append("after_success")
+
+        @app.task(emit=sink, hooks=TaskHooks(before=(before,), after_success=(after,)))
+        async def consume(ctx, payload):
+            steps.append("handler")
+            return {"value": payload["value"] * 2}
+
+        await TaskRunner(app, app.tasks[0])._handle_delivery(RecordingDelivery(steps))
+
+        assert steps == [
+            "start_processing",
+            "event:started",
+            "before",
+            "handler",
+            "after_success",
+            "sink",
+            "ack",
+            "event:succeeded",
+        ]
+
+    asyncio.run(scenario())
+```
+
+Import `TaskHooks` and `TaskRunner` from their current modules at the top of the
+test file.
+
+- [ ] **Step 2: Add a fallback-retry characterization test**
+
+Add a delivery whose `fail()` raises and whose `retry()` records the fallback.
+Use `NoRetry()` and a successful dead-letter sink; assert event order remains
+`started`, `dead_lettered`, `failed`, while the delivery action order is
+`fail`, `retry`. This deliberately locks the current public event semantics even
+though the terminal classification used by capture must be non-terminal.
+
+- [ ] **Step 3: Run the characterization slice**
+
+```bash
+uv run pytest tests/contract/test_runtime_contract.py -k 'single_delivery_success_order or fail_action_fallback' -v
+```
+
+Expected: both tests pass against the pre-refactor runtime.
+
+- [ ] **Step 4: Commit the contract tests**
+
+```bash
+git add tests/contract/test_runtime_contract.py
+git commit -m "test: characterize single delivery execution"
+```
+
+## Task 2: Add Failure Capture Configuration
+
+**Files:**
+- Create: `src/onestep/capture/__init__.py`
+- Create: `src/onestep/capture/config.py`
+- Modify: `src/onestep/app.py`
+- Modify: `src/onestep/config.py`
+- Modify: `src/onestep/__init__.py`
+- Test: `tests/test_failure_capture.py`
+- Test: `tests/test_config_env.py`
+- Test: `tests/test_packaging.py`
+
+- [ ] **Step 1: Write failing Python and YAML configuration tests**
+
+Create `tests/test_failure_capture.py` with:
+
+```python
+from pathlib import Path
+
+import pytest
+
+from onestep import FailureCaptureConfig
+from onestep.config import load_app_config
+
+
+def test_failure_capture_config_normalizes_values(tmp_path: Path) -> None:
+    config = FailureCaptureConfig(
+        directory=tmp_path / "captures",
+        mode="all",
+        max_bytes=2048,
+        redact_paths=("/body/password",),
+    )
+    assert config.directory == tmp_path / "captures"
+    assert config.mode == "all"
+    assert config.max_bytes == 2048
+    assert config.redact_paths == ("/body/password",)
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"mode": "sometimes"}, "mode must be 'terminal' or 'all'"),
+        ({"max_bytes": 0}, "max_bytes must be >= 1"),
+        ({"redact_paths": ("body/password",)}, "JSON Pointer"),
+        ({"redact_paths": ("",)}, "JSON Pointer"),
+    ],
+)
+def test_failure_capture_config_rejects_invalid_values(kwargs, match) -> None:
+    with pytest.raises((TypeError, ValueError), match=match):
+        FailureCaptureConfig(directory="captures", **kwargs)
+
+
+def test_yaml_app_builds_failure_capture_config(tmp_path: Path) -> None:
+    app = load_app_config(
+        {
+            "app": {
+                "name": "capture-yaml",
+                "failure_capture": {
+                    "directory": str(tmp_path / "captures"),
+                    "mode": "terminal",
+                    "max_bytes": 4096,
+                    "redact_paths": ["/body/token"],
+                },
+            },
+            "tasks": [],
+        },
+        strict=True,
+    )
+    assert app.failure_capture == FailureCaptureConfig(
+        directory=tmp_path / "captures",
+        mode="terminal",
+        max_bytes=4096,
+        redact_paths=("/body/token",),
+    )
+```
+
+Add strict-YAML cases to `tests/test_config_env.py` for an unknown nested field,
+non-string directory, invalid mode, non-positive max bytes, and non-list
+`redact_paths`. Add `FailureCaptureConfig` to the public export assertion in
+`tests/test_packaging.py`.
+
+- [ ] **Step 2: Run the focused tests and confirm missing API/schema failures**
+
+```bash
+uv run pytest tests/test_failure_capture.py tests/test_config_env.py tests/test_packaging.py -k 'failure_capture or public_api' -v
+```
+
+Expected: collection fails because `FailureCaptureConfig` is not exported.
+
+- [ ] **Step 3: Implement the validated config type**
+
+Create `src/onestep/capture/config.py`:
+
+```python
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+CaptureMode = Literal["terminal", "all"]
+
+
+@dataclass(frozen=True)
+class FailureCaptureConfig:
+    directory: Path | str
+    mode: CaptureMode = "terminal"
+    max_bytes: int = 1_048_576
+    redact_paths: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.directory, (str, Path)):
+            raise TypeError("failure_capture.directory must be a path string")
+        if self.mode not in {"terminal", "all"}:
+            raise ValueError("failure_capture.mode must be 'terminal' or 'all'")
+        if isinstance(self.max_bytes, bool) or not isinstance(self.max_bytes, int):
+            raise TypeError("failure_capture.max_bytes must be an integer")
+        if self.max_bytes < 1:
+            raise ValueError("failure_capture.max_bytes must be >= 1")
+        paths = tuple(self.redact_paths)
+        for path in paths:
+            if not isinstance(path, str) or not path.startswith("/"):
+                raise ValueError("failure_capture.redact_paths entries must be JSON Pointer paths")
+        object.__setattr__(self, "directory", Path(self.directory))
+        object.__setattr__(self, "redact_paths", paths)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "FailureCaptureConfig":
+        allowed = {"directory", "mode", "max_bytes", "redact_paths"}
+        unknown = sorted(set(value) - allowed)
+        if unknown:
+            raise ValueError("unsupported fields for app.failure_capture: " + ", ".join(unknown))
+        if "directory" not in value:
+            raise ValueError("app.failure_capture.directory is required")
+        paths = value.get("redact_paths", ())
+        if not isinstance(paths, (list, tuple)) or isinstance(paths, (str, bytes)):
+            raise TypeError("app.failure_capture.redact_paths must be a list")
+        return cls(
+            directory=value["directory"],
+            mode=value.get("mode", "terminal"),
+            max_bytes=value.get("max_bytes", 1_048_576),
+            redact_paths=tuple(paths),
+        )
+```
+
+Export it from `src/onestep/capture/__init__.py` and `src/onestep/__init__.py`.
+Add keyword-only `failure_capture: FailureCaptureConfig | None = None` to
+`OneStepApp.__init__` and assign `self.failure_capture`.
+
+- [ ] **Step 4: Wire and strictly validate YAML**
+
+Add `failure_capture` to `_STRICT_APP_FIELDS`. In `load_app_config()`, resolve:
+
+```python
+raw_failure_capture = app_section.get("failure_capture") if app_section is not None else None
+failure_capture = None
+if raw_failure_capture is not None:
+    if not isinstance(raw_failure_capture, Mapping):
+        raise TypeError("'app.failure_capture' must be a mapping")
+    failure_capture = FailureCaptureConfig.from_mapping(raw_failure_capture)
+
+app = OneStepApp(
+    app_name,
+    config=dict(app_config),
+    shutdown_timeout_s=shutdown_timeout_s,
+    failure_capture=failure_capture,
+)
+```
+
+Call the same mapping validation from strict validation so `check --strict`
+fails before app construction.
+
+- [ ] **Step 5: Run config and export tests**
+
+```bash
+uv run pytest tests/test_failure_capture.py tests/test_config_env.py tests/test_packaging.py -k 'failure_capture or public_api' -v
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 6: Commit configuration support**
+
+```bash
+git add src/onestep/capture src/onestep/app.py src/onestep/config.py src/onestep/__init__.py tests/test_failure_capture.py tests/test_config_env.py tests/test_packaging.py
+git commit -m "feat: configure failure capture"
+```
+
+## Task 3: Implement The Lossless Capture Codec
+
+**Files:**
+- Create: `src/onestep/capture/codec.py`
+- Modify: `src/onestep/capture/__init__.py`
+- Test: `tests/test_failure_capture.py`
+
+- [ ] **Step 1: Write codec round-trip and rejection tests**
+
+Define module-level test types so they are importable during decode:
+
+```python
+from collections import namedtuple
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import Enum
+from uuid import UUID
+
+from onestep.capture.codec import CaptureEncodingError, decode_value, encode_value
+
+
+class CaptureStatus(Enum):
+    READY = ("ready", 1)
+
+
+CapturePoint = namedtuple("CapturePoint", "x y")
+
+
+def test_capture_codec_round_trips_supported_values() -> None:
+    value = {
+        "at": datetime(2026, 7, 30, 9, 15, tzinfo=timezone.utc),
+        "id": UUID("d78e3d0d-13e1-44ef-96a5-10bd28fc882d"),
+        "raw": b"\x00\xff",
+        "amount": Decimal("-0.0100"),
+        "tuple": (1, "x"),
+        "enum": CaptureStatus.READY,
+        "point": CapturePoint(2, 3),
+        "set": {"b", "a"},
+        "frozen": frozenset({2, 1}),
+        "$onestep": {"type": "user-data"},
+    }
+    assert decode_value(encode_value(value)) == value
+
+
+def test_capture_codec_orders_sets_deterministically() -> None:
+    assert encode_value({"b", "a", "c"}) == encode_value({"c", "b", "a"})
+
+
+def test_capture_codec_rejects_custom_values_without_repr() -> None:
+    class SecretObject:
+        def __repr__(self) -> str:
+            return "token=do-not-log"
+
+    with pytest.raises(CaptureEncodingError) as captured:
+        encode_value({"nested": [SecretObject()]})
+    assert captured.value.path == "/nested/0"
+    assert captured.value.type_name.endswith("SecretObject")
+    assert "do-not-log" not in str(captured.value)
+```
+
+Create `test_capture_codec_rejects_unknown_tag()`,
+`test_capture_codec_rejects_unloaded_enum_module()`,
+`test_capture_codec_rejects_changed_enum_value()`,
+`test_capture_codec_rejects_local_namedtuple()`,
+`test_capture_codec_rejects_non_string_mapping_key()`, and
+`test_capture_codec_rejects_non_finite_float()`. Each uses
+`pytest.raises(CaptureEncodingError, match=...)` for encode errors or
+`pytest.raises(ValueError, match=...)` for decode errors; every message asserts
+the safe pointer/type and explicitly asserts secret test values are absent.
+
+- [ ] **Step 2: Run tests and confirm the missing codec failure**
+
+```bash
+uv run pytest tests/test_failure_capture.py -k capture_codec -v
+```
+
+Expected: import fails because `onestep.capture.codec` does not exist.
+
+- [ ] **Step 3: Implement collision-safe tagged encoding**
+
+Create `src/onestep/capture/codec.py`. Use `$onestep` only for extension nodes;
+ordinary dictionaries containing that key are escaped as a tagged mapping:
+
+```python
+from __future__ import annotations
+
+import base64
+import json
+import math
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+TAG = "$onestep"
+
+
+class CaptureEncodingError(ValueError):
+    def __init__(self, *, path: str, type_name: str, reason: str) -> None:
+        self.path = path or "/"
+        self.type_name = type_name
+        self.reason = reason
+        super().__init__(f"cannot encode {type_name} at {self.path}: {reason}")
+
+
+def _type_name(value: Any) -> str:
+    cls = type(value)
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _pointer(path: str, token: str) -> str:
+    escaped = token.replace("~", "~0").replace("/", "~1")
+    return f"{path}/{escaped}"
+
+
+def _tag(type_name: str, **fields: Any) -> dict[str, Any]:
+    return {TAG: {"type": type_name, **fields}}
+
+
+def encode_value(value: Any, *, _path: str = "") -> Any:
+    if isinstance(value, Enum):
+        cls = type(value)
+        return _tag(
+            "enum",
+            module=cls.__module__,
+            qualname=cls.__qualname__,
+            name=value.name,
+            value=encode_value(value.value, _path=_pointer(_path, "value")),
+        )
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise CaptureEncodingError(path=_path, type_name="builtins.float", reason="non-finite float")
+        return value
+    if isinstance(value, datetime):
+        return _tag("datetime", value=value.isoformat(), fold=value.fold)
+    if isinstance(value, UUID):
+        return _tag("uuid", value=str(value))
+    if isinstance(value, bytes):
+        return _tag("bytes", value=base64.b64encode(value).decode("ascii"))
+    if isinstance(value, Decimal):
+        return _tag("decimal", value=str(value))
+    if isinstance(value, tuple) and hasattr(type(value), "_fields"):
+        cls = type(value)
+        fields = tuple(getattr(cls, "_fields"))
+        return _tag(
+            "namedtuple",
+            module=cls.__module__,
+            qualname=cls.__qualname__,
+            fields=list(fields),
+            values=[encode_value(item, _path=_pointer(_path, field)) for field, item in zip(fields, value)],
+        )
+    if isinstance(value, tuple):
+        return _tag("tuple", values=[encode_value(item, _path=_pointer(_path, str(i))) for i, item in enumerate(value)])
+    if isinstance(value, (set, frozenset)):
+        encoded = [encode_value(item, _path=_pointer(_path, "set")) for item in value]
+        encoded.sort(key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":"), ensure_ascii=True))
+        return _tag("frozenset" if isinstance(value, frozenset) else "set", values=encoded)
+    if isinstance(value, list):
+        return [encode_value(item, _path=_pointer(_path, str(i))) for i, item in enumerate(value)]
+    if isinstance(value, dict):
+        for key in value:
+            if not isinstance(key, str):
+                raise CaptureEncodingError(path=_path, type_name=_type_name(key), reason="mapping keys must be strings")
+        if TAG in value:
+            return _tag("mapping", items=[[key, encode_value(item, _path=_pointer(_path, key))] for key, item in value.items()])
+        return {key: encode_value(item, _path=_pointer(_path, key)) for key, item in value.items()}
+    raise CaptureEncodingError(path=_path, type_name=_type_name(value), reason="unsupported value type")
+```
+
+- [ ] **Step 4: Implement strict decoding and type reconstruction**
+
+In the same module, add `_resolve_loaded_type()` that rejects `<locals>`, requires
+the module to already exist in `sys.modules`, walks `qualname`, and verifies the
+resolved object is a type. Implement `decode_value()` for every tag above. For
+enum, require `issubclass(cls, Enum)`, resolve by recorded member name, and
+compare its value with the decoded recorded value. For namedtuple, require
+`tuple(cls._fields) == tuple(recorded_fields)` before construction. Reject extra
+tag fields rather than silently accepting malformed captures.
+
+Use the exact public signature `decode_value(value: Any, *, _path: str = "") ->
+Any` and export list `__all__ = ["CaptureEncodingError", "decode_value",
+"encode_value"]`.
+
+- [ ] **Step 5: Run codec tests**
+
+```bash
+uv run pytest tests/test_failure_capture.py -k capture_codec -v
+```
+
+Expected: all codec tests pass, including deterministic output and safe errors.
+
+- [ ] **Step 6: Commit the codec**
+
+```bash
+git add src/onestep/capture tests/test_failure_capture.py
+git commit -m "feat: add lossless capture codec"
+```
+
+## Task 4: Add Redacted Private Capture Persistence And Replay Loading
+
+**Files:**
+- Create: `src/onestep/capture/writer.py`
+- Modify: `src/onestep/capture/__init__.py`
+- Test: `tests/test_failure_capture.py`
+
+- [ ] **Step 1: Write redaction and writer failure tests**
+
+Create named tests `test_redaction_is_recursive_and_case_insensitive()`,
+`test_redaction_pointer_navigates_lists()`,
+`test_redaction_missing_pointer_is_a_noop()`,
+`test_capture_writer_uses_private_permissions()`,
+`test_capture_writer_cleans_temp_after_replace_failure()`,
+`test_capture_writer_retries_random_name_collision()`,
+`test_capture_writer_rejects_max_bytes_before_destination_open()`,
+`test_capture_writer_surfaces_disk_error_without_partial_file()`, and
+`test_capture_writer_rejects_symlink_component_and_target()`. The main success
+test and exact permission assertions are:
+
+```python
+def test_capture_writer_redacts_and_round_trips(tmp_path: Path) -> None:
+    writer = FailureCaptureWriter(
+        FailureCaptureConfig(
+            directory=tmp_path / "captures",
+            redact_paths=("/body/customer/card",),
+        )
+    )
+    envelope = Envelope(
+        body={"password": "p", "customer": {"card": "4111", "amount": Decimal("1.20")}},
+        meta={"Authorization": "Bearer secret", "trace": "t-1"},
+        attempts=2,
+    )
+
+    path = asyncio.run(
+        writer.write(
+            app="billing",
+            task="sync",
+            stage="handler",
+            terminal=True,
+            failure=FailureInfo(FailureKind.ERROR, "ValueError", "bad row"),
+            envelope=envelope,
+        )
+    )
+    capture = load_capture(path)
+    assert capture.envelope.body == {
+        "password": "<redacted>",
+        "customer": {"card": "<redacted>", "amount": Decimal("1.20")},
+    }
+    assert capture.envelope.meta == {"Authorization": "<redacted>", "trace": "t-1"}
+    assert set(capture.redacted_paths) == {
+        "/body/password",
+        "/body/customer/card",
+        "/meta/Authorization",
+    }
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert path.parent.stat().st_mode & 0o077 == 0
+```
+
+Use `load_capture(path, expected_app="billing", expected_task="sync")` in the
+success test, then assert `expected_app="other"` and `expected_task="other"`
+each raise `ValueError` containing both expected and captured identities.
+
+- [ ] **Step 2: Run writer tests and confirm missing symbols**
+
+```bash
+uv run pytest tests/test_failure_capture.py -k 'capture_writer or load_capture' -v
+```
+
+Expected: imports fail because the writer module is absent.
+
+- [ ] **Step 3: Implement the versioned capture model and redaction**
+
+Create `src/onestep/capture/writer.py` with frozen `LoadedCapture`, constants
+`CAPTURE_SCHEMA = "onestep/envelope-capture"` and `CAPTURE_VERSION = 1`, and:
+
+```python
+_REDACTED = "<redacted>"
+_SECRET_KEYS = {
+    "password", "passwd", "secret", "token", "authorization", "cookie",
+    "api_key", "apikey", "dsn", "database_url", "connection_string",
+}
+
+
+@dataclass(frozen=True)
+class LoadedCapture:
+    app: str
+    task: str
+    stage: str
+    terminal: bool
+    failure: dict[str, Any]
+    envelope: Envelope
+    redacted_paths: tuple[str, ...]
+
+
+def redact_envelope(envelope: Envelope, pointers: tuple[str, ...]) -> tuple[Envelope, tuple[str, ...]]:
+    logical = {"body": copy.deepcopy(envelope.body), "meta": copy.deepcopy(envelope.meta)}
+    redacted: set[str] = set()
+    logical = _redact_secret_keys(logical, path="", redacted=redacted)
+    for pointer in pointers:
+        if _replace_pointer(logical, pointer, _REDACTED):
+            redacted.add(pointer)
+    return (
+        Envelope(body=logical["body"], meta=logical["meta"], attempts=envelope.attempts),
+        tuple(sorted(redacted)),
+    )
+```
+
+Normalize secret keys with `key.casefold().replace("-", "_")`. Decode JSON
+Pointer `~0` and `~1`, accept dictionary keys and integer list/tuple indices, and
+treat missing paths as no-ops. Preserve tuple/namedtuple/set container types
+while recursively redacting built-in keys.
+
+- [ ] **Step 4: Implement secure atomic writing**
+
+Implement `FailureCaptureWriter.write()` as an async `asyncio.to_thread()`
+wrapper around `_write_sync()`. `_write_sync()` must:
+
+1. reject any existing symlink component with `os.lstat()`;
+2. create the directory with mode `0700`, then `chmod(0700)` only when newly created;
+3. redact before encoding;
+4. encode `body` and `meta` with `encode_value()`;
+5. serialize the capture document with
+   `json.dumps(document, ensure_ascii=False, sort_keys=True, indent=2)`;
+6. reject UTF-8 output larger than `max_bytes` before opening a destination;
+7. create a random same-directory temporary file with
+   `flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)`
+   and `os.open(temp_path, flags, 0o600)`; when `O_NOFOLLOW` is unavailable,
+   immediately verify `os.fstat(fd)` is a regular file and verify the path with
+   `os.lstat(temp_path)` refers to the same `(st_dev, st_ino)` before writing;
+8. flush and `fsync()`, reject an existing/symlink final path, then `os.replace()`;
+9. unlink the temporary file in `finally`.
+
+Use filenames `<UTC YYYYmmddTHHMMSSffffffZ>-<uuid4 hex>.json`; never derive a
+name from app, task, payload, or exception data.
+
+- [ ] **Step 5: Implement strict replay loading**
+
+`load_capture()` must parse JSON, require exact schema/version, decode body and
+meta, require non-negative integer attempts, validate all required scalar
+fields, and reject app/task mismatches with messages containing expected and
+received identities. It must return `LoadedCapture`, never an `Envelope`
+subclass.
+
+- [ ] **Step 6: Run capture persistence tests**
+
+```bash
+uv run pytest tests/test_failure_capture.py -k 'capture_writer or redacts or load_capture or symlink or atomic' -v
+```
+
+The persisted document has exactly the design's keys: schema, version,
+UTC `captured_at`, app, task, stage, terminal, failure, envelope, and
+redacted_paths. Persist only failure `kind`, `exception_type`, and `message`;
+do not persist `FailureInfo.traceback`. The envelope object contains encoded
+body/meta and the original non-negative attempts.
+
+Expected: all selected tests pass.
+
+- [ ] **Step 7: Commit capture persistence**
+
+```bash
+git add src/onestep/capture tests/test_failure_capture.py
+git commit -m "feat: persist redacted failure captures"
+```
+
+## Task 5: Extract The Production Delivery Executor
+
+**Files:**
+- Create: `src/onestep/runtime/executor.py`
+- Modify: `src/onestep/runtime/runner.py`
+- Test: `tests/contract/test_runtime_contract.py`
+
+- [ ] **Step 1: Add a delegation contract test**
+
+Monkeypatch `onestep.runtime.runner.DeliveryExecutor` with a fake whose
+`execute()` records the delivery. Assert `TaskRunner._handle_delivery()` calls it
+once and still returns `None`. Keep the production characterization tests from
+Task 1 unchanged.
+
+- [ ] **Step 2: Run the delegation test and confirm the missing executor**
+
+```bash
+uv run pytest tests/contract/test_runtime_contract.py -k delivery_executor_delegation -v
+```
+
+Expected: fail because `DeliveryExecutor` is not imported by `runner.py`.
+
+- [ ] **Step 3: Create executor result and collaborator types**
+
+Create `src/onestep/runtime/executor.py` with these internal types:
+
+```python
+class DeliveryAction(str, Enum):
+    ACK = "ack"
+    RETRY = "retry"
+    DEAD_LETTER = "dead_letter"
+    FAIL = "fail"
+
+
+@dataclass
+class ExecutionOutcome:
+    completion: str
+    handler_result: Any = None
+    selected_sinks: list[str] = field(default_factory=list)
+    delivery_action: DeliveryAction | None = None
+    retry_delay_s: float | None = None
+    failure: FailureInfo | None = None
+    public_failure: dict[str, str] | None = None
+    failure_stage: str | None = None
+    dead_letter_attempted: bool = False
+    dead_letter_published: bool | None = None
+    terminal: bool = False
+
+
+EventEmitter = Callable[[TaskEvent], Awaitable[None]]
+SinkDispatcher = Callable[[Sink, Envelope, str], Awaitable[bool]]
+Checkpoint = Callable[[str, str, Mapping[str, Any]], Awaitable[None]]
+```
+
+`SinkDispatcher` returns `True` when a real send occurred and `False` when a
+diagnostic policy suppressed it; it raises on send failure. Use a no-op async
+checkpoint by default.
+
+When `_handle_failure()` receives the original exception, set
+`outcome.public_failure` with only `exception_type` and `failure_kind`. For
+`ConnectorOperationError`, add its normalized `backend`, `operation`, and
+`connector_kind`; never copy `str(exc)`, traceback, payload, DSN, or credentials
+into this public diagnostic field.
+
+- [ ] **Step 4: Move single-delivery behavior without semantic edits**
+
+Implement:
+
+```python
+class DeliveryExecutor:
+    _SEND_ATTEMPTS = 2
+
+    def __init__(
+        self,
+        app: "OneStepApp",
+        task: TaskSpec,
+        *,
+        emit_event: EventEmitter | None = None,
+        dispatch_sink: SinkDispatcher | None = None,
+        apply_delivery_actions: bool = True,
+        checkpoint: Checkpoint | None = None,
+    ) -> None:
+        self.app = app
+        self.task = task
+        self.emit_event = emit_event or app.emit_event
+        self.dispatch_sink = dispatch_sink or self._dispatch_production_sink
+        self.apply_delivery_actions = apply_delivery_actions
+        self.checkpoint = checkpoint or _noop_checkpoint
+        self.logger = logging.getLogger(f"onestep.{app.name}.{task.name}")
+
+    async def execute(self, delivery: Delivery) -> ExecutionOutcome:
+        outcome = ExecutionOutcome(completion="running")
+        ctx = TaskContext(app=self.app, task=self.task, delivery=delivery)
+        started_at = time.perf_counter()
+        active_stage = "delivery_action"
+        try:
+            await delivery.start_processing()
+            await self._emit(TaskEventKind.STARTED, delivery)
+            active_stage = "before_hook"
+            await self.checkpoint("before_hook", "entered", {})
+            await self._run_hooks(self.task.hooks.before, ctx, delivery.payload)
+            await self.checkpoint("before_hook", "completed", {})
+            active_stage = "handler"
+            await self.checkpoint("handler", "entered", {})
+            outcome.handler_result = await self._invoke_handler(ctx, delivery)
+            await self.checkpoint("handler", "completed", {})
+            active_stage = "after_success_hook"
+            await self.checkpoint("after_success_hook", "entered", {})
+            await self._run_hooks(self.task.hooks.after_success, ctx, delivery.payload, outcome.handler_result)
+            await self.checkpoint("after_success_hook", "completed", {})
+            if outcome.handler_result is not None and self.task.emit_routes:
+                active_stage = "route"
+                await self.checkpoint("route", "entered", {})
+                selected = await self._select_emit_sinks(ctx, delivery.payload, outcome.handler_result)
+                outcome.selected_sinks = [getattr(sink, "name", type(sink).__name__) for sink in selected]
+                await self.checkpoint("route", "completed", {"selected_sinks": outcome.selected_sinks})
+                emitted = Envelope(body=outcome.handler_result)
+                for sink in selected:
+                    active_stage = "sink"
+                    await self.dispatch_sink(sink, emitted, "emit")
+            active_stage = "ack"
+            outcome.delivery_action = DeliveryAction.ACK
+            if self.apply_delivery_actions:
+                await delivery.ack()
+            await self._emit(
+                TaskEventKind.SUCCEEDED,
+                delivery,
+                duration_s=time.perf_counter() - started_at,
+                event_meta=self._build_succeeded_event_meta(delivery, outcome.handler_result),
+            )
+            outcome.completion = "succeeded"
+            outcome.terminal = True
+            return outcome
+        except asyncio.CancelledError:
+            outcome.failure_stage = active_stage
+            await self._handle_cancelled(delivery, outcome, started_at)
+            raise
+        except asyncio.TimeoutError as exc:
+            outcome.failure_stage = active_stage
+            return await self._handle_failure(ctx, delivery, exc, FailureKind.TIMEOUT, outcome, started_at)
+        except Exception as exc:
+            outcome.failure_stage = active_stage
+            return await self._handle_failure(ctx, delivery, exc, FailureKind.ERROR, outcome, started_at)
+```
+
+Move these methods with the exact existing positional/keyword parameters and
+return contracts, changing only their owner and collaborator calls:
+
+The exact signatures are `_invoke_handler(self, ctx: TaskContext, delivery:
+Delivery) -> Any`, `_select_emit_sinks(self, ctx: TaskContext, payload: Any,
+result: Any) -> tuple[Sink, ...]`, `_handle_failure(self, ctx: TaskContext,
+delivery: Delivery, exc: Exception, kind: FailureKind, outcome:
+ExecutionOutcome, started_at: float) -> ExecutionOutcome`,
+`_publish_dead_letter(self, ctx: TaskContext, delivery: Delivery, failure:
+FailureInfo, *, duration_s: float | None) -> bool`, `_fail_delivery(self, ctx:
+TaskContext, delivery: Delivery, exc: Exception) -> bool`, and the current
+`_run_task_hooks()` / `_emit_event()` signatures renamed to `_run_hooks()` /
+`_emit()` without changing their parameter defaults.
+
+Also move `_send_to_sink()`, `_build_succeeded_event_meta()`,
+`_extract_handler_notifications()`, and `_sanitize_notification_value()` with
+their current signatures and statements. `_dispatch_production_sink()` must
+call the moved `_send_to_sink()` and return `True`. Replace direct sink calls in
+dead-letter publication with `dispatch_sink(sink, envelope, "dead_letter")`.
+Treat a `False` dispatch return as a deliberately suppressed diagnostic send,
+not as a publish failure: leave `dead_letter_attempted=False` and
+`dead_letter_published=None`, but continue to the predicted terminal source
+action. Only a raised dispatch exception triggers the existing dead-letter
+fallback-to-retry path. A `True` return sets `dead_letter_attempted=True` and
+contributes to `dead_letter_published=True` after every configured sink succeeds.
+When `apply_delivery_actions=False`, set the outcome action/delay exactly as
+production resolution dictates but do not call `delivery.ack()`, `retry()`, or
+`fail()`. In this mode `_fail_delivery()` returns `True` because the predicted
+source fail action itself cannot be observed; a real dead-letter send failure
+still produces `would_retry` through the unchanged publication fallback.
+Before failure hooks, dead-letter publication, and delivery actions, update
+`active_stage` through a small `_set_stage()` helper and emit matching
+`entered`/`completed` checkpoints. `_handle_failure()` returns the populated
+`ExecutionOutcome` after the unchanged retry/dead-letter/fail event sequence.
+
+- [ ] **Step 5: Make TaskRunner a compatibility facade**
+
+Instantiate one executor in `TaskRunner.__init__` and replace the old body:
+
+```python
+self._executor = DeliveryExecutor(app, task)
+
+async def _handle_delivery(self, delivery: "Delivery") -> None:
+    await self._executor.execute(delivery)
+```
+
+Leave fetching, inflight tracking, pause/drain/shutdown handling, and public
+`TaskRunner` imports in `runner.py`. Do not export `DeliveryExecutor` from
+`onestep.runtime` or top-level `onestep`.
+
+- [ ] **Step 6: Run all production contract tests**
+
+```bash
+uv run pytest tests/contract/test_runtime_contract.py -v
+```
+
+Expected: all tests pass unchanged, including Task 1 ordering and existing
+`run_task_once()` behavior.
+
+- [ ] **Step 7: Commit executor extraction**
+
+```bash
+git add src/onestep/runtime tests/contract/test_runtime_contract.py
+git commit -m "refactor: extract delivery executor"
+```
+
+## Task 6: Integrate Production Failure Capture At Final Action Resolution
+
+**Files:**
+- Modify: `src/onestep/runtime/executor.py`
+- Modify: `src/onestep/app.py`
+- Test: `tests/contract/test_runtime_contract.py`
+- Test: `tests/test_failure_capture.py`
+
+- [ ] **Step 1: Write failing terminal/all capture tests**
+
+Create tests using temporary capture directories for these exact outcomes:
+
+- `terminal` writes after successful dead-letter publication and successful `delivery.fail()`;
+- `terminal` does not write for retry policy decisions;
+- `terminal` does not write when dead-letter send fails and original delivery is retried;
+- `terminal` does not write when `delivery.fail()` fails and falls back to retry;
+- `all` writes non-terminal retry attempts with `terminal: false`;
+- unsupported payload logs one ERROR containing app/task/stage/type/path, writes no file, and preserves the original retry/fail action.
+
+Use existing delivery/sink test doubles and assert task event sequences remain
+identical to Task 1.
+
+- [ ] **Step 2: Run focused tests and confirm no files are produced**
+
+```bash
+uv run pytest tests/contract/test_runtime_contract.py tests/test_failure_capture.py -k 'failure_capture_runtime' -v
+```
+
+Expected: fail because the executor does not call the writer.
+
+- [ ] **Step 3: Create one writer per configured app**
+
+In `OneStepApp.__init__` add:
+
+```python
+self._failure_capture_writer = FailureCaptureWriter(failure_capture) if failure_capture is not None else None
+```
+
+Keep this object internal and do not treat it as a resource: startup/shutdown
+must not open or close it.
+
+- [ ] **Step 4: Capture only after the effective action is known**
+
+Make `_fail_delivery()` return `True` only when `delivery.fail()` succeeds and
+`False` after fallback retry. Set `ExecutionOutcome.terminal` from the effective
+result, not merely from `RetryDecision.FAIL`. At the end of every handled
+failure call:
+
+```python
+async def _capture_failure(self, delivery: Delivery, outcome: ExecutionOutcome) -> None:
+    writer = self.app._failure_capture_writer
+    if writer is None or outcome.failure is None:
+        return
+    if self.app.failure_capture.mode == "terminal" and not outcome.terminal:
+        return
+    try:
+        await writer.write(
+            app=self.app.name,
+            task=self.task.name,
+            stage=outcome.failure_stage or "delivery_action",
+            terminal=outcome.terminal,
+            failure=outcome.failure,
+            envelope=delivery.envelope,
+        )
+    except CaptureEncodingError as exc:
+        self.logger.error(
+            "failure capture encoding failed",
+            extra={
+                "app_name": self.app.name,
+                "task_name": self.task.name,
+                "failure_stage": outcome.failure_stage,
+                "capture_type": exc.type_name,
+                "capture_path": exc.path,
+            },
+        )
+    except Exception:
+        self.logger.exception(
+            "failure capture persistence failed",
+            extra={"app_name": self.app.name, "task_name": self.task.name},
+        )
+```
+
+Call it after retry/dead-letter/fail resolution and before returning from the
+executor. Never re-raise capture failures.
+
+- [ ] **Step 5: Run capture and production contracts**
+
+```bash
+uv run pytest tests/test_failure_capture.py tests/contract/test_runtime_contract.py -k 'failure_capture_runtime or single_delivery_success_order or dead_letter or fail_action' -v
+```
+
+Expected: all selected tests pass; capture failures do not alter actions.
+
+- [ ] **Step 6: Commit runtime capture integration**
+
+```bash
+git add src/onestep/app.py src/onestep/runtime/executor.py tests/test_failure_capture.py tests/contract/test_runtime_contract.py
+git commit -m "feat: capture runtime delivery failures"
+```
+
+## Task 7: Build The In-Process Diagnostic Runner
+
+**Files:**
+- Create: `src/onestep/diagnostics/__init__.py`
+- Create: `src/onestep/diagnostics/models.py`
+- Create: `src/onestep/diagnostics/runner.py`
+- Test: `tests/test_diagnostics.py`
+
+- [ ] **Step 1: Write diagnostic model and dry-run tests**
+
+Create `tests/test_diagnostics.py`. Use a `RecordingSink` whose `open()`,
+`send()`, and `close()` append to a list, and assert the default mode never
+touches it:
+
+```python
+def test_diagnostic_dry_run_executes_handler_hooks_and_routes_without_sink_io() -> None:
+    async def scenario() -> None:
+        calls: list[str] = []
+        app = OneStepApp("diagnostic")
+        sink = RecordingSink("selected", calls)
+
+        async def before(ctx, payload):
+            calls.append("before")
+
+        async def after(ctx, payload, result):
+            calls.append("after")
+
+        async def predicate(ctx, payload, result):
+            calls.append("route")
+            return True
+
+        @app.task(
+            emit=EmitRoute(predicate=predicate, then_sinks=(sink,)),
+            hooks=TaskHooks(before=(before,), after_success=(after,)),
+        )
+        async def consume(ctx, payload):
+            calls.append("handler")
+            return {"output": payload["input"]}
+
+        report = await DiagnosticRunner(app).run(
+            task_name="consume",
+            envelope=Envelope(body={"input": 1}),
+            send=False,
+        )
+
+        assert calls == ["before", "handler", "after", "route"]
+        assert report.completion == "succeeded"
+        assert report.mode == "dry-run"
+        assert report.selected_sinks == ("selected",)
+        assert report.delivery_action == "would_ack"
+        assert report.delivery_action_basis == "predicted"
+        assert report.side_effect_outcome == "not_attempted"
+
+    asyncio.run(scenario())
+```
+
+Add named tests with these exact assertions:
+
+```python
+assert [event.kind for event in report.events] == [TaskEventKind.STARTED, TaskEventKind.SUCCEEDED]
+assert reporter.events == []
+assert report.warning == "handler and task hooks may perform external side effects"
+assert report.to_dict()["schema"] == "onestep/diagnostic-result"
+assert report.to_dict()["version"] == 1
+```
+
+The reporter test attaches a recording reporter/event handler before running;
+only the runner's local event list may change.
+
+- [ ] **Step 2: Write send, cleanup, and one-attempt failure tests**
+
+Use two selected `RecordingSink` instances and require:
+
+```python
+assert calls == [
+    "first:open", "first:send",
+    "second:open", "second:send",
+    "second:close", "first:close",
+]
+```
+
+Each selected sink is opened immediately before its send and all opened sinks
+are closed in reverse order after execution. Add
+`test_diagnostic_send_closes_after_send_failure()` and assert `close` still
+follows the failing `send`. Add parameterized retry-policy cases whose body
+constructs an app with a handler that always raises, runs one diagnostic, and
+asserts the three values shown:
+
+```python
+@pytest.mark.parametrize(
+    "retry,dead_letter,expected",
+    [
+        (MaxAttempts(max_attempts=3, delay_s=30), None, "would_retry"),
+        (NoRetry(), RecordingSink("dead", []), "would_dead_letter"),
+        (NoRetry(), None, "would_fail"),
+    ],
+)
+def test_diagnostic_runs_exactly_one_failed_attempt(retry, dead_letter, expected) -> None:
+    async def scenario() -> None:
+        calls = 0
+        app = OneStepApp("failed-diagnostic")
+
+        @app.task(retry=retry, dead_letter=dead_letter)
+        async def consume(ctx, payload):
+            nonlocal calls
+            calls += 1
+            raise ValueError("boom")
+
+        report = await DiagnosticRunner(app).run(
+            task_name="consume",
+            envelope=Envelope(body={"id": 1}, attempts=0),
+            send=False,
+        )
+        assert calls == 1
+        assert report.delivery_action == expected
+        assert report.delivery_action_basis == "predicted"
+
+    asyncio.run(scenario())
+```
+
+For every row assert the handler call count is one, no backoff sleep occurs,
+and `delivery_action_basis == "predicted"`. For dry-run dead-letter assert
+`dead_letter == {"attempted": False, "published": None}`. For send mode assert
+successful publication gives `{ "attempted": True, "published": True }`, while
+a broken dead-letter sink gives `{ "attempted": True, "published": False }`
+and `delivery_action == "would_retry"`.
+
+- [ ] **Step 3: Run the diagnostic tests and confirm missing modules**
+
+```bash
+uv run pytest tests/test_diagnostics.py -k 'diagnostic_dry_run or diagnostic_send or one_failed_attempt' -v
+```
+
+Expected: collection fails because `onestep.diagnostics` does not exist.
+
+- [ ] **Step 4: Implement diagnostic request/result models**
+
+Create `src/onestep/diagnostics/models.py` with this private surface:
+
+```python
+DIAGNOSTIC_SCHEMA = "onestep/diagnostic-result"
+DIAGNOSTIC_VERSION = 1
+SIDE_EFFECT_WARNING = "handler and task hooks may perform external side effects"
+
+
+@dataclass(frozen=True)
+class DiagnosticRequest:
+    operation: Literal["run", "replay"]
+    target: str
+    task: str
+    envelope: Envelope | None = None
+    capture_path: str | None = None
+    send: bool = False
+
+
+@dataclass(frozen=True)
+class DiagnosticReport:
+    operation: str
+    app: str
+    task: str
+    mode: str
+    completion: str
+    attempts: int
+    selected_sinks: tuple[str, ...]
+    delivery_action: str | None
+    delivery_action_basis: str
+    dead_letter: dict[str, bool | None]
+    events: tuple[TaskEvent, ...]
+    duration_s: float
+    warning: str = SIDE_EFFECT_WARNING
+    failure: dict[str, str] | None = None
+    failure_stage: str | None = None
+    cleanup: str = "complete"
+    side_effect_outcome: str = "not_attempted"
+    last_checkpoint: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": DIAGNOSTIC_SCHEMA,
+            "version": DIAGNOSTIC_VERSION,
+            "operation": self.operation,
+            "app": self.app,
+            "task": self.task,
+            "mode": self.mode,
+            "completion": self.completion,
+            "attempts": self.attempts,
+            "selected_sinks": list(self.selected_sinks),
+            "delivery_action": self.delivery_action,
+            "delivery_action_basis": self.delivery_action_basis,
+            "dead_letter": dict(self.dead_letter),
+            "events": [_event_to_dict(event) for event in self.events],
+            "duration_s": self.duration_s,
+            "warning": self.warning,
+            "failure": self.failure,
+            "failure_stage": self.failure_stage,
+            "cleanup": self.cleanup,
+            "side_effect_outcome": self.side_effect_outcome,
+            "last_checkpoint": self.last_checkpoint,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "DiagnosticReport":
+        _validate_diagnostic_result(value)
+        return cls(
+            operation=value["operation"],
+            app=value["app"],
+            task=value["task"],
+            mode=value["mode"],
+            completion=value["completion"],
+            attempts=value["attempts"],
+            selected_sinks=tuple(value["selected_sinks"]),
+            delivery_action=value["delivery_action"],
+            delivery_action_basis=value["delivery_action_basis"],
+            dead_letter=dict(value["dead_letter"]),
+            events=tuple(_event_from_dict(item) for item in value["events"]),
+            duration_s=value["duration_s"],
+            warning=value["warning"],
+            failure=value["failure"],
+            failure_stage=value["failure_stage"],
+            cleanup=value["cleanup"],
+            side_effect_outcome=value["side_effect_outcome"],
+            last_checkpoint=value["last_checkpoint"],
+        )
+```
+
+`_event_to_dict()` and `_event_from_dict()` serialize only existing `TaskEvent`
+fields. They must not serialize `FailureInfo.message` or traceback: emit failure
+kind and exception type only. The report-level `failure` comes from
+`ExecutionOutcome.public_failure`, so official connector failures additionally
+carry normalized backend/operation/kind fields while unknown exceptions expose
+only their type. `_validate_diagnostic_result()` requires the exact schema/version,
+required keys, scalar/container types, allowed completion values, and
+non-negative attempts/duration. Do not add fields to `TaskEvent`, `Envelope`,
+reporter payloads, or top-level exports.
+
+- [ ] **Step 5: Implement local delivery and sink policies**
+
+Create `src/onestep/diagnostics/runner.py` with:
+
+```python
+class _DiagnosticDelivery(Delivery):
+    def __init__(self, envelope: Envelope) -> None:
+        super().__init__(envelope)
+        self.actions: list[tuple[str, float | None]] = []
+
+    async def ack(self) -> None:
+        self.actions.append(("ack", None))
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        self.actions.append(("retry", delay_s))
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        self.actions.append(("fail", None))
+
+
+class DiagnosticRunner:
+    def __init__(self, app: OneStepApp, *, checkpoint: Checkpoint | None = None) -> None:
+        self.app = app
+        self.checkpoint = checkpoint or _noop_checkpoint
+
+    async def run(
+        self,
+        *,
+        task_name: str,
+        envelope: Envelope,
+        send: bool,
+        operation: str = "run",
+    ) -> DiagnosticReport:
+        task = self._resolve_task(task_name)
+        events: list[TaskEvent] = []
+        delivery = _DiagnosticDelivery(envelope)
+        opened: list[Sink] = []
+
+        async def emit_event(event: TaskEvent) -> None:
+            events.append(event)
+
+        executor = DeliveryExecutor(
+            self.app,
+            task,
+            emit_event=emit_event,
+            dispatch_sink=self._sink_dispatcher(send=send, opened=opened),
+            apply_delivery_actions=False,
+            checkpoint=self.checkpoint,
+        )
+        started_at = time.perf_counter()
+        cleanup_errors: list[Exception] = []
+        try:
+            outcome = await executor.execute(delivery)
+        finally:
+            for sink in reversed(opened):
+                sink_name = getattr(sink, "name", type(sink).__name__)
+                await self.checkpoint("cleanup", "entered", {"resource": sink_name})
+                try:
+                    await sink.close()
+                except Exception as exc:
+                    cleanup_errors.append(exc)
+                await self.checkpoint("cleanup", "completed", {"resource": sink_name})
+        return self._build_report(
+            operation=operation,
+            send=send,
+            envelope=envelope,
+            events=events,
+            outcome=outcome,
+            cleanup_errors=cleanup_errors,
+            duration_s=time.perf_counter() - started_at,
+        )
+```
+
+Resolve exactly one task by name and raise `ValueError` for missing or duplicate
+matches. Pass a local `emit_event` collector, `apply_delivery_actions=False`,
+the supplied checkpoint, and `_dispatch_sink()` into `DeliveryExecutor`.
+Dry-run dispatch calls `encode_value(envelope.body)` and
+`encode_value(envelope.meta)` so unrepresentable output fails explicitly, then
+returns `False` without `open()`, `send()`, or `close()`.
+
+Send dispatch must use this open/send shape for every individual sink:
+
+```python
+await self.checkpoint("sink", "entered", {"resource": sink_name})
+if id(sink) not in opened_ids:
+    await sink.open()
+    opened_ids.add(id(sink))
+    opened.append(sink)
+await sink.send(envelope)
+await self.checkpoint("sink", "completed", {"resource": sink_name})
+return True
+```
+
+`_sink_dispatcher()` creates the `opened_ids: set[int]` closure used above.
+
+The real dispatcher opens a sink only once by identity, immediately before its
+first send, appends it to `opened`, sends, and emits `sink entered/completed`
+checkpoints. `DiagnosticRunner.run()` wraps `executor.execute()` in `try/finally`
+and closes `reversed(opened)`, emitting `cleanup entered/completed` for each.
+Track close errors separately so they set `completion="failed"` and
+`cleanup="failed"` without hiding the send result. Never call `app.startup()`,
+`app.shutdown()`, app hooks, source methods, reporter attach/start/flush, or
+`TaskRunner.run()`.
+
+- [ ] **Step 6: Map execution outcomes into reports**
+
+Map `DeliveryAction.ACK`, `RETRY`, `DEAD_LETTER`, and `FAIL` to `would_ack`,
+`would_retry`, `would_dead_letter`, and `would_fail`. Always use
+`delivery_action_basis="predicted"` because source actions remain synthetic.
+Carry the input envelope's `attempts` into retry resolution and the report.
+Copy only `outcome.public_failure` into the report's `failure` field.
+Set `side_effect_outcome` to `completed` only when every requested real send
+completed; use `not_attempted` in dry-run.
+
+- [ ] **Step 7: Run diagnostic runner tests**
+
+```bash
+uv run pytest tests/test_diagnostics.py -k 'diagnostic_' -v
+```
+
+Expected: all in-process diagnostic tests pass.
+
+- [ ] **Step 8: Commit the diagnostic runner**
+
+```bash
+git add src/onestep/diagnostics tests/test_diagnostics.py
+git commit -m "feat: add local diagnostic runner"
+```
+
+## Task 8: Add Capability-Based Connectivity Checks
+
+**Files:**
+- Create: `src/onestep/diagnostics/connectivity.py`
+- Modify: `src/onestep/diagnostics/models.py`
+- Test: `tests/test_diagnostics.py`
+
+- [ ] **Step 1: Write inventory and non-probeable store tests**
+
+Create a shared resource registered as `resources["queue"]`, a task source, and
+an emit sink. Assert one deduplicated result retains all aliases and roles:
+
+```python
+assert report.resources[0].aliases == ("queue", "consume.source", "consume.emit[0]")
+assert report.resources[0].roles == ("named", "source", "sink")
+```
+
+Use a store whose `load()`, `save()`, and `delete()` raise `AssertionError`.
+Bind it as app state and assert:
+
+```python
+assert store_result.probe_kind == "none"
+assert store_result.status == "not_probeable"
+assert store.calls == []
+assert report.ok is True
+assert "no connection was verified" in report.warnings[0]
+```
+
+This test is also the regression guard that a SQLAlchemy store's `auto_create`
+path cannot be triggered by connectivity checking.
+
+- [ ] **Step 2: Write lifecycle timeout and cleanup tests**
+
+Use resources whose `open()` succeeds, fails, or blocks and whose `close()`
+records its call. Require sequential order and a bounded close attempt after
+every invoked open, including failed/timed-out opens:
+
+```python
+assert calls == [
+    "good:open", "good:close",
+    "broken:open", "broken:close",
+    "slow:open", "slow:close",
+]
+assert [item.status for item in report.resources] == ["connected", "failed", "failed"]
+assert report.ok is False
+```
+
+Assert unknown plugin errors expose only `type(exc).__name__`; for
+`ConnectorOperationError`, assert the report includes normalized `backend`,
+`operation`, and `kind` but excludes the raw exception message.
+
+- [ ] **Step 3: Run tests and confirm missing checker**
+
+```bash
+uv run pytest tests/test_diagnostics.py -k connectivity -v
+```
+
+Expected: fail because `check_connectivity()` is missing.
+
+- [ ] **Step 4: Implement resource inventory models**
+
+Add frozen `ConnectivityResourceResult` and `ConnectivityReport` dataclasses to
+`models.py`. Their `to_dict()` output uses schema
+`onestep/connectivity-result`, version `1`, and includes aliases, roles,
+`module.qualname` type, probe kind, status, separate open/close outcome objects,
+warnings, and `ok`.
+
+Create `src/onestep/diagnostics/connectivity.py` with:
+
+```python
+@dataclass
+class _InventoryEntry:
+    resource: Any
+    aliases: list[str]
+    roles: list[str]
+
+
+def inventory_resources(app: OneStepApp) -> tuple[_InventoryEntry, ...]:
+    entries: dict[int, _InventoryEntry] = {}
+
+    def add(resource: Any, alias: str, role: str) -> None:
+        if resource is None:
+            return
+        entry = entries.setdefault(id(resource), _InventoryEntry(resource, [], []))
+        if alias not in entry.aliases:
+            entry.aliases.append(alias)
+        if role not in entry.roles:
+            entry.roles.append(role)
+
+    for name, resource in app.resources.items():
+        add(resource, name, "named")
+    add(app.state, "app.state", "state_store")
+    for task in app.tasks:
+        add(task.source, f"{task.name}.source", "source")
+        for index, sink in enumerate(task.sinks):
+            add(sink, f"{task.name}.emit[{index}]", "sink")
+        for index, sink in enumerate(task.dead_letter_sinks):
+            add(sink, f"{task.name}.dead_letter[{index}]", "dead_letter_sink")
+    return tuple(entries.values())
+```
+
+- [ ] **Step 5: Implement sequential capability probes**
+
+Use this exact entry point:
+
+```python
+async def check_connectivity(app: OneStepApp, *, timeout_s: float) -> ConnectivityReport:
+    if timeout_s <= 0:
+        raise ValueError("connect timeout must be > 0")
+    results = []
+    for entry in inventory_resources(app):
+        results.append(await _probe_entry(entry, timeout_s=timeout_s))
+    return ConnectivityReport.from_results(results)
+```
+
+`_probe_entry()` checks `callable(getattr(resource, "open", None))` and
+`callable(getattr(resource, "close", None))`. Unless both are true, return
+`not_probeable` without calling any other method. Wrap open and close separately
+with the same sync-or-awaitable invocation rule as `app._open_resource()`:
+
+```python
+async def _invoke_lifecycle(method: Callable[[], Any]) -> None:
+    result = method()
+    if inspect.isawaitable(result):
+        await result
+```
+
+Call `await asyncio.wait_for(_invoke_lifecycle(method), timeout_s)` and always
+attempt bounded close once open
+was invoked. Continue inventory after all failures. Do not call app hooks,
+fetch, send, `load`, `save`, or `delete`.
+
+- [ ] **Step 6: Run connectivity tests**
+
+```bash
+uv run pytest tests/test_diagnostics.py -k connectivity -v
+```
+
+Expected: all connectivity tests pass, including all-resource reporting after a
+partial failure.
+
+- [ ] **Step 7: Commit connectivity checking**
+
+```bash
+git add src/onestep/diagnostics tests/test_diagnostics.py
+git commit -m "feat: check resource connectivity"
+```
+
+## Task 9: Supervise Diagnostics With Versioned JSON IPC
+
+**Files:**
+- Create: `src/onestep/diagnostics/ipc.py`
+- Create: `src/onestep/diagnostics/targets.py`
+- Create: `src/onestep/diagnostics/worker.py`
+- Create: `src/onestep/diagnostics/supervisor.py`
+- Create: `tests/assets/diagnostic_app.py`
+- Modify: `src/onestep/cli.py`
+- Modify: `tests/test_diagnostics.py`
+
+- [ ] **Step 1: Write frame validation tests**
+
+Require exact schema/version/kind/sequence validation:
+
+```python
+def test_ipc_rejects_non_monotonic_and_unknown_frames() -> None:
+    validator = FrameValidator(direction="status")
+    validator.accept(decode_frame(encode_frame("checkpoint", sequence=1, payload={"phase": "child_start"})))
+    with pytest.raises(IPCProtocolError, match="sequence"):
+        validator.accept(decode_frame(encode_frame("checkpoint", sequence=1, payload={})))
+    with pytest.raises(IPCProtocolError, match="kind"):
+        decode_frame(b'{"schema":"onestep/diagnostic-ipc","version":1,"kind":"other","sequence":2,"payload":{}}')
+```
+
+Also reject malformed UTF-8, malformed JSON, unknown schema/version, booleans as
+sequence numbers, unallowlisted checkpoint fields, and `final` payloads that do
+not validate as a complete diagnostic result.
+
+- [ ] **Step 2: Write spawned timeout and stdout-isolation tests**
+
+Create `tests/assets/diagnostic_app.py` with importable apps/tasks selected by
+environment variables. Include synchronous infinite-block handlers/hooks,
+stdout/stderr writers, cooperative async cancellation, and a sink that blocks
+after recording `entered` to a file. Spawned tests use `monkeypatch.chdir()` to
+the copied/temp asset directory and target `diagnostic_app:app`, so the fixture
+does not require turning `tests/` into a Python package.
+
+Create a temporary YAML target in the spawned-worker test whose `handler.ref`
+points to `diagnostic_app:yaml_handler`, then run the same request
+once against `tests.assets.diagnostic_app:app` and once against that YAML path.
+Assert both produce `completion="succeeded"` and the same selected-sink/action
+fields. This is the end-to-end Python/YAML target parity gate.
+
+Use a real `spawn` process and assert:
+
+```python
+started = time.monotonic()
+report = supervise_diagnostic(request, timeout_s=0.2, grace_s=0.2)
+assert time.monotonic() - started < 1.5
+assert report.completion == "timed_out"
+assert report.cleanup in {"complete", "incomplete"}
+assert report.last_checkpoint["phase"] in {"handler", "before_hook"}
+```
+
+For JSON isolation, redirect the parent's stdout/stderr and require exactly one
+`json.loads(stdout)` document while child stdout and stderr both appear only in
+parent stderr. For a forced timeout during send, assert:
+
+```python
+assert report.side_effect_outcome == "unknown"
+assert "partial" in report.warning
+assert "duplicate" in report.warning
+```
+
+Add child-exit-without-final, broken pipe, malformed/truncated status frame, and
+no-checkpoint cases. The last must synthesize `phase="child_start"`.
+
+- [ ] **Step 3: Run supervision tests and confirm missing IPC**
+
+```bash
+uv run pytest tests/test_diagnostics.py -k 'ipc or supervisor or spawned' -v
+```
+
+Expected: fail because IPC and supervision modules do not exist.
+
+- [ ] **Step 4: Implement byte-only JSON frames**
+
+Create `src/onestep/diagnostics/ipc.py`:
+
+```python
+IPC_SCHEMA = "onestep/diagnostic-ipc"
+IPC_VERSION = 1
+STATUS_KINDS = frozenset({"checkpoint", "final"})
+CONTROL_KINDS = frozenset({"cancel"})
+
+
+def encode_frame(kind: str, *, sequence: int, payload: Mapping[str, Any]) -> bytes:
+    frame = {
+        "schema": IPC_SCHEMA,
+        "version": IPC_VERSION,
+        "kind": kind,
+        "sequence": sequence,
+        "payload": dict(payload),
+    }
+    return json.dumps(frame, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+
+
+def decode_frame(data: bytes) -> dict[str, Any]:
+    try:
+        frame = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise IPCProtocolError("malformed JSON frame") from exc
+    if not isinstance(frame, dict):
+        raise IPCProtocolError("frame must be an object")
+    if set(frame) != {"schema", "version", "kind", "sequence", "payload"}:
+        raise IPCProtocolError("frame fields are invalid")
+    if frame["schema"] != IPC_SCHEMA or frame["version"] != IPC_VERSION:
+        raise IPCProtocolError("unsupported IPC schema or version")
+    return frame
+
+
+class FrameValidator:
+    def __init__(self, *, direction: Literal["status", "control"]) -> None:
+        self.direction = direction
+        self.last_sequence = 0
+
+    def accept(self, frame: Mapping[str, Any]) -> dict[str, Any]:
+        sequence = frame["sequence"]
+        if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence <= self.last_sequence:
+            raise IPCProtocolError("non-monotonic IPC sequence")
+        allowed = STATUS_KINDS if self.direction == "status" else CONTROL_KINDS
+        if frame["kind"] not in allowed:
+            raise IPCProtocolError("invalid IPC kind for direction")
+        payload = _validate_payload(frame["kind"], frame["payload"])
+        self.last_sequence = sequence
+        return payload
+```
+
+`decode_frame()` requires a JSON object with the exact five keys above.
+`FrameValidator.accept()` requires a positive non-boolean integer sequence
+strictly greater than the previous accepted sequence, enforces direction kinds,
+and advances sequence only after the payload validates. Checkpoint payloads use
+only `phase`, `transition`, `elapsed_s`, `app`, `task`, `resource`,
+`selected_sinks`, `completion`, and `cleanup`; transition is `entered` or
+`completed`. No payload, exception message, credential, or arbitrary repr may
+enter a checkpoint.
+
+- [ ] **Step 5: Implement the spawned child entry point**
+
+Create `targets.py` and move `_ensure_local_import_paths()`,
+`_candidate_import_paths()`, `_target_import_root()`, `_find_project_root()`, and
+`_path_on_syspath()` from `cli.py` without changing their statements. Add:
+
+```python
+def load_diagnostic_target(target: str) -> OneStepApp:
+    _ensure_local_import_paths(target)
+    if is_yaml_target(target):
+        return load_yaml_app(target)
+    return OneStepApp.load(target)
+```
+
+Both the CLI parent and spawned child must call this shared loader so Python
+targets in the current directory, `src/` layouts, project subdirectories, and
+YAML-relative handler imports behave identically.
+
+Create `worker.py` with a module-level picklable function:
+
+```python
+def diagnostic_worker_main(
+    request_bytes: bytes,
+    control_rx: Connection,
+    status_tx: Connection,
+    stderr_handle: Any,
+) -> None:
+    stderr_fd = stderr_handle.detach()
+    os.dup2(stderr_fd, 1)
+    os.dup2(stderr_fd, 2)
+    asyncio.run(_run_worker(request_bytes, control_rx, status_tx))
+```
+
+The request bytes use a separately validated internal request JSON document;
+never pickle a request or app object. Add `encode_request()` and
+`decode_request()` to `models.py`. A `run` request requires an envelope and
+encodes its body/meta with the capture codec; a `replay` request requires a
+capture path and must not carry an envelope. Both require operation, target,
+task, and send, and run attempts must be non-negative. The worker loads the
+target module graph before decoding a run envelope or loading a replay capture
+so enum/namedtuple types are already importable.
+`_run_worker()` sends `child_start`
+entered/completed checkpoints, loads Python or YAML targets in the child,
+validates replay identity through `load_capture(capture_path,
+expected_app=app.name, expected_task=request.task)`, and invokes
+`DiagnosticRunner`. A daemon control thread blocks on `control_rx.recv_bytes()`,
+validates only `cancel`, and calls `loop.call_soon_threadsafe(task.cancel)`.
+Every child status write is
+`status_tx.send_bytes(encode_frame(kind, sequence=sequence, payload=payload))`;
+never call `Connection.send()` or serialize a Python object through pickle.
+Normal cancellation performs cleanup and sends one `final`; forced process
+termination is handled only by the parent.
+
+- [ ] **Step 6: Implement total-deadline supervision**
+
+Create `supervisor.py` with:
+
+```python
+def supervise_diagnostic(
+    request: DiagnosticRequest,
+    *,
+    timeout_s: float = 60.0,
+    grace_s: float = 5.0,
+) -> DiagnosticReport:
+    if timeout_s <= 0 or grace_s < 0:
+        raise ValueError("diagnostic timeouts must be positive")
+    return _SpawnSupervisor(request, timeout_s=timeout_s, grace_s=grace_s).run()
+```
+
+Use `multiprocessing.get_context("spawn")` and two unidirectional
+`ctx.Pipe(duplex=False)` pairs. The monotonic deadline begins immediately after
+`process.start()`. Continuously use `status_rx.poll(short_remaining)` followed by
+`recv_bytes()` and retain only the highest validated checkpoint. On deadline,
+send one validated cancel frame with
+`control_tx.send_bytes(encode_frame("cancel", sequence=1, payload={}))` and
+drain for at most `grace_s`. If no valid
+final arrives, call `terminate()`, `join()`, and, only if still alive where the
+platform provides it, `kill()` followed by another `join()`.
+If decode/validation of any status frame fails, retain the last previously valid
+checkpoint, terminate the child immediately, and synthesize
+`completion="child_failed"`; never accept later frames after a protocol error.
+
+Put all process/pipe cleanup in one outer `finally`:
+
+```python
+finally:
+    for endpoint in (control_tx, control_rx, status_tx, status_rx):
+        endpoint.close()
+    if process.is_alive():
+        process.terminate()
+    process.join(timeout=grace_s)
+    if process.is_alive() and hasattr(process, "kill"):
+        process.kill()
+        process.join()
+```
+
+Close the parent copies of the child-only `control_rx` and `status_tx`
+immediately after a successful `start()` so broken-pipe/EOF detection works.
+Track `started = False` before start and guard `is_alive()`/`join()` calls so a
+spawn failure also closes every pipe without calling process methods that
+require a PID. Pass stderr with the platform multiprocessing reduction handle
+(`DupFd` on POSIX, `DupHandle` on Windows); the child detaches the handle before
+`dup2()`. Every return path must pass through this `finally`; no child may
+outlive the supervisor. Synthesize `timed_out` or `child_failed` from the last valid
+checkpoint, defaulting to `child_start`. If a send has an `entered` checkpoint
+without a matching `completed`, set `side_effect_outcome="unknown"` and use the
+duplicate/partial-write warning. The supervisor returns a model and never
+prints; the CLI parent alone renders stdout.
+
+- [ ] **Step 7: Run IPC and supervision tests**
+
+```bash
+uv run pytest tests/test_diagnostics.py -k 'ipc or supervisor or spawned' -v
+uv run pytest tests/test_cli.py -k 'loads_modules_from or loads_yaml_handlers' -v
+```
+
+Expected: all tests pass, and blocking synchronous fixtures return within the
+configured deadline plus grace period; existing import-path behavior is
+unchanged after moving the helpers.
+
+- [ ] **Step 8: Commit process supervision**
+
+```bash
+git add src/onestep/diagnostics src/onestep/cli.py tests/assets/diagnostic_app.py tests/test_diagnostics.py
+git commit -m "feat: supervise local diagnostics"
+```
+
+## Task 10: Add CLI Commands, Reports, And Exit Codes
+
+**Files:**
+- Modify: `src/onestep/cli.py`
+- Modify: `tests/test_cli.py`
+
+- [ ] **Step 1: Write parser and argv-normalization tests**
+
+Add exact parser assertions:
+
+```python
+def test_task_command_bypasses_legacy_run_shorthand() -> None:
+    args = parse_args(["task", "run", "pkg.jobs:app", "--task", "sync", "--input", "input.json"])
+    assert (args.command, args.task_command, args.target) == ("task", "run", "pkg.jobs:app")
+
+
+def test_explicit_run_still_accepts_reserved_task_target() -> None:
+    assert parse_args(["run", "task"]).target == "task"
+
+
+def test_other_bare_targets_keep_legacy_shorthand() -> None:
+    args = parse_args(["pkg.jobs:app"])
+    assert (args.command, args.target) == ("run", "pkg.jobs:app")
+```
+
+Assert both task subcommands default `timeout=60.0` and `send=False`, reject
+non-positive timeouts, and `check --connect` defaults `connect_timeout=10.0`.
+
+- [ ] **Step 2: Write command and rendering tests**
+
+Monkeypatch `supervise_diagnostic()` and `check_connectivity()` at the CLI
+boundary. Require run input to accept any single JSON value, replay to pass the
+capture envelope, human output to carry the side-effect warning, and JSON output
+to parse as exactly one object. Parameterize exit mapping:
+
+```python
+@pytest.mark.parametrize(
+    "completion,expected",
+    [("succeeded", 0), ("failed", 1), ("timed_out", 1), ("child_failed", 1)],
+)
+def test_task_exit_codes(completion, expected) -> None:
+    report = make_diagnostic_report(completion=completion)
+    assert _diagnostic_exit_code(report) == expected
+```
+
+Assert invalid input JSON, unreadable input, bad capture version, app/task
+mismatch, target load failure, and argparse validation return `2`. Connectivity
+returns `0` for connected/not-probeable-only reports and `1` for any failed
+lifecycle probe.
+
+- [ ] **Step 3: Run CLI tests and confirm unknown command/options**
+
+```bash
+uv run pytest tests/test_cli.py -k 'task_command or diagnostic or connect' -v
+```
+
+Expected: parser tests fail because `task` and `--connect` are unknown.
+
+- [ ] **Step 4: Add nested parsers and reserve `task`**
+
+Add `task_parser = subparsers.add_parser("task", help="Run local task diagnostics")`, required nested
+subparsers `run` and `replay`, and shared arguments:
+
+```python
+def _positive_seconds(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive number of seconds")
+    return parsed
+```
+
+Run requires `<target> --task <name> --input <path>`; replay requires
+`<target> --task <name> --envelope <path>`. Both accept `--send`,
+`--timeout` using `_positive_seconds` with default `60.0`, and `--json` stored as
+`as_json`. Add `--connect`, `--connect-timeout` with default `10.0`, and existing
+`--json` support to `check`.
+
+Change `_normalize_argv()` exactly to:
+
+```python
+if argv[0].startswith("-") or argv[0] in {
+    "run", "check", "init", "build", "catalog", "task"
+}:
+    return argv
+```
+
+- [ ] **Step 5: Dispatch diagnostics in the parent CLI**
+
+Before loading an app in `main()`, branch `args.command == "task"`. Read input
+JSON in the parent only to validate it, construct a versioned request for the
+child, call `supervise_diagnostic()`, then render the returned report. Replay
+uses `load_capture()` for early schema/identity validation after resolving the
+target identity, sends `capture_path` rather than a decoded envelope in the
+request, and lets the child repeat validation before execution. Print the
+side-effect warning to stderr for both dry-run and send modes; JSON stdout must
+contain only `json.dumps(report.to_dict(), indent=2)`.
+
+For `check --connect`, keep existing target loading and strict YAML behavior,
+run `asyncio.run(check_connectivity(app, timeout_s=args.connect_timeout))`, and
+render a connectivity report instead of the ordinary summary. Without
+`--connect`, preserve the current summary byte-for-byte.
+Import the moved path helpers from `diagnostics.targets` for all CLI commands so
+existing local/source-layout target behavior remains covered by the unchanged
+CLI tests.
+
+- [ ] **Step 6: Implement stable renderers and exit mapping**
+
+Use one `_diagnostic_exit_code()` and one `_connectivity_exit_code()`:
+
+```python
+def _diagnostic_exit_code(report: DiagnosticReport) -> int:
+    return 0 if report.completion == "succeeded" else 1
+
+
+def _connectivity_exit_code(report: ConnectivityReport) -> int:
+    return 0 if report.ok else 1
+```
+
+Validation exceptions are caught before these helpers and return `2` with an
+`onestep:` error on stderr. Human diagnostic output includes operation, target,
+app/task, mode, completion, failure stage, selected sinks, predicted delivery
+action, dead-letter attempted/published, cleanup, side-effect outcome, last
+checkpoint, duration, and warning. Human connectivity output prints every
+resource and separate open/close outcomes.
+
+- [ ] **Step 7: Run all CLI tests**
+
+```bash
+uv run pytest tests/test_cli.py -v
+```
+
+Expected: all existing and new CLI tests pass; prior `run`, `check`, `init`,
+`build`, and `catalog` behavior remains unchanged.
+
+- [ ] **Step 8: Commit the CLI surface**
+
+```bash
+git add src/onestep/cli.py tests/test_cli.py
+git commit -m "feat: add local task diagnostics CLI"
+```
+
+## Task 11: Document P2 And Prepare Core 1.8.0 Metadata
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+- Modify: `docs/yaml-task-definition.md`
+- Modify: `docs/framework-evolution-roadmap.md`
+- Modify: `CHANGELOG.md`
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+
+- [ ] **Step 1: Update English and Chinese user documentation**
+
+Add matching local diagnostics sections containing the exact three command
+forms from the design. State all of these constraints in both languages:
+
+- dry-run suppresses only framework-managed sinks; handlers/hooks can still
+  write externally;
+- `would_dead_letter` in dry-run is conditional on successful production
+  dead-letter publication and source finalization;
+- `--send` observes sink publication but never a real source action;
+- `--timeout` defaults to 60 seconds and forced termination during `--send` can
+  leave partial or duplicate writes with an unknown outcome;
+- connectivity probes only callable `open()`/`close()` pairs and reports stores
+  without lifecycle as `not_probeable` without calling `load()`;
+- `mode=all` is best-effort; unsupported custom values log safe type/path
+  context and produce no lossy capture;
+- captures can retain PII and require access and retention controls.
+
+- [ ] **Step 2: Document YAML capture policy and roadmap status**
+
+Add the complete `app.failure_capture` YAML example to
+`docs/yaml-task-definition.md`, including defaults and supported lossless types.
+In `docs/framework-evolution-roadmap.md`, mark P2 complete only in the final
+implementation commit after Task 12 gates have passed; preserve P3 as the next
+phase and do not add P3 protocol fields. Align the P2 deliverable row with the
+approved design by removing the stale `handler scaffold tests` phrase; handler
+scaffolding is not in the approved P2 design or success criteria. Update the
+committed command examples to the final argument order and include `--send`,
+`--timeout`, and `--connect-timeout` options.
+
+- [ ] **Step 3: Update changelog and version metadata**
+
+Add a `1.8.0` changelog entry covering commands, capture policy, overall
+timeout/IPC behavior, compatibility, reserved bare shorthand target `task`, and
+the `--send` side-effect warning. Change only the core version:
+
+```toml
+[project]
+name = "onestep"
+version = "1.8.0"
+```
+
+Run:
+
+```bash
+uv lock
+```
+
+Expected: `uv.lock` changes the root `onestep` package version to `1.8.0` and
+does not bump plugin versions or add upper bounds.
+
+- [ ] **Step 4: Verify documentation and lock consistency**
+
+```bash
+rg -n 'task run|task replay|--connect|not_probeable|mode=all|unknown|1\.8\.0' README.md README.zh-CN.md docs/yaml-task-definition.md docs/framework-evolution-roadmap.md CHANGELOG.md pyproject.toml uv.lock
+uv lock --check
+```
+
+Expected: every required concept is present and the lockfile is current.
+
+- [ ] **Step 5: Commit documentation and release metadata**
+
+```bash
+git add README.md README.zh-CN.md docs/yaml-task-definition.md docs/framework-evolution-roadmap.md CHANGELOG.md pyproject.toml uv.lock
+git commit -m "docs: document P2 local handler loop"
+```
+
+Do not tag, publish, push, or rebuild the Control Plane in this implementation
+plan. Those actions require a separate explicit release request. No Control
+Plane source or image is changed by P2.
+
+## Task 12: Run Compatibility And Reliability Gates
+
+**Files:**
+- Modify only files implicated by a failing gate; keep fixes inside P2 scope.
+
+- [ ] **Step 1: Run focused feature tests**
+
+```bash
+uv run pytest -q tests/test_cli.py tests/test_diagnostics.py tests/test_failure_capture.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run production contract tests**
+
+```bash
+uv run pytest -q tests/contract/test_runtime_contract.py
+```
+
+Expected: PASS with unchanged reporter, WebSocket, remote manual-run,
+`Envelope`, and `TaskEvent` contracts.
+
+- [ ] **Step 3: Run all non-integration tests**
+
+```bash
+uv run pytest -q -m "not integration"
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run repository reliability checks**
+
+```bash
+./scripts/run-reliability-checks.sh
+```
+
+Expected: every configured reliability check passes.
+
+- [ ] **Step 5: Inspect the final diff and compatibility boundary**
+
+```bash
+git diff --check
+git diff --stat 611cf49..HEAD
+git diff 611cf49..HEAD -- src/onestep/events.py src/onestep/envelope.py plugins/onestep-control-plane
+```
+
+Expected: no whitespace errors; no changes to `events.py`, `envelope.py`, or
+Control Plane code. Confirm `DeliveryExecutor` and all diagnostics modules remain
+internal except the intended `FailureCaptureConfig` top-level export.
+
+- [ ] **Step 6: Mark P2 complete after all gates pass**
+
+If Step 1 through Step 5 all passed, update the P2 roadmap status from planned
+to complete and amend the Task 11 documentation commit:
+
+```bash
+git add docs/framework-evolution-roadmap.md
+git commit --amend --no-edit
+```
+
+If any gate fails, leave P2 unmarked and fix the scoped failure before repeating
+all gates.

--- a/docs/superpowers/specs/2026-07-30-onestep-local-handler-loop-design.md
+++ b/docs/superpowers/specs/2026-07-30-onestep-local-handler-loop-design.md
@@ -13,8 +13,8 @@ YAML remains a wiring and runtime-policy layer.
 The committed CLI surface is:
 
 ```text
-onestep task run <target> --task <name> --input <json-file> [--send] [--json]
-onestep task replay <target> --task <name> --envelope <capture-file> [--send] [--json]
+onestep task run <target> --task <name> --input <json-file> [--send] [--timeout 60] [--json]
+onestep task replay <target> --task <name> --envelope <capture-file> [--send] [--timeout 60] [--json]
 onestep check <target> --connect [--connect-timeout 10] [--json]
 ```
 
@@ -50,11 +50,12 @@ The current gaps are:
 - Default local execution to dry-run for framework-managed sinks.
 - Make real sink sends an explicit `--send` opt-in.
 - Replay a versioned capture without requiring a running worker or control plane.
-- Capture terminal runtime failures by default, with an option to capture every
-  failed attempt.
+- Attempt to capture terminal runtime failures by default, with an option to
+  attempt capture for every failed attempt.
 - Redact resource secrets and configured payload paths before persistence.
-- Check all configured resources for open/close connectivity without fetching
-  deliveries or starting task runners.
+- Include every configured resource in connectivity reports, probe resources
+  with an explicit lifecycle without fetching, reading, or sending, and clearly
+  identify resources that cannot be probed safely.
 - Preserve existing stable APIs, delivery ordering, task-event semantics,
   reporter payloads, remote controls, and WebSocket behavior.
 
@@ -81,7 +82,7 @@ Production Source
   TaskRunner --------------------------+
   fetch/concurrency/stop controls      |
                                        v
-CLI input/capture -> DiagnosticRunner -> DeliveryExecutor
+CLI supervisor -> diagnostic worker -> DiagnosticRunner -> DeliveryExecutor
                                        | handler
                                        | task hooks
                                        | timeout
@@ -160,6 +161,31 @@ Task-level before, success, and failure hooks do execute. Handler and hook code
 may perform external writes directly; the CLI cannot sandbox those effects and
 must warn before every task run or replay.
 
+### Diagnostic Process And Overall Timeout
+
+`task run` and `task replay` execute the diagnostic session in a fresh child
+process supervised by the CLI parent. Process isolation is required because a
+blocking synchronous handler, hook, route predicate, plugin call, or native
+library cannot be reliably interrupted by an asyncio timeout in the same
+process.
+
+`--timeout` is a positive number of seconds and defaults to `60`. Its monotonic
+deadline begins when the child starts and covers target loading, task
+validation, handler and hook execution, routing, real sends, dead-letter work,
+and normal cleanup. The task's existing `timeout_s` still applies to the handler
+using production semantics; whichever deadline expires first wins.
+
+On overall timeout, the parent requests cooperative cancellation and allows up
+to five additional seconds for reverse-order resource cleanup. If the child is
+still blocked, the parent terminates it and reports cleanup as incomplete. This
+makes the maximum expected wall time `--timeout + 5` seconds while acknowledging
+that forced termination cannot run arbitrary plugin cleanup code.
+
+Timeout produces a versioned diagnostic report with `completion` set to
+`timed_out`, the last stage reported by the child when available, and cleanup
+status. It exits with code `1`. The parent owns final rendering so `--json`
+still emits one valid JSON document even if the child is terminated.
+
 ## Local Execution Semantics
 
 Local diagnostics execute exactly one attempt. They do not loop or sleep for a
@@ -171,6 +197,13 @@ attempt count and reports one of:
 - `would_retry`;
 - `would_dead_letter`;
 - `would_fail`.
+
+These values are diagnostic conclusions, not all equally observable outcomes.
+In dry-run, `would_dead_letter` means that production would attempt dead-letter
+publication; it becomes terminal only if every configured dead-letter publish
+and the source delivery's `fail()` action succeed. The report therefore sets
+`delivery_action_basis` to `predicted` and records that dead-letter publication
+was not attempted.
 
 This makes a production attempt reproducible without making the CLI wait through
 production backoff windows. Existing remote `run_task_once()` keeps its current
@@ -185,6 +218,8 @@ Dry-run is the default.
 - Selected sink names and output envelopes are recorded.
 - Configured emit and dead-letter sinks are not opened or called.
 - Synthetic delivery actions are recorded rather than sent to a source.
+- `would_dead_letter` is explicitly reported as a prediction conditional on
+  successful dead-letter publication and source finalization.
 
 ### Send Mode
 
@@ -197,13 +232,17 @@ Dry-run is the default.
   machine-readable output carries the same warning as structured data.
 - Synthetic source `ack()`, `retry()`, and `fail()` remain local observations;
   no source delivery exists to mutate.
+- A successful dead-letter send is an observed result for this invocation, but
+  the final source action remains synthetic. `--send` can confirm whether the
+  configured dead-letter sinks accepted the capture in this run; it cannot
+  guarantee that a production source's later `fail()` call would succeed.
 
 ## CLI Contract
 
 ### `task run`
 
 ```text
-onestep task run <target> --task <name> --input <json-file> [--send] [--json]
+onestep task run <target> --task <name> --input <json-file> [--send] [--timeout 60] [--json]
 ```
 
 The input file must contain one JSON value. That value becomes `Envelope.body`.
@@ -212,7 +251,7 @@ The synthetic envelope uses empty metadata and `attempts=0`.
 ### `task replay`
 
 ```text
-onestep task replay <target> --task <name> --envelope <capture-file> [--send] [--json]
+onestep task replay <target> --task <name> --envelope <capture-file> [--send] [--timeout 60] [--json]
 ```
 
 Replay validates the capture schema and version, verifies that its app and task
@@ -228,14 +267,29 @@ onestep check <target> --connect [--connect-timeout 10] [--json]
 Connectivity checking:
 
 - performs the normal target load and optional strict YAML validation first;
-- deduplicates shared resource objects by identity;
-- calls each resource's `open()` and `close()` without fetching or sending;
+- inventories named resources, app state, task sources, emit sinks, and
+  dead-letter sinks, then deduplicates shared objects by identity while
+  retaining every name and role in the result;
+- probes only resources that expose callable `open()` and `close()` methods;
+- calls `open()` and `close()` without fetching, reading, writing, or sending;
+- reports state stores, cursor stores, and other resources without both
+  lifecycle methods as `not_probeable`; this status is visible but does not
+  make the command fail;
+- never calls `load()`, `save()`, or `delete()` as a generic connectivity probe,
+  because store operations may create schema or otherwise mutate a backend;
 - checks resources sequentially to avoid connection storms and preserve clear
   attribution;
-- applies the timeout independently to each resource;
+- applies `--connect-timeout` independently to each lifecycle operation;
 - continues after a resource failure so the report includes every resource;
-- always attempts reverse-order cleanup for successfully opened resources;
+- always attempts bounded cleanup after an invoked `open()`, including an open
+  failure or timeout that may have left a partially initialized resource;
 - does not run app hooks or task runners.
+
+Each resource result contains its aliases, roles, concrete type, probe kind
+(`lifecycle` or `none`), status (`connected`, `failed`, or `not_probeable`), and
+separate open/close outcomes when applicable. Exit code `0` means every
+lifecycle probe passed; a report containing only `not_probeable` resources is
+successful but carries an explicit warning that no connection was verified.
 
 ### Output And Exit Codes
 
@@ -249,19 +303,31 @@ Human-readable output is the default. `--json` returns a versioned report:
   "app": "billing-sync",
   "task": "sync_users",
   "mode": "dry-run",
+  "timeout_s": 60,
   "completion": "succeeded",
   "attempts": 0,
   "selected_sinks": ["warehouse"],
   "delivery_action": "would_ack",
+  "delivery_action_basis": "predicted",
+  "dead_letter": {"attempted": false, "published": null},
   "events": [],
   "warning": "handler and task hooks may perform external side effects"
 }
 ```
 
+For `task run` and `task replay`, `delivery_action` always describes the
+synthetic source transition and `delivery_action_basis` is therefore
+`predicted`. The separate `dead_letter` object distinguishes an unattempted
+dry-run (`published: null`) from an observed `--send` success or failure
+(`published: true` or `false`). This prevents a successful sink publication
+from being presented as proof that a real source delivery was finalized.
+
 Exit codes retain the existing CLI convention:
 
-- `0`: successful execution or all connectivity checks passed;
-- `1`: handler execution, sink send, cleanup, or connectivity failure;
+- `0`: successful execution or all attempted lifecycle connectivity probes
+  passed;
+- `1`: handler execution, overall timeout, sink send, cleanup, or lifecycle
+  connectivity failure;
 - `2`: argument, target, configuration, input, capture-version, or capture-task
   validation failure.
 
@@ -302,10 +368,10 @@ app:
 
 `mode` is either:
 
-- `terminal`: capture only after the runtime confirms the delivery will not be
-  retried;
-- `all`: capture every failed attempt that produces a retry or terminal
-  decision.
+- `terminal`: attempt capture only after the runtime confirms the delivery will
+  not be retried;
+- `all`: attempt capture for every failed attempt that produces a retry or
+  terminal decision.
 
 ### Capture Format
 
@@ -334,9 +400,30 @@ Capture files do not reuse or modify the `Envelope` dataclass schema.
 }
 ```
 
-The codec supports JSON values plus tagged datetime, UUID, and bytes values.
-Unsupported values fail capture explicitly. The writer must not persist a lossy
-record that cannot reproduce the delivery.
+The codec uses collision-safe recursive type tags rather than `default=str` or
+`repr()`. It supports JSON values plus these lossless extensions:
+
+- `datetime`, UUID, and bytes;
+- `Decimal`, encoded with its exact string form so exponent, trailing zeros,
+  signed zero, infinities, and NaN forms round trip;
+- plain tuple;
+- enum members, encoded with module, qualified class name, member name, and
+  encoded value;
+- namedtuple instances, encoded with module, qualified class name, field names,
+  and encoded field values;
+- set and frozenset, with members ordered by their canonical encoded JSON so
+  captures are deterministic.
+
+Enum and namedtuple reconstruction is allowed only when the class is importable
+from the already loaded target module graph and its recorded metadata still
+matches. Local classes, dataclasses, arbitrary custom classes, generators,
+open handles, and other unsupported values fail capture explicitly. The error
+identifies the JSON Pointer and type but never includes `repr(value)`.
+
+`mode=all` is therefore best-effort rather than a promise that every failed
+attempt produces a file. Every encode failure emits an ERROR log with app,
+task, stage, safe type name, and unsupported path. The writer must not persist a
+lossy or partial record that cannot reproduce the delivery.
 
 ### Capture Timing
 
@@ -351,7 +438,7 @@ For terminal mode, capture only after the resolved delivery action is known:
   terminal;
 - a `delivery.fail()` failure that falls back to retry is not terminal.
 
-All mode records these retrying failures as non-terminal captures.
+All mode attempts to record these retrying failures as non-terminal captures.
 
 Capture persistence runs through `asyncio.to_thread()` so filesystem work does
 not block the event loop. The delivery waits for the capture result so a reported
@@ -383,11 +470,13 @@ successful capture is durable before the runtime proceeds.
 | Replay load | unsupported schema/version | exit 2 | supported version and received version |
 | Replay validation | app/task mismatch | exit 2 | expected and captured identity |
 | Handler/hook/route | exception or timeout | compute one retry decision | local failure report with stage |
+| Overall diagnostic session | `--timeout` expires | cooperative cancel, bounded cleanup, then terminate if needed; exit 1 | `timed_out`, last stage, and cleanup status |
 | Dry-run sink | output cannot be represented | exit 1 | serialization failure without lossy output |
 | Send sink | normalized connector failure | preserve error kind | redacted backend/operation/kind |
 | Connectivity open | timeout or connector failure | record failure, continue | per-resource result |
 | Resource close | close failure | record failure, continue cleanup | per-resource cleanup result |
-| Capture encode | unsupported value or size limit | do not write | ERROR log with app/task/stage |
+| Resource without lifecycle | no callable `open()` and `close()` pair | do not perform a surrogate read/write probe | `not_probeable` with role and type |
+| Capture encode | unsupported value or size limit | do not write | ERROR log with app/task/stage and safe type/path context |
 | Capture persist | permissions, disk full, atomic-write error | do not change delivery action | ERROR log with safe path context |
 
 Capture failure must never change production acknowledgement, retry, fail, or
@@ -440,16 +529,25 @@ Cover:
 - synchronous and asynchronous handlers and task hooks;
 - conditional true/false routes and multiple selected sinks;
 - one-attempt execution and `would_retry`/`would_dead_letter`/`would_fail`;
+- predicted dry-run dead-letter versus observed `--send` publication, including
+  publication failure and synthetic source finalization;
 - captured attempts participating in retry-policy resolution;
 - local events never reaching an attached reporter;
-- exception, timeout, cancellation, and reverse-order cleanup paths.
+- task timeout, overall process timeout, cooperative cancellation, forced child
+  termination, valid parent-rendered JSON, and reverse-order cleanup paths;
+- blocking synchronous handler and hook fixtures that prove the CLI returns by
+  `--timeout + 5` seconds.
 
 ### Capture Codec And Writer
 
 Cover:
 
-- JSON, datetime, UUID, and bytes round trips;
-- unsupported and oversized values;
+- JSON, datetime, UUID, bytes, Decimal, plain tuple, enum, namedtuple, set, and
+  frozenset round trips;
+- deterministic set ordering and collision-safe tags;
+- unsupported local/custom classes and oversized values;
+- codec failures logging safe type/path context without `repr()` or payload
+  leakage;
 - built-in nested credential-key redaction;
 - configured JSON Pointer paths, including lists and missing paths;
 - owner-only directory and file permissions;
@@ -466,8 +564,10 @@ Cover:
 - human and JSON reports;
 - exit codes 0, 1, and 2;
 - invalid input, schema version, task identity, and target loading;
-- all-resource connectivity results after partial failure;
-- per-resource timeout and reverse-order cleanup;
+- all-resource inventory after partial lifecycle failure;
+- `not_probeable` state/cursor stores, including proof that no store method is
+  called and SQLAlchemy `auto_create` cannot run;
+- per-operation connectivity timeout and bounded cleanup;
 - shared resource identity deduplication;
 - normalized official-connector errors and hidden unknown-plugin messages.
 
@@ -487,6 +587,11 @@ uv run pytest -q -m "not integration"
 - Update `CHANGELOG.md` with the new CLI, capture policy, compatibility statement,
   and side-effect warning.
 - Document the commands in the English and Chinese READMEs.
+- Document that dry-run dead-letter actions are predictions, `--send` observes
+  sink publication but not a real source finalization, and diagnostic commands
+  have an overall timeout.
+- Document the lossless codec's supported types and make the best-effort nature
+  of `mode=all` explicit, including how unsupported custom types are reported.
 - Extend `docs/yaml-task-definition.md` with `app.failure_capture`.
 - Mark P2 complete in `docs/framework-evolution-roadmap.md` only after all exit
   gates pass.
@@ -514,7 +619,8 @@ P2 is complete when:
 - a captured terminal handler failure can be replayed without a worker or
   Control Plane;
 - capture files are versioned, bounded, redacted, private, atomic, and lossless;
-- connectivity checks report every configured resource without fetching work;
+- connectivity checks represent every configured resource, probe only explicit
+  lifecycle capabilities, and never use store reads or writes as a surrogate;
 - local diagnostic events never reach the Control Plane;
 - production delivery and remote manual-run contracts remain unchanged;
 - focused, non-integration, and all-plugin reliability gates pass.

--- a/docs/superpowers/specs/2026-07-30-onestep-local-handler-loop-design.md
+++ b/docs/superpowers/specs/2026-07-30-onestep-local-handler-loop-design.md
@@ -189,6 +189,13 @@ kinds, non-monotonic sequences, or malformed JSON are protocol failures. The
 parent discards the invalid frame, terminates the child, and synthesizes
 `child_failed` from the last previously validated checkpoint.
 
+Target, request, capture, and task validation run only in the supervised child.
+A validation error produces a complete `final` report with
+`completion: validation_failed`; the parent maps that result to exit code `2`.
+The parent never imports a replay target or decodes its capture before starting
+the deadline, so import side effects occur once and target loading cannot bypass
+the overall timeout.
+
 Checkpoint phases cover child startup, target loading, validation, before hook,
 handler, success/failure hook, routing, each sink send, dead-letter publication,
 synthetic delivery action, and cleanup. The partial-field allowlist is limited
@@ -340,6 +347,8 @@ Connectivity checking:
 - checks resources sequentially to avoid connection storms and preserve clear
   attribution;
 - applies `--connect-timeout` independently to each lifecycle operation;
+- invokes synchronous lifecycle methods on a daemon call thread so a blocking
+  method cannot pin the diagnostic event loop beyond that timeout;
 - continues after a resource failure so the report includes every resource;
 - always attempts bounded cleanup after an invoked `open()`, including an open
   failure or timeout that may have left a partially initialized resource;
@@ -381,6 +390,10 @@ synthetic source transition and `delivery_action_basis` is therefore
 dry-run (`published: null`) from an observed `--send` success or failure
 (`published: true` or `false`). This prevents a successful sink publication
 from being presented as proof that a real source delivery was finalized.
+
+`completion: validation_failed` is reserved for target, request, capture, or
+task validation performed by the supervised child. It is a structured
+exit-code `2` result, not a handler execution failure.
 
 Exit codes retain the existing CLI convention:
 
@@ -474,6 +487,12 @@ The codec uses collision-safe recursive type tags rather than `default=str` or
 - set and frozenset, with members ordered by their canonical encoded JSON so
   captures are deterministic.
 
+Only exact built-in scalar and container types are accepted by the plain JSON
+branches. Subclasses of `int`, `str`, `dict`, `list`, and the other supported
+built-ins are rejected unless they have an explicit lossless extension such as
+enum or namedtuple; silently converting a custom subtype to its base type would
+make the capture lossy.
+
 Enum and namedtuple reconstruction is allowed only when the class is importable
 from the already loaded target module graph and its recorded metadata still
 matches. Local classes, dataclasses, arbitrary custom classes, generators,
@@ -527,8 +546,8 @@ successful capture is durable before the runtime proceeds.
 | Codepath | Failure | Behavior | User visibility |
 | --- | --- | --- | --- |
 | Input load | invalid JSON or unreadable file | exit 2 | exact file and validation error |
-| Replay load | unsupported schema/version | exit 2 | supported version and received version |
-| Replay validation | app/task mismatch | exit 2 | expected and captured identity |
+| Replay load | unsupported schema/version | child returns `validation_failed`; exit 2 | supported version and received version |
+| Replay validation | target load or app/task mismatch | child returns `validation_failed`; exit 2 | report has safe exception type/stage; stderr retains validation detail |
 | Handler/hook/route | exception or timeout | compute one retry decision | local failure report with stage |
 | Overall diagnostic session | `--timeout` expires | cooperative cancel, bounded cleanup, then terminate if needed; exit 1 | `timed_out`, last stage, and cleanup status |
 | Diagnostic child/IPC | child exits or status pipe breaks without `final` | parent synthesizes report; exit 1 | `child_failed` and last valid checkpoint |

--- a/docs/superpowers/specs/2026-07-30-onestep-local-handler-loop-design.md
+++ b/docs/superpowers/specs/2026-07-30-onestep-local-handler-loop-design.md
@@ -164,10 +164,45 @@ must warn before every task run or replay.
 ### Diagnostic Process And Overall Timeout
 
 `task run` and `task replay` execute the diagnostic session in a fresh child
-process supervised by the CLI parent. Process isolation is required because a
-blocking synchronous handler, hook, route predicate, plugin call, or native
-library cannot be reliably interrupted by an asyncio timeout in the same
-process.
+process supervised by the CLI parent. The child uses the `spawn` start method so
+it does not inherit event-loop, app, thread, or connector state. Process
+isolation is required because a blocking synchronous handler, hook, route
+predicate, plugin call, or native library cannot be reliably interrupted by an
+asyncio timeout in the same process.
+
+The parent creates two private one-way pipes for each spawned child: a control
+pipe from parent to child and a status pipe from child to parent. Pipe messages
+are UTF-8 JSON frames sent with `Connection.send_bytes()` and
+`Connection.recv_bytes()`, not pickled Python objects and not stdout. Every
+frame contains the internal schema `onestep/diagnostic-ipc`, version `1`, and a
+monotonically increasing sequence for its direction. The status pipe supports:
+
+- `checkpoint`: the child sends this immediately before each potentially
+  blocking phase and after each externally visible send or cleanup transition.
+  It contains the current phase, transition (`entered` or `completed`), elapsed
+  time, and only safe partial result fields accumulated so far;
+- `final`: the complete versioned diagnostic result, sent only after normal
+  cleanup finishes.
+
+The control pipe accepts only a `cancel` frame. Unknown schemas, versions,
+kinds, non-monotonic sequences, or malformed JSON are protocol failures. The
+parent discards the invalid frame, terminates the child, and synthesizes
+`child_failed` from the last previously validated checkpoint.
+
+Checkpoint phases cover child startup, target loading, validation, before hook,
+handler, success/failure hook, routing, each sink send, dead-letter publication,
+synthetic delivery action, and cleanup. The partial-field allowlist is limited
+to app/task/resource identifiers, selected sink names, completion booleans,
+elapsed time, and cleanup status. Checkpoints must not contain envelope bodies,
+exception messages, credentials, or arbitrary object representations.
+The parent continuously drains and validates the status pipe while supervising
+the deadline, retaining the highest valid checkpoint sequence. Child stdout and
+stderr are forwarded to parent stderr; stdout is reserved for the parent's final
+human or JSON report and is never used as IPC.
+
+This IPC is local and private to a parent and child from the same installed
+onestep version. It is not an exported API, reporter payload, WebSocket message,
+or Control Plane protocol.
 
 `--timeout` is a positive number of seconds and defaults to `60`. Its monotonic
 deadline begins when the child starts and covers target loading, task
@@ -175,16 +210,31 @@ validation, handler and hook execution, routing, real sends, dead-letter work,
 and normal cleanup. The task's existing `timeout_s` still applies to the handler
 using production semantics; whichever deadline expires first wins.
 
-On overall timeout, the parent requests cooperative cancellation and allows up
-to five additional seconds for reverse-order resource cleanup. If the child is
-still blocked, the parent terminates it and reports cleanup as incomplete. This
-makes the maximum expected wall time `--timeout + 5` seconds while acknowledging
-that forced termination cannot run arbitrary plugin cleanup code.
+On overall timeout, the parent sends a `cancel` control frame. A child-side
+control listener schedules cancellation on the diagnostic event loop when it is
+responsive, after which the child attempts reverse-order cleanup and may return
+a final timeout report. The parent allows up to five additional seconds for
+this cooperative path. If the child is still blocked, the parent forcibly
+terminates it and reports cleanup as incomplete. This makes the maximum expected
+wall time `--timeout + 5` seconds while acknowledging that forced termination
+cannot run arbitrary plugin cleanup code.
 
 Timeout produces a versioned diagnostic report with `completion` set to
-`timed_out`, the last stage reported by the child when available, and cleanup
-status. It exits with code `1`. The parent owns final rendering so `--json`
-still emits one valid JSON document even if the child is terminated.
+`timed_out`, the last valid checkpoint retained by the parent, and cleanup
+status. If the child never produced a checkpoint, the parent uses
+`child_start`. A child exit or broken status pipe without a valid `final` frame
+similarly produces a parent-authored `child_failed` report rather than partial
+JSON. Timeout exits with code `1`; the parent always owns final rendering, so
+`--json` emits exactly one valid JSON document even after forced termination.
+
+In `--send` mode, timeout or forced termination may occur after an external sink
+has accepted all or part of a write but before its `completed` checkpoint. That
+outcome is inherently ambiguous and can leave partial fan-out, duplicates on a
+later replay, or backend connections that close only when the operating system
+reclaims the process. Any timeout with an entered but incomplete send sets
+`side_effect_outcome` to `unknown` and repeats this warning in the result. This
+is an explicit risk accepted by opting into `--send`; onestep cannot roll back
+or prove the outcome of the interrupted external operation.
 
 ## Local Execution Semantics
 
@@ -236,8 +286,18 @@ Dry-run is the default.
   the final source action remains synthetic. `--send` can confirm whether the
   configured dead-letter sinks accepted the capture in this run; it cannot
   guarantee that a production source's later `fail()` call would succeed.
+- A timeout or forced child termination during a real send has an unknown
+  external outcome. Retrying the diagnostic may duplicate a write that the
+  backend committed before the timeout.
 
 ## CLI Contract
+
+The current argument-normalization shim treats an unknown first token as the
+legacy `run` shorthand. Implementation must add `task` to
+`_normalize_argv()`'s known top-level command set before parsing nested
+subcommands; otherwise `onestep task run ...` is silently rewritten as
+`onestep run task run ...`. The legacy shorthand remains unchanged for other
+unknown first tokens.
 
 ### `task run`
 
@@ -471,8 +531,10 @@ successful capture is durable before the runtime proceeds.
 | Replay validation | app/task mismatch | exit 2 | expected and captured identity |
 | Handler/hook/route | exception or timeout | compute one retry decision | local failure report with stage |
 | Overall diagnostic session | `--timeout` expires | cooperative cancel, bounded cleanup, then terminate if needed; exit 1 | `timed_out`, last stage, and cleanup status |
+| Diagnostic child/IPC | child exits or status pipe breaks without `final` | parent synthesizes report; exit 1 | `child_failed` and last valid checkpoint |
 | Dry-run sink | output cannot be represented | exit 1 | serialization failure without lossy output |
 | Send sink | normalized connector failure | preserve error kind | redacted backend/operation/kind |
+| Interrupted in-flight `--send` | external commit state cannot be known | do not claim rollback or retry safety | `side_effect_outcome: unknown` and duplicate/partial-write warning |
 | Connectivity open | timeout or connector failure | record failure, continue | per-resource result |
 | Resource close | close failure | record failure, continue cleanup | per-resource cleanup result |
 | Resource without lifecycle | no callable `open()` and `close()` pair | do not perform a surrogate read/write probe | `not_probeable` with role and type |
@@ -491,6 +553,10 @@ This is an additive core feature suitable for a minor release.
 - Existing YAML remains valid; `app.failure_capture` is additive.
 - Existing `run`, `check`, `init`, `build`, and `catalog` command behavior is
   unchanged.
+- `_normalize_argv()` recognizes `task` as a top-level command so nested task
+  commands bypass legacy shorthand rewriting. Consequently, the bare shorthand
+  target name `task` becomes reserved; users of that exact target must write
+  `onestep run task`. Other shorthand targets remain unchanged.
 - `TaskRunner` retains its constructor and compatibility entry point.
 - `run_task_once()` retains its current remote-control contract.
 - Existing `Envelope` and `TaskEvent` fields and semantics are unchanged.
@@ -536,7 +602,14 @@ Cover:
 - task timeout, overall process timeout, cooperative cancellation, forced child
   termination, valid parent-rendered JSON, and reverse-order cleanup paths;
 - blocking synchronous handler and hook fixtures that prove the CLI returns by
-  `--timeout + 5` seconds.
+  `--timeout + 5` seconds;
+- ordered IPC checkpoints for every blocking phase, malformed/truncated frame
+  handling, child exit without `final`, and fallback to `child_start` when no
+  checkpoint arrives;
+- child stdout/stderr during `--json` without corruption of the single JSON
+  document emitted on parent stdout;
+- forced termination during `--send` reporting an unknown external side-effect
+  outcome and the duplicate/partial-write warning.
 
 ### Capture Codec And Writer
 
@@ -560,7 +633,8 @@ Cover:
 
 Cover:
 
-- command parsing and help;
+- command parsing and help, including `task` bypassing shorthand normalization,
+  explicit `onestep run task`, and unchanged shorthand for other targets;
 - human and JSON reports;
 - exit codes 0, 1, and 2;
 - invalid input, schema version, task identity, and target loading;
@@ -585,11 +659,13 @@ uv run pytest -q -m "not integration"
 - Release core as a minor version, expected to be `1.8.0` if no earlier minor is
   released first.
 - Update `CHANGELOG.md` with the new CLI, capture policy, compatibility statement,
-  and side-effect warning.
+  the reserved bare `task` shorthand, and side-effect warning.
 - Document the commands in the English and Chinese READMEs.
 - Document that dry-run dead-letter actions are predictions, `--send` observes
   sink publication but not a real source finalization, and diagnostic commands
   have an overall timeout.
+- Document that timeout or forced termination during `--send` has an unknown
+  external outcome and may cause partial or duplicate writes on replay.
 - Document the lossless codec's supported types and make the best-effort nature
   of `mode=all` explicit, including how unsupported custom types are reported.
 - Extend `docs/yaml-task-definition.md` with `app.failure_capture`.
@@ -615,7 +691,13 @@ frontend types and views, and image rebuild/restart in one compatibility window.
 P2 is complete when:
 
 - both Python and YAML targets support local run and replay;
+- `task` commands bypass legacy argv rewriting while explicit `run` and other
+  shorthand targets retain their behavior;
 - dry-run never invokes framework-managed sinks;
+- an unresponsive diagnostic child returns a parent-authored valid report with
+  its last safe checkpoint within the documented deadline and cleanup grace;
+- an interrupted in-flight `--send` is reported with an unknown external
+  side-effect outcome rather than a false success or rollback claim;
 - a captured terminal handler failure can be replayed without a worker or
   Control Plane;
 - capture files are versioned, bounded, redacted, private, atomic, and lossless;

--- a/docs/superpowers/specs/2026-07-30-onestep-local-handler-loop-design.md
+++ b/docs/superpowers/specs/2026-07-30-onestep-local-handler-loop-design.md
@@ -1,0 +1,520 @@
+# onestep Local Handler Loop Design
+
+## Summary
+
+P2 adds a local diagnostic loop for running one task delivery, replaying a
+captured production failure, checking resource connectivity, and optionally
+capturing runtime failures to versioned files.
+
+The implementation must reuse production delivery execution semantics without
+changing the existing remote manual-run behavior. Python owns handler logic;
+YAML remains a wiring and runtime-policy layer.
+
+The committed CLI surface is:
+
+```text
+onestep task run <target> --task <name> --input <json-file> [--send] [--json]
+onestep task replay <target> --task <name> --envelope <capture-file> [--send] [--json]
+onestep check <target> --connect [--connect-timeout 10] [--json]
+```
+
+## Current State
+
+`TaskRunner` currently owns both polling/concurrency control and single-delivery
+execution. Its `_handle_delivery()` method invokes task hooks, the handler,
+conditional sink routes, sink sends, acknowledgement, retry, dead-letter, and
+task-event emission.
+
+`OneStepApp.run_task_once()` already creates a synthetic delivery and calls the
+same `TaskRunner` path. The control-plane WebSocket implementation calls this
+method directly for remote manual runs, so its signature, return value,
+exceptions, eligibility checks, and event behavior are compatibility
+commitments for this work.
+
+The current gaps are:
+
+- there is no public local task-run or replay CLI;
+- `run_task_once()` is coupled to remote manual-run eligibility;
+- local execution cannot suppress framework-managed sink writes while retaining
+  handler, hook, and route behavior;
+- there is no versioned, redacted envelope capture format;
+- `check` validates configuration but does not test resource connectivity;
+- task events do not contain delivery bodies, so failure capture cannot be
+  implemented safely as a generic event observer.
+
+## Goals
+
+- Support Python `module:app` and YAML worker targets equally.
+- Execute one synthetic delivery through the same handler, task hooks, route
+  selection, timeout, and retry-policy decision logic as production.
+- Default local execution to dry-run for framework-managed sinks.
+- Make real sink sends an explicit `--send` opt-in.
+- Replay a versioned capture without requiring a running worker or control plane.
+- Capture terminal runtime failures by default, with an option to capture every
+  failed attempt.
+- Redact resource secrets and configured payload paths before persistence.
+- Check all configured resources for open/close connectivity without fetching
+  deliveries or starting task runners.
+- Preserve existing stable APIs, delivery ordering, task-event semantics,
+  reporter payloads, remote controls, and WebSocket behavior.
+
+## Non-Goals
+
+- No general side-effect sandbox for handler or hook code.
+- No multi-delivery batch replay.
+- No YAML transformation or workflow DSL.
+- No Control Plane capture download or replay UI.
+- No delivery/attempt correlation fields, source lag metrics, recovery audit
+  records, or reporter protocol changes. Those belong to P3.
+- No change to the existing remote `run_task_once()` contract.
+- No modification of `Envelope` or `TaskEvent` fields in P2.
+
+## Architecture
+
+Extract single-delivery execution into an internal `DeliveryExecutor`. Keep
+fetching and worker lifecycle behavior in `TaskRunner`.
+
+```text
+Production Source
+      |
+      v
+  TaskRunner --------------------------+
+  fetch/concurrency/stop controls      |
+                                       v
+CLI input/capture -> DiagnosticRunner -> DeliveryExecutor
+                                       | handler
+                                       | task hooks
+                                       | timeout
+                                       | route selection
+                                       | retry decision
+                                       |
+                         +-------------+-------------+
+                         |                           |
+                  production policy          diagnostic policy
+                  real delivery actions      synthetic actions
+                  app.emit_event()            local event collector
+                  real sink sends             collect or --send
+```
+
+### Compatibility Facade
+
+`TaskRunner` remains importable from `onestep.runtime`. Preserve:
+
+- `TaskRunner(app, task)` construction;
+- the existing runner lifecycle properties and methods;
+- the current `_handle_delivery()` behavior as a delegating compatibility
+  entry point;
+- production event ordering and delivery action ordering.
+
+`OneStepApp.run_task_once()` retains its current public signature and result
+shape. It may reuse the extracted executor internally, but this refactor must be
+covered by characterization tests before behavior moves.
+
+### DeliveryExecutor
+
+`DeliveryExecutor` is internal and is not exported from `onestep`.
+
+It accepts explicit collaborators for:
+
+- event emission;
+- sink dispatch;
+- delivery actions;
+- optional failure capture.
+
+Production collaborators retain the current behavior. Diagnostic collaborators
+collect local events and intended delivery actions without invoking the
+reporter or source acknowledgement callbacks.
+
+The executor tracks the active failure stage:
+
+- `before_hook`;
+- `handler`;
+- `after_success_hook`;
+- `route`;
+- `sink`;
+- `ack`;
+- `dead_letter`;
+- `delivery_action`.
+
+This stage is diagnostic metadata only. It does not add task-event kinds or
+change retry classification.
+
+### DiagnosticRunner
+
+`DiagnosticRunner` is internal and is used by the CLI.
+
+It:
+
+- resolves a task by name;
+- creates a synthetic delivery from input or a capture;
+- executes one attempt through `DeliveryExecutor`;
+- collects the handler result, selected sinks, local task events, resolved
+  retry decision, failure stage, and duration;
+- never starts source polling;
+- never invokes app-level startup or shutdown hooks;
+- does not attach, start, or flush a reporter;
+- opens a selected sink immediately before a real `--send` and closes opened
+  resources in reverse order.
+
+Task-level before, success, and failure hooks do execute. Handler and hook code
+may perform external writes directly; the CLI cannot sandbox those effects and
+must warn before every task run or replay.
+
+## Local Execution Semantics
+
+Local diagnostics execute exactly one attempt. They do not loop or sleep for a
+configured retry delay.
+
+On failure, the executor evaluates the existing retry policy with the captured
+attempt count and reports one of:
+
+- `would_retry`;
+- `would_dead_letter`;
+- `would_fail`.
+
+This makes a production attempt reproducible without making the CLI wait through
+production backoff windows. Existing remote `run_task_once()` keeps its current
+multi-attempt behavior.
+
+### Dry-Run
+
+Dry-run is the default.
+
+- Handler and task hooks execute.
+- Conditional route predicates execute.
+- Selected sink names and output envelopes are recorded.
+- Configured emit and dead-letter sinks are not opened or called.
+- Synthetic delivery actions are recorded rather than sent to a source.
+
+### Send Mode
+
+`--send` opts into framework-managed external writes.
+
+- Selected emit sinks are opened, called, and closed.
+- If execution resolves to dead-letter, configured dead-letter sinks may be
+  opened and called.
+- The CLI prints an explicit side-effect warning even when `--json` is used;
+  machine-readable output carries the same warning as structured data.
+- Synthetic source `ack()`, `retry()`, and `fail()` remain local observations;
+  no source delivery exists to mutate.
+
+## CLI Contract
+
+### `task run`
+
+```text
+onestep task run <target> --task <name> --input <json-file> [--send] [--json]
+```
+
+The input file must contain one JSON value. That value becomes `Envelope.body`.
+The synthetic envelope uses empty metadata and `attempts=0`.
+
+### `task replay`
+
+```text
+onestep task replay <target> --task <name> --envelope <capture-file> [--send] [--json]
+```
+
+Replay validates the capture schema and version, verifies that its app and task
+match the selected target, then reconstructs body, metadata, and attempts.
+Cross-task replay is rejected in P2.
+
+### `check --connect`
+
+```text
+onestep check <target> --connect [--connect-timeout 10] [--json]
+```
+
+Connectivity checking:
+
+- performs the normal target load and optional strict YAML validation first;
+- deduplicates shared resource objects by identity;
+- calls each resource's `open()` and `close()` without fetching or sending;
+- checks resources sequentially to avoid connection storms and preserve clear
+  attribution;
+- applies the timeout independently to each resource;
+- continues after a resource failure so the report includes every resource;
+- always attempts reverse-order cleanup for successfully opened resources;
+- does not run app hooks or task runners.
+
+### Output And Exit Codes
+
+Human-readable output is the default. `--json` returns a versioned report:
+
+```json
+{
+  "schema": "onestep/diagnostic-result",
+  "version": 1,
+  "operation": "run",
+  "app": "billing-sync",
+  "task": "sync_users",
+  "mode": "dry-run",
+  "completion": "succeeded",
+  "attempts": 0,
+  "selected_sinks": ["warehouse"],
+  "delivery_action": "would_ack",
+  "events": [],
+  "warning": "handler and task hooks may perform external side effects"
+}
+```
+
+Exit codes retain the existing CLI convention:
+
+- `0`: successful execution or all connectivity checks passed;
+- `1`: handler execution, sink send, cleanup, or connectivity failure;
+- `2`: argument, target, configuration, input, capture-version, or capture-task
+  validation failure.
+
+## Failure Capture
+
+### Configuration
+
+Failure capture is disabled by default.
+
+Python applications opt in with an additive stable API:
+
+```python
+from onestep import FailureCaptureConfig, OneStepApp
+
+app = OneStepApp(
+    "billing-sync",
+    failure_capture=FailureCaptureConfig(
+        directory=".onestep/captures",
+        mode="terminal",
+        max_bytes=1_048_576,
+        redact_paths=("/body/password",),
+    ),
+)
+```
+
+YAML applications use runtime policy under `app`:
+
+```yaml
+app:
+  name: billing-sync
+  failure_capture:
+    directory: .onestep/captures
+    mode: terminal
+    max_bytes: 1048576
+    redact_paths:
+      - /body/password
+```
+
+`mode` is either:
+
+- `terminal`: capture only after the runtime confirms the delivery will not be
+  retried;
+- `all`: capture every failed attempt that produces a retry or terminal
+  decision.
+
+### Capture Format
+
+Capture files do not reuse or modify the `Envelope` dataclass schema.
+
+```json
+{
+  "schema": "onestep/envelope-capture",
+  "version": 1,
+  "captured_at": "2026-07-30T10:00:00Z",
+  "app": "billing-sync",
+  "task": "sync_users",
+  "stage": "handler",
+  "terminal": true,
+  "failure": {
+    "kind": "error",
+    "exception_type": "ValueError",
+    "message": "invalid record"
+  },
+  "envelope": {
+    "body": {},
+    "meta": {},
+    "attempts": 2
+  },
+  "redacted_paths": []
+}
+```
+
+The codec supports JSON values plus tagged datetime, UUID, and bytes values.
+Unsupported values fail capture explicitly. The writer must not persist a lossy
+record that cannot reproduce the delivery.
+
+### Capture Timing
+
+Capture occurs inside the delivery executor because task events deliberately do
+not carry payload bodies.
+
+For terminal mode, capture only after the resolved delivery action is known:
+
+- a successful dead-letter publish followed by a successful fail action is
+  terminal;
+- a dead-letter publish failure that retries the original delivery is not
+  terminal;
+- a `delivery.fail()` failure that falls back to retry is not terminal.
+
+All mode records these retrying failures as non-terminal captures.
+
+Capture persistence runs through `asyncio.to_thread()` so filesystem work does
+not block the event loop. The delivery waits for the capture result so a reported
+successful capture is durable before the runtime proceeds.
+
+## Security
+
+- Capture directories are created with owner-only permissions where supported.
+- Capture files use mode `0600` and a temporary file plus atomic replacement.
+- Existing symbolic-link directories or file targets are rejected.
+- File names use capture time and a random identifier, never payload values.
+- Common case-insensitive credential keys are redacted by default, including
+  password, secret, token, authorization, cookie, API key, and DSN variants.
+- User JSON Pointer paths provide workload-specific payload redaction.
+- Redacted paths are recorded in the capture metadata without recording the
+  removed values.
+- Captures remain sensitive operational artifacts even after redaction. The
+  documentation must state that payload PII may remain and that capture
+  directories require normal retention and access controls.
+- Official connector connectivity errors use normalized public error fields.
+- Unknown plugin exceptions expose the exception type but hide the raw message
+  by default, because it may contain credentials or DSNs.
+
+## Error Handling
+
+| Codepath | Failure | Behavior | User visibility |
+| --- | --- | --- | --- |
+| Input load | invalid JSON or unreadable file | exit 2 | exact file and validation error |
+| Replay load | unsupported schema/version | exit 2 | supported version and received version |
+| Replay validation | app/task mismatch | exit 2 | expected and captured identity |
+| Handler/hook/route | exception or timeout | compute one retry decision | local failure report with stage |
+| Dry-run sink | output cannot be represented | exit 1 | serialization failure without lossy output |
+| Send sink | normalized connector failure | preserve error kind | redacted backend/operation/kind |
+| Connectivity open | timeout or connector failure | record failure, continue | per-resource result |
+| Resource close | close failure | record failure, continue cleanup | per-resource cleanup result |
+| Capture encode | unsupported value or size limit | do not write | ERROR log with app/task/stage |
+| Capture persist | permissions, disk full, atomic-write error | do not change delivery action | ERROR log with safe path context |
+
+Capture failure must never change production acknowledgement, retry, fail, or
+dead-letter decisions. It must also never be silently ignored.
+
+## Compatibility
+
+This is an additive core feature suitable for a minor release.
+
+- Existing `OneStepApp` constructor calls continue to work because
+  `failure_capture` is keyword-only and defaults to `None`.
+- Existing YAML remains valid; `app.failure_capture` is additive.
+- Existing `run`, `check`, `init`, `build`, and `catalog` command behavior is
+  unchanged.
+- `TaskRunner` retains its constructor and compatibility entry point.
+- `run_task_once()` retains its current remote-control contract.
+- Existing `Envelope` and `TaskEvent` fields and semantics are unchanged.
+- Reporter payloads, lifecycle event kinds, WebSocket messages, runtime identity,
+  and Control Plane storage are unchanged.
+- Capture is disabled unless configured, so existing workers gain no filesystem
+  writes or new failure-path latency.
+
+Strict YAML files using `app.failure_capture` require a P2-capable runtime. Older
+runtimes will reject the unknown field in strict mode; this is expected forward
+configuration incompatibility, not a change to existing configurations.
+
+## Testing Strategy
+
+### Production Characterization
+
+Before extracting the executor, add or identify tests that lock down:
+
+- handler and task-hook ordering;
+- conditional route selection;
+- sink send before source acknowledgement;
+- success event after acknowledgement;
+- handler, hook, predicate, sink, timeout, and acknowledgement failure paths;
+- retry, dead-letter, fail, cancellation, and fallback-retry behavior;
+- event kinds, attempts, duration, failure classification, and metadata.
+
+The same tests must pass unchanged after extraction.
+
+### DiagnosticRunner
+
+Cover:
+
+- Python and YAML targets;
+- dry-run does not open or call emit/dead-letter sinks;
+- `--send` opens, sends, and closes selected sinks;
+- synchronous and asynchronous handlers and task hooks;
+- conditional true/false routes and multiple selected sinks;
+- one-attempt execution and `would_retry`/`would_dead_letter`/`would_fail`;
+- captured attempts participating in retry-policy resolution;
+- local events never reaching an attached reporter;
+- exception, timeout, cancellation, and reverse-order cleanup paths.
+
+### Capture Codec And Writer
+
+Cover:
+
+- JSON, datetime, UUID, and bytes round trips;
+- unsupported and oversized values;
+- built-in nested credential-key redaction;
+- configured JSON Pointer paths, including lists and missing paths;
+- owner-only directory and file permissions;
+- atomic replacement, collisions, disk errors, and symbolic-link rejection;
+- terminal versus all capture modes;
+- dead-letter and fail-action fallback-to-retry classification;
+- capture failures preserving the original delivery action.
+
+### CLI And Connectivity
+
+Cover:
+
+- command parsing and help;
+- human and JSON reports;
+- exit codes 0, 1, and 2;
+- invalid input, schema version, task identity, and target loading;
+- all-resource connectivity results after partial failure;
+- per-resource timeout and reverse-order cleanup;
+- shared resource identity deduplication;
+- normalized official-connector errors and hidden unknown-plugin messages.
+
+### Validation Gates
+
+```bash
+uv run pytest -q tests/test_cli.py tests/test_diagnostics.py tests/test_failure_capture.py
+uv run pytest -q tests/contract/test_runtime_contract.py
+uv run pytest -q -m "not integration"
+./scripts/run-reliability-checks.sh
+```
+
+## Documentation And Release
+
+- Release core as a minor version, expected to be `1.8.0` if no earlier minor is
+  released first.
+- Update `CHANGELOG.md` with the new CLI, capture policy, compatibility statement,
+  and side-effect warning.
+- Document the commands in the English and Chinese READMEs.
+- Extend `docs/yaml-task-definition.md` with `app.failure_capture`.
+- Mark P2 complete in `docs/framework-evolution-roadmap.md` only after all exit
+  gates pass.
+- Update `uv.lock` as part of the core version bump.
+- No plugin version bump is required because plugin contracts do not change.
+- No Control Plane image rebuild is required because P2 changes no Control Plane
+  code or baked assets.
+
+## P3 Boundary
+
+P3 begins only after the P2 capture and diagnostic APIs are proven. Its separate
+design will cover stable delivery correlation across retries and dead-letter
+replay, attempt identity, reporter payloads, Control Plane migration, API/UI
+rendering, lag metrics, and audited recovery operations.
+
+P3 must coordinate runtime, the control-plane reporter plugin, backend schema,
+frontend types and views, and image rebuild/restart in one compatibility window.
+
+## Success Criteria
+
+P2 is complete when:
+
+- both Python and YAML targets support local run and replay;
+- dry-run never invokes framework-managed sinks;
+- a captured terminal handler failure can be replayed without a worker or
+  Control Plane;
+- capture files are versioned, bounded, redacted, private, atomic, and lossless;
+- connectivity checks report every configured resource without fetching work;
+- local diagnostic events never reach the Control Plane;
+- production delivery and remote manual-run contracts remain unchanged;
+- focused, non-integration, and all-plugin reliability gates pass.

--- a/docs/yaml-task-definition.md
+++ b/docs/yaml-task-definition.md
@@ -9,7 +9,7 @@
 
 YAML is responsible for:
 
-- `app`: name, global config, shutdown timeout, state store binding, framework log level
+- `app`: name, global config, shutdown timeout, state store binding, framework log level, failure capture policy
 - `reporter`: optional control-plane telemetry wiring through `onestep[control-plane]`
 - `resources`: named runtime objects and their dependencies
 - `hooks`: app-level startup, shutdown, and event observers
@@ -68,6 +68,49 @@ For long-lived configs, prefer adding:
 apiVersion: onestep/v1alpha1
 kind: App
 ```
+
+## Failure Capture
+
+Failure capture is disabled unless `app.failure_capture` is configured:
+
+```yaml
+app:
+  name: billing-sync
+  failure_capture:
+    directory: ./captures
+    mode: terminal
+    max_bytes: 1048576
+    redact_paths:
+      - /body/customer/token
+      - /meta/authorization
+```
+
+| Field | Required/default | Meaning |
+| --- | --- | --- |
+| `directory` | required | Directory for private, atomically written capture files. |
+| `mode` | `terminal` | `terminal` captures effective terminal failures; `all` also captures retryable attempts. |
+| `max_bytes` | `1048576` | Positive maximum encoded file size. Oversized captures fail explicitly. |
+| `redact_paths` | `[]` | JSON Pointer paths under the logical `/body` and `/meta` document. |
+
+Known secret-key names are redacted recursively in addition to configured
+pointers. Capture files use the versioned `onestep/envelope-capture` schema and
+preserve JSON scalars/containers plus datetime, UUID, bytes, Decimal, enum,
+tuple/namedtuple, set, and frozenset values. Enum and namedtuple types must
+remain importable when replayed.
+
+The format does not stringify unsupported values. In `mode: all`, an attempt
+containing an unsupported custom value logs a capture encoding error and writes
+no file; task retry/dead-letter behavior continues unchanged. This avoids a
+record that looks replayable but has already lost type information.
+
+Replay a valid capture with:
+
+```bash
+onestep task replay worker.yaml --task sync_billing --envelope captures/failure.json
+```
+
+The capture schema/version and app/task identity are validated before replay.
+Sink I/O remains disabled unless `--send` is explicit.
 
 ## Real Project Layout
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep"
-version = "1.7.3"
+version = "1.8.0"
 description = "Async task runtime for queue, polling, schedule, and webhook workloads."
 authors = [
     { name = "miclon", email = "jcnd@163.com" }

--- a/src/onestep/__init__.py
+++ b/src/onestep/__init__.py
@@ -2,6 +2,7 @@ from importlib.metadata import PackageNotFoundError, version as _package_version
 from importlib.util import find_spec as _find_spec
 
 from .app import OneStepApp
+from .capture import FailureCaptureConfig
 from .config import load_app_config, load_resource_catalog, load_yaml_app
 from .context import TaskContext
 from .envelope import Envelope
@@ -90,6 +91,7 @@ _CORE_EXPORTS = [
     "Delivery",
     "Envelope",
     "FailureInfo",
+    "FailureCaptureConfig",
     "FailureKind",
     "GaugeMetric",
     "HttpSink",

--- a/src/onestep/app.py
+++ b/src/onestep/app.py
@@ -10,6 +10,7 @@ import signal
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
+from .capture.config import FailureCaptureConfig
 from .connectors.base import Sink, Source
 from .envelope import Envelope
 from .events import StructuredEventLogger, TaskEvent
@@ -60,6 +61,7 @@ class OneStepApp:
         config: Mapping[str, Any] | None = None,
         state: StateStore | None = None,
         shutdown_timeout_s: float | None = 30.0,
+        failure_capture: FailureCaptureConfig | None = None,
     ) -> None:
         if shutdown_timeout_s is not None and shutdown_timeout_s <= 0:
             raise ValueError("shutdown_timeout_s must be > 0")
@@ -67,6 +69,7 @@ class OneStepApp:
         self.config = dict(config or {})
         self.state = state or InMemoryStateStore()
         self.shutdown_timeout_s = shutdown_timeout_s
+        self.failure_capture = failure_capture
         self.custom_metrics = CustomMetricsRegistry()
         self._tasks: list[TaskSpec] = []
         self._named_resources: dict[str, Any] = {}

--- a/src/onestep/app.py
+++ b/src/onestep/app.py
@@ -11,6 +11,7 @@ from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from .capture.config import FailureCaptureConfig
+from .capture.writer import FailureCaptureWriter
 from .connectors.base import Sink, Source
 from .envelope import Envelope
 from .events import StructuredEventLogger, TaskEvent
@@ -70,6 +71,11 @@ class OneStepApp:
         self.state = state or InMemoryStateStore()
         self.shutdown_timeout_s = shutdown_timeout_s
         self.failure_capture = failure_capture
+        self._failure_capture_writer = (
+            FailureCaptureWriter(failure_capture)
+            if failure_capture is not None
+            else None
+        )
         self.custom_metrics = CustomMetricsRegistry()
         self._tasks: list[TaskSpec] = []
         self._named_resources: dict[str, Any] = {}

--- a/src/onestep/capture/__init__.py
+++ b/src/onestep/capture/__init__.py
@@ -1,0 +1,15 @@
+from .codec import CaptureEncodingError, decode_value, encode_value
+from .config import CaptureMode, FailureCaptureConfig
+from .writer import FailureCaptureWriter, LoadedCapture, load_capture, redact_envelope
+
+__all__ = [
+    "CaptureEncodingError",
+    "CaptureMode",
+    "FailureCaptureConfig",
+    "FailureCaptureWriter",
+    "LoadedCapture",
+    "decode_value",
+    "encode_value",
+    "load_capture",
+    "redact_envelope",
+]

--- a/src/onestep/capture/codec.py
+++ b/src/onestep/capture/codec.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import base64
+import json
+import math
+import sys
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+TAG = "$onestep"
+
+
+class CaptureEncodingError(ValueError):
+    def __init__(self, *, path: str, type_name: str, reason: str) -> None:
+        self.path = path or "/"
+        self.type_name = type_name
+        self.reason = reason
+        super().__init__(f"cannot encode {type_name} at {self.path}: {reason}")
+
+
+def _type_name(value: Any) -> str:
+    cls = type(value)
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _pointer(path: str, token: str) -> str:
+    escaped = token.replace("~", "~0").replace("/", "~1")
+    return f"{path}/{escaped}"
+
+
+def _tag(type_name: str, **fields: Any) -> dict[str, Any]:
+    return {TAG: {"type": type_name, **fields}}
+
+
+def encode_value(value: Any, *, _path: str = "") -> Any:
+    if isinstance(value, Enum):
+        cls = type(value)
+        return _tag(
+            "enum",
+            module=cls.__module__,
+            qualname=cls.__qualname__,
+            name=value.name,
+            value=encode_value(value.value, _path=_pointer(_path, "value")),
+        )
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise CaptureEncodingError(
+                path=_path,
+                type_name="builtins.float",
+                reason="non-finite float",
+            )
+        return value
+    if isinstance(value, datetime):
+        return _tag("datetime", value=value.isoformat(), fold=value.fold)
+    if isinstance(value, UUID):
+        return _tag("uuid", value=str(value))
+    if isinstance(value, bytes):
+        return _tag("bytes", value=base64.b64encode(value).decode("ascii"))
+    if isinstance(value, Decimal):
+        return _tag("decimal", value=str(value))
+    if isinstance(value, tuple) and hasattr(type(value), "_fields"):
+        cls = type(value)
+        fields = tuple(getattr(cls, "_fields"))
+        return _tag(
+            "namedtuple",
+            module=cls.__module__,
+            qualname=cls.__qualname__,
+            fields=list(fields),
+            values=[
+                encode_value(item, _path=_pointer(_path, field))
+                for field, item in zip(fields, value)
+            ],
+        )
+    if isinstance(value, tuple):
+        return _tag(
+            "tuple",
+            values=[
+                encode_value(item, _path=_pointer(_path, str(index)))
+                for index, item in enumerate(value)
+            ],
+        )
+    if isinstance(value, (set, frozenset)):
+        encoded = [
+            encode_value(item, _path=_pointer(_path, "set")) for item in value
+        ]
+        encoded.sort(
+            key=lambda item: json.dumps(
+                item,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            )
+        )
+        return _tag(
+            "frozenset" if isinstance(value, frozenset) else "set",
+            values=encoded,
+        )
+    if isinstance(value, list):
+        return [
+            encode_value(item, _path=_pointer(_path, str(index)))
+            for index, item in enumerate(value)
+        ]
+    if isinstance(value, dict):
+        for key in value:
+            if not isinstance(key, str):
+                raise CaptureEncodingError(
+                    path=_path,
+                    type_name=_type_name(key),
+                    reason="mapping keys must be strings",
+                )
+        if TAG in value:
+            return _tag(
+                "mapping",
+                items=[
+                    [key, encode_value(item, _path=_pointer(_path, key))]
+                    for key, item in value.items()
+                ],
+            )
+        return {
+            key: encode_value(item, _path=_pointer(_path, key))
+            for key, item in value.items()
+        }
+    raise CaptureEncodingError(
+        path=_path,
+        type_name=_type_name(value),
+        reason="unsupported value type",
+    )
+
+
+def _require_fields(
+    payload: dict[str, Any],
+    *,
+    type_name: str,
+    fields: set[str],
+    path: str,
+) -> None:
+    expected = {"type", *fields}
+    if set(payload) != expected:
+        raise ValueError(f"invalid {type_name} tag fields at {path or '/'}")
+
+
+def _resolve_loaded_type(module_name: Any, qualname: Any, *, path: str) -> type[Any]:
+    if not isinstance(module_name, str) or not isinstance(qualname, str):
+        raise ValueError(f"invalid recorded type at {path or '/'}")
+    if "<locals>" in qualname.split("."):
+        raise ValueError(f"local recorded type is not replayable at {path or '/'}")
+    module = sys.modules.get(module_name)
+    if module is None:
+        raise ValueError(f"recorded module {module_name!r} is not loaded at {path or '/'}")
+    resolved: Any = module
+    for part in qualname.split("."):
+        try:
+            resolved = getattr(resolved, part)
+        except AttributeError as exc:
+            raise ValueError(
+                f"recorded type {module_name}.{qualname} is unavailable at {path or '/'}"
+            ) from exc
+    if not isinstance(resolved, type):
+        raise ValueError(f"recorded object is not a type at {path or '/'}")
+    return resolved
+
+
+def decode_value(value: Any, *, _path: str = "") -> Any:
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"non-finite float at {_path or '/'}")
+        return value
+    if isinstance(value, list):
+        return [
+            decode_value(item, _path=_pointer(_path, str(index)))
+            for index, item in enumerate(value)
+        ]
+    if not isinstance(value, dict):
+        raise ValueError(f"invalid encoded value at {_path or '/'}")
+    if TAG not in value:
+        if not all(isinstance(key, str) for key in value):
+            raise ValueError(f"mapping keys must be strings at {_path or '/'}")
+        return {
+            key: decode_value(item, _path=_pointer(_path, key))
+            for key, item in value.items()
+        }
+    if set(value) != {TAG} or not isinstance(value[TAG], dict):
+        raise ValueError(f"invalid extension tag at {_path or '/'}")
+
+    payload = value[TAG]
+    type_name = payload.get("type")
+    if not isinstance(type_name, str):
+        raise ValueError(f"extension type must be a string at {_path or '/'}")
+    if type_name == "datetime":
+        _require_fields(payload, type_name=type_name, fields={"value", "fold"}, path=_path)
+        if not isinstance(payload["value"], str) or payload["fold"] not in {0, 1}:
+            raise ValueError(f"invalid datetime tag at {_path or '/'}")
+        return datetime.fromisoformat(payload["value"]).replace(fold=payload["fold"])
+    if type_name == "uuid":
+        _require_fields(payload, type_name=type_name, fields={"value"}, path=_path)
+        if not isinstance(payload["value"], str):
+            raise ValueError(f"invalid uuid tag at {_path or '/'}")
+        return UUID(payload["value"])
+    if type_name == "bytes":
+        _require_fields(payload, type_name=type_name, fields={"value"}, path=_path)
+        if not isinstance(payload["value"], str):
+            raise ValueError(f"invalid bytes tag at {_path or '/'}")
+        try:
+            return base64.b64decode(payload["value"], validate=True)
+        except ValueError as exc:
+            raise ValueError(f"invalid bytes tag at {_path or '/'}") from exc
+    if type_name == "decimal":
+        _require_fields(payload, type_name=type_name, fields={"value"}, path=_path)
+        if not isinstance(payload["value"], str):
+            raise ValueError(f"invalid decimal tag at {_path or '/'}")
+        return Decimal(payload["value"])
+    if type_name in {"tuple", "set", "frozenset"}:
+        _require_fields(payload, type_name=type_name, fields={"values"}, path=_path)
+        if not isinstance(payload["values"], list):
+            raise ValueError(f"invalid {type_name} tag at {_path or '/'}")
+        items = [
+            decode_value(item, _path=_pointer(_path, str(index)))
+            for index, item in enumerate(payload["values"])
+        ]
+        if type_name == "tuple":
+            return tuple(items)
+        try:
+            return frozenset(items) if type_name == "frozenset" else set(items)
+        except TypeError as exc:
+            raise ValueError(f"unhashable {type_name} member at {_path or '/'}") from exc
+    if type_name == "mapping":
+        _require_fields(payload, type_name=type_name, fields={"items"}, path=_path)
+        if not isinstance(payload["items"], list):
+            raise ValueError(f"invalid mapping tag at {_path or '/'}")
+        result: dict[str, Any] = {}
+        for index, pair in enumerate(payload["items"]):
+            if (
+                not isinstance(pair, list)
+                or len(pair) != 2
+                or not isinstance(pair[0], str)
+                or pair[0] in result
+            ):
+                raise ValueError(f"invalid mapping item at {_pointer(_path, str(index))}")
+            result[pair[0]] = decode_value(pair[1], _path=_pointer(_path, pair[0]))
+        return result
+    if type_name == "enum":
+        _require_fields(
+            payload,
+            type_name=type_name,
+            fields={"module", "qualname", "name", "value"},
+            path=_path,
+        )
+        enum_type = _resolve_loaded_type(payload["module"], payload["qualname"], path=_path)
+        if not issubclass(enum_type, Enum) or not isinstance(payload["name"], str):
+            raise ValueError(f"recorded type is not an enum at {_path or '/'}")
+        try:
+            member = enum_type[payload["name"]]
+        except KeyError as exc:
+            raise ValueError(f"enum member changed at {_path or '/'}") from exc
+        recorded_value = decode_value(payload["value"], _path=_pointer(_path, "value"))
+        if member.value != recorded_value:
+            raise ValueError(f"enum value changed at {_path or '/'}")
+        return member
+    if type_name == "namedtuple":
+        _require_fields(
+            payload,
+            type_name=type_name,
+            fields={"module", "qualname", "fields", "values"},
+            path=_path,
+        )
+        namedtuple_type = _resolve_loaded_type(
+            payload["module"], payload["qualname"], path=_path
+        )
+        fields = payload["fields"]
+        values = payload["values"]
+        if (
+            not isinstance(fields, list)
+            or not all(isinstance(field, str) for field in fields)
+            or not isinstance(values, list)
+            or len(fields) != len(values)
+            or tuple(getattr(namedtuple_type, "_fields", ())) != tuple(fields)
+        ):
+            raise ValueError(f"namedtuple definition changed at {_path or '/'}")
+        decoded = [
+            decode_value(item, _path=_pointer(_path, field))
+            for field, item in zip(fields, values)
+        ]
+        return namedtuple_type(*decoded)
+    raise ValueError(f"unknown extension type {type_name!r} at {_path or '/'}")
+
+
+__all__ = ["CaptureEncodingError", "decode_value", "encode_value"]

--- a/src/onestep/capture/codec.py
+++ b/src/onestep/capture/codec.py
@@ -26,6 +26,30 @@ def _type_name(value: Any) -> str:
     return f"{cls.__module__}.{cls.__qualname__}"
 
 
+def _ensure_replayable_type(cls: type[Any], *, path: str) -> None:
+    module_name = cls.__module__
+    qualname = cls.__qualname__
+    if "<locals>" in qualname.split("."):
+        raise CaptureEncodingError(
+            path=path,
+            type_name=f"{module_name}.{qualname}",
+            reason="local recorded type is not replayable",
+        )
+    module = sys.modules.get(module_name)
+    resolved: Any = module
+    if resolved is not None:
+        for part in qualname.split("."):
+            resolved = getattr(resolved, part, None)
+            if resolved is None:
+                break
+    if resolved is not cls:
+        raise CaptureEncodingError(
+            path=path,
+            type_name=f"{module_name}.{qualname}",
+            reason="recorded type is not replayable from the loaded module",
+        )
+
+
 def _pointer(path: str, token: str) -> str:
     escaped = token.replace("~", "~0").replace("/", "~1")
     return f"{path}/{escaped}"
@@ -38,6 +62,7 @@ def _tag(type_name: str, **fields: Any) -> dict[str, Any]:
 def encode_value(value: Any, *, _path: str = "") -> Any:
     if isinstance(value, Enum):
         cls = type(value)
+        _ensure_replayable_type(cls, path=_path)
         return _tag(
             "enum",
             module=cls.__module__,
@@ -45,9 +70,9 @@ def encode_value(value: Any, *, _path: str = "") -> Any:
             name=value.name,
             value=encode_value(value.value, _path=_pointer(_path, "value")),
         )
-    if value is None or isinstance(value, (bool, int, str)):
+    if value is None or type(value) in {bool, int, str}:
         return value
-    if isinstance(value, float):
+    if type(value) is float:
         if not math.isfinite(value):
             raise CaptureEncodingError(
                 path=_path,
@@ -55,16 +80,17 @@ def encode_value(value: Any, *, _path: str = "") -> Any:
                 reason="non-finite float",
             )
         return value
-    if isinstance(value, datetime):
+    if type(value) is datetime:
         return _tag("datetime", value=value.isoformat(), fold=value.fold)
-    if isinstance(value, UUID):
+    if type(value) is UUID:
         return _tag("uuid", value=str(value))
-    if isinstance(value, bytes):
+    if type(value) is bytes:
         return _tag("bytes", value=base64.b64encode(value).decode("ascii"))
-    if isinstance(value, Decimal):
+    if type(value) is Decimal:
         return _tag("decimal", value=str(value))
     if isinstance(value, tuple) and hasattr(type(value), "_fields"):
         cls = type(value)
+        _ensure_replayable_type(cls, path=_path)
         fields = tuple(getattr(cls, "_fields"))
         return _tag(
             "namedtuple",
@@ -76,7 +102,7 @@ def encode_value(value: Any, *, _path: str = "") -> Any:
                 for field, item in zip(fields, value)
             ],
         )
-    if isinstance(value, tuple):
+    if type(value) is tuple:
         return _tag(
             "tuple",
             values=[
@@ -84,7 +110,7 @@ def encode_value(value: Any, *, _path: str = "") -> Any:
                 for index, item in enumerate(value)
             ],
         )
-    if isinstance(value, (set, frozenset)):
+    if type(value) in {set, frozenset}:
         encoded = [
             encode_value(item, _path=_pointer(_path, "set")) for item in value
         ]
@@ -97,15 +123,15 @@ def encode_value(value: Any, *, _path: str = "") -> Any:
             )
         )
         return _tag(
-            "frozenset" if isinstance(value, frozenset) else "set",
+            "frozenset" if type(value) is frozenset else "set",
             values=encoded,
         )
-    if isinstance(value, list):
+    if type(value) is list:
         return [
             encode_value(item, _path=_pointer(_path, str(index)))
             for index, item in enumerate(value)
         ]
-    if isinstance(value, dict):
+    if type(value) is dict:
         for key in value:
             if not isinstance(key, str):
                 raise CaptureEncodingError(

--- a/src/onestep/capture/config.py
+++ b/src/onestep/capture/config.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+CaptureMode = Literal["terminal", "all"]
+
+
+@dataclass(frozen=True)
+class FailureCaptureConfig:
+    directory: Path | str
+    mode: CaptureMode = "terminal"
+    max_bytes: int = 1_048_576
+    redact_paths: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.directory, (str, Path)):
+            raise TypeError("failure_capture.directory must be a path string")
+        if self.mode not in {"terminal", "all"}:
+            raise ValueError("failure_capture.mode must be 'terminal' or 'all'")
+        if isinstance(self.max_bytes, bool) or not isinstance(self.max_bytes, int):
+            raise TypeError("failure_capture.max_bytes must be an integer")
+        if self.max_bytes < 1:
+            raise ValueError("failure_capture.max_bytes must be >= 1")
+        if isinstance(self.redact_paths, (str, bytes)) or not isinstance(
+            self.redact_paths, Sequence
+        ):
+            raise TypeError("failure_capture.redact_paths must be a sequence")
+        paths = tuple(self.redact_paths)
+        for path in paths:
+            if not isinstance(path, str) or not path.startswith("/"):
+                raise ValueError(
+                    "failure_capture.redact_paths entries must be JSON Pointer paths"
+                )
+        object.__setattr__(self, "directory", Path(self.directory))
+        object.__setattr__(self, "redact_paths", paths)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "FailureCaptureConfig":
+        allowed = {"directory", "mode", "max_bytes", "redact_paths"}
+        unknown = sorted(set(value) - allowed)
+        if unknown:
+            raise ValueError(
+                "unsupported fields for app.failure_capture: " + ", ".join(unknown)
+            )
+        if "directory" not in value:
+            raise ValueError("app.failure_capture.directory is required")
+        paths = value.get("redact_paths", ())
+        if not isinstance(paths, (list, tuple)) or isinstance(paths, (str, bytes)):
+            raise TypeError("app.failure_capture.redact_paths must be a list")
+        return cls(
+            directory=value["directory"],
+            mode=value.get("mode", "terminal"),
+            max_bytes=value.get("max_bytes", 1_048_576),
+            redact_paths=tuple(paths),
+        )
+
+
+__all__ = ["CaptureMode", "FailureCaptureConfig"]

--- a/src/onestep/capture/writer.py
+++ b/src/onestep/capture/writer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import copy
 import json
 import os
 import stat
@@ -52,7 +51,7 @@ def _escape_pointer_token(value: str) -> str:
 
 
 def _redact_secret_keys(value: Any, *, path: str, redacted: set[str]) -> Any:
-    if isinstance(value, dict):
+    if type(value) is dict:
         result: dict[Any, Any] = {}
         for key, item in value.items():
             child_path = f"{path}/{_escape_pointer_token(str(key))}"
@@ -69,7 +68,7 @@ def _redact_secret_keys(value: Any, *, path: str, redacted: set[str]) -> Any:
                     redacted=redacted,
                 )
         return result
-    if isinstance(value, list):
+    if type(value) is list:
         return [
             _redact_secret_keys(
                 item,
@@ -78,7 +77,7 @@ def _redact_secret_keys(value: Any, *, path: str, redacted: set[str]) -> Any:
             )
             for index, item in enumerate(value)
         ]
-    if isinstance(value, tuple):
+    if isinstance(value, tuple) and hasattr(type(value), "_fields"):
         items = [
             _redact_secret_keys(
                 item,
@@ -87,14 +86,22 @@ def _redact_secret_keys(value: Any, *, path: str, redacted: set[str]) -> Any:
             )
             for index, item in enumerate(value)
         ]
-        if hasattr(type(value), "_fields"):
-            return type(value)(*items)
+        return type(value)(*items)
+    if type(value) is tuple:
+        items = [
+            _redact_secret_keys(
+                item,
+                path=f"{path}/{index}",
+                redacted=redacted,
+            )
+            for index, item in enumerate(value)
+        ]
         return tuple(items)
-    if isinstance(value, set):
+    if type(value) is set:
         return {
             _redact_secret_keys(item, path=path, redacted=redacted) for item in value
         }
-    if isinstance(value, frozenset):
+    if type(value) is frozenset:
         return frozenset(
             _redact_secret_keys(item, path=path, redacted=redacted) for item in value
         )
@@ -125,7 +132,7 @@ def _replace_tokens(value: Any, tokens: list[str], replacement: Any) -> tuple[An
     if not tokens:
         return replacement, True
     token, *remaining = tokens
-    if isinstance(value, dict):
+    if type(value) is dict:
         if token not in value:
             return value, False
         replaced, changed = _replace_tokens(value[token], remaining, replacement)
@@ -134,7 +141,9 @@ def _replace_tokens(value: Any, tokens: list[str], replacement: Any) -> tuple[An
         result = dict(value)
         result[token] = replaced
         return result, True
-    if isinstance(value, (list, tuple)):
+    if type(value) is list or type(value) is tuple or (
+        isinstance(value, tuple) and hasattr(type(value), "_fields")
+    ):
         try:
             index = int(token)
         except ValueError:
@@ -148,7 +157,7 @@ def _replace_tokens(value: Any, tokens: list[str], replacement: Any) -> tuple[An
         result_items[index] = replaced
         if isinstance(value, tuple) and hasattr(type(value), "_fields"):
             return type(value)(*result_items), True
-        if isinstance(value, tuple):
+        if type(value) is tuple:
             return tuple(result_items), True
         return result_items, True
     return value, False
@@ -159,8 +168,8 @@ def redact_envelope(
     pointers: tuple[str, ...],
 ) -> tuple[Envelope, tuple[str, ...]]:
     logical = {
-        "body": copy.deepcopy(envelope.body),
-        "meta": copy.deepcopy(envelope.meta),
+        "body": envelope.body,
+        "meta": envelope.meta,
     }
     redacted: set[str] = set()
     logical = _redact_secret_keys(logical, path="", redacted=redacted)

--- a/src/onestep/capture/writer.py
+++ b/src/onestep/capture/writer.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import os
+import stat
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from onestep.envelope import Envelope
+from onestep.retry import FailureInfo
+
+from .codec import decode_value, encode_value
+from .config import FailureCaptureConfig
+
+CAPTURE_SCHEMA = "onestep/envelope-capture"
+CAPTURE_VERSION = 1
+_REDACTED = "<redacted>"
+_SECRET_KEYS = {
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "authorization",
+    "cookie",
+    "api_key",
+    "apikey",
+    "dsn",
+    "database_url",
+    "connection_string",
+}
+
+
+@dataclass(frozen=True)
+class LoadedCapture:
+    app: str
+    task: str
+    stage: str
+    terminal: bool
+    failure: dict[str, Any]
+    envelope: Envelope
+    redacted_paths: tuple[str, ...]
+    captured_at: str
+
+
+def _escape_pointer_token(value: str) -> str:
+    return value.replace("~", "~0").replace("/", "~1")
+
+
+def _redact_secret_keys(value: Any, *, path: str, redacted: set[str]) -> Any:
+    if isinstance(value, dict):
+        result: dict[Any, Any] = {}
+        for key, item in value.items():
+            child_path = f"{path}/{_escape_pointer_token(str(key))}"
+            normalized = (
+                key.casefold().replace("-", "_") if isinstance(key, str) else ""
+            )
+            if normalized in _SECRET_KEYS:
+                result[key] = _REDACTED
+                redacted.add(child_path)
+            else:
+                result[key] = _redact_secret_keys(
+                    item,
+                    path=child_path,
+                    redacted=redacted,
+                )
+        return result
+    if isinstance(value, list):
+        return [
+            _redact_secret_keys(
+                item,
+                path=f"{path}/{index}",
+                redacted=redacted,
+            )
+            for index, item in enumerate(value)
+        ]
+    if isinstance(value, tuple):
+        items = [
+            _redact_secret_keys(
+                item,
+                path=f"{path}/{index}",
+                redacted=redacted,
+            )
+            for index, item in enumerate(value)
+        ]
+        if hasattr(type(value), "_fields"):
+            return type(value)(*items)
+        return tuple(items)
+    if isinstance(value, set):
+        return {
+            _redact_secret_keys(item, path=path, redacted=redacted) for item in value
+        }
+    if isinstance(value, frozenset):
+        return frozenset(
+            _redact_secret_keys(item, path=path, redacted=redacted) for item in value
+        )
+    return value
+
+
+def _decode_pointer(pointer: str) -> list[str]:
+    if not pointer.startswith("/"):
+        raise ValueError(f"invalid JSON Pointer {pointer!r}")
+    tokens: list[str] = []
+    for raw in pointer[1:].split("/"):
+        token = ""
+        index = 0
+        while index < len(raw):
+            if raw[index] != "~":
+                token += raw[index]
+                index += 1
+                continue
+            if index + 1 >= len(raw) or raw[index + 1] not in {"0", "1"}:
+                raise ValueError(f"invalid JSON Pointer escape in {pointer!r}")
+            token += "~" if raw[index + 1] == "0" else "/"
+            index += 2
+        tokens.append(token)
+    return tokens
+
+
+def _replace_tokens(value: Any, tokens: list[str], replacement: Any) -> tuple[Any, bool]:
+    if not tokens:
+        return replacement, True
+    token, *remaining = tokens
+    if isinstance(value, dict):
+        if token not in value:
+            return value, False
+        replaced, changed = _replace_tokens(value[token], remaining, replacement)
+        if not changed:
+            return value, False
+        result = dict(value)
+        result[token] = replaced
+        return result, True
+    if isinstance(value, (list, tuple)):
+        try:
+            index = int(token)
+        except ValueError:
+            return value, False
+        if index < 0 or index >= len(value) or str(index) != token:
+            return value, False
+        replaced, changed = _replace_tokens(value[index], remaining, replacement)
+        if not changed:
+            return value, False
+        result_items = list(value)
+        result_items[index] = replaced
+        if isinstance(value, tuple) and hasattr(type(value), "_fields"):
+            return type(value)(*result_items), True
+        if isinstance(value, tuple):
+            return tuple(result_items), True
+        return result_items, True
+    return value, False
+
+
+def redact_envelope(
+    envelope: Envelope,
+    pointers: tuple[str, ...],
+) -> tuple[Envelope, tuple[str, ...]]:
+    logical = {
+        "body": copy.deepcopy(envelope.body),
+        "meta": copy.deepcopy(envelope.meta),
+    }
+    redacted: set[str] = set()
+    logical = _redact_secret_keys(logical, path="", redacted=redacted)
+    for pointer in pointers:
+        logical, changed = _replace_tokens(
+            logical,
+            _decode_pointer(pointer),
+            _REDACTED,
+        )
+        if changed:
+            redacted.add(pointer)
+    return (
+        Envelope(
+            body=logical["body"],
+            meta=logical["meta"],
+            attempts=envelope.attempts,
+        ),
+        tuple(sorted(redacted)),
+    )
+
+
+def _ensure_private_directory(path: Path) -> None:
+    absolute = path.absolute()
+    missing: list[Path] = []
+    current = absolute
+    while True:
+        try:
+            info = os.lstat(current)
+        except FileNotFoundError:
+            missing.append(current)
+        else:
+            if stat.S_ISLNK(info.st_mode):
+                raise ValueError(f"capture directory contains a symbolic link: {current}")
+            if not stat.S_ISDIR(info.st_mode):
+                raise NotADirectoryError(current)
+            break
+        parent = current.parent
+        if parent == current:
+            raise FileNotFoundError(current)
+        current = parent
+    for directory in reversed(missing):
+        os.mkdir(directory, 0o700)
+        os.chmod(directory, 0o700)
+
+
+def _validate_scalar(value: Any, field: str, expected: type[Any]) -> Any:
+    if not isinstance(value, expected):
+        raise ValueError(f"capture field {field!r} has invalid type")
+    return value
+
+
+class FailureCaptureWriter:
+    def __init__(self, config: FailureCaptureConfig) -> None:
+        self.config = config
+
+    async def write(
+        self,
+        *,
+        app: str,
+        task: str,
+        stage: str,
+        terminal: bool,
+        failure: FailureInfo,
+        envelope: Envelope,
+    ) -> Path:
+        return await asyncio.to_thread(
+            self._write_sync,
+            app=app,
+            task=task,
+            stage=stage,
+            terminal=terminal,
+            failure=failure,
+            envelope=envelope,
+        )
+
+    def _write_sync(
+        self,
+        *,
+        app: str,
+        task: str,
+        stage: str,
+        terminal: bool,
+        failure: FailureInfo,
+        envelope: Envelope,
+    ) -> Path:
+        directory = self.config.directory
+        _ensure_private_directory(directory)
+        redacted_envelope, redacted_paths = redact_envelope(
+            envelope,
+            self.config.redact_paths,
+        )
+        captured_at = datetime.now(timezone.utc)
+        document = {
+            "schema": CAPTURE_SCHEMA,
+            "version": CAPTURE_VERSION,
+            "captured_at": captured_at.isoformat().replace("+00:00", "Z"),
+            "app": app,
+            "task": task,
+            "stage": stage,
+            "terminal": terminal,
+            "failure": {
+                "kind": failure.kind.value,
+                "exception_type": failure.exception_type,
+                "message": failure.message,
+            },
+            "envelope": {
+                "body": encode_value(redacted_envelope.body),
+                "meta": encode_value(redacted_envelope.meta),
+                "attempts": redacted_envelope.attempts,
+            },
+            "redacted_paths": list(redacted_paths),
+        }
+        data = json.dumps(
+            document,
+            ensure_ascii=False,
+            sort_keys=True,
+            indent=2,
+        ).encode("utf-8")
+        if len(data) > self.config.max_bytes:
+            raise ValueError(
+                f"capture exceeds max_bytes ({len(data)} > {self.config.max_bytes})"
+            )
+
+        for _attempt in range(10):
+            filename = f"{captured_at.strftime('%Y%m%dT%H%M%S%fZ')}-{uuid4().hex}.json"
+            final_path = directory / filename
+            try:
+                os.lstat(final_path)
+            except FileNotFoundError:
+                pass
+            else:
+                continue
+            temp_path = directory / f".{filename}.{uuid4().hex}.tmp"
+            flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
+            fd = -1
+            try:
+                fd = os.open(temp_path, flags, 0o600)
+                descriptor_info = os.fstat(fd)
+                path_info = os.lstat(temp_path)
+                if not stat.S_ISREG(descriptor_info.st_mode) or (
+                    descriptor_info.st_dev,
+                    descriptor_info.st_ino,
+                ) != (path_info.st_dev, path_info.st_ino):
+                    raise ValueError("capture temporary path is not a regular file")
+                with os.fdopen(fd, "wb") as handle:
+                    fd = -1
+                    handle.write(data)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                try:
+                    target_info = os.lstat(final_path)
+                except FileNotFoundError:
+                    target_info = None
+                if target_info is not None:
+                    if stat.S_ISLNK(target_info.st_mode):
+                        raise ValueError("capture target is a symbolic link")
+                    continue
+                os.replace(temp_path, final_path)
+                os.chmod(final_path, 0o600)
+                directory_fd = os.open(directory, os.O_RDONLY)
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+                return final_path
+            finally:
+                if fd >= 0:
+                    os.close(fd)
+                try:
+                    os.unlink(temp_path)
+                except FileNotFoundError:
+                    pass
+        raise FileExistsError("could not allocate a unique capture filename")
+
+
+def load_capture(
+    path: str | Path,
+    *,
+    expected_app: str | None = None,
+    expected_task: str | None = None,
+) -> LoadedCapture:
+    capture_path = Path(path)
+    raw = json.loads(capture_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("capture document must be an object")
+    expected_fields = {
+        "schema",
+        "version",
+        "captured_at",
+        "app",
+        "task",
+        "stage",
+        "terminal",
+        "failure",
+        "envelope",
+        "redacted_paths",
+    }
+    if set(raw) != expected_fields:
+        raise ValueError("capture document fields are invalid")
+    if raw["schema"] != CAPTURE_SCHEMA:
+        raise ValueError(
+            f"unsupported capture schema {raw['schema']!r}; expected {CAPTURE_SCHEMA!r}"
+        )
+    if raw["version"] != CAPTURE_VERSION:
+        raise ValueError(
+            f"unsupported capture version {raw['version']!r}; expected {CAPTURE_VERSION}"
+        )
+    app = _validate_scalar(raw["app"], "app", str)
+    task = _validate_scalar(raw["task"], "task", str)
+    stage = _validate_scalar(raw["stage"], "stage", str)
+    captured_at = _validate_scalar(raw["captured_at"], "captured_at", str)
+    try:
+        datetime.fromisoformat(captured_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("capture field 'captured_at' is invalid") from exc
+    if not isinstance(raw["terminal"], bool):
+        raise ValueError("capture field 'terminal' has invalid type")
+    if expected_app is not None and app != expected_app:
+        raise ValueError(f"capture app mismatch: expected {expected_app!r}, received {app!r}")
+    if expected_task is not None and task != expected_task:
+        raise ValueError(
+            f"capture task mismatch: expected {expected_task!r}, received {task!r}"
+        )
+
+    failure = raw["failure"]
+    if not isinstance(failure, dict) or set(failure) != {
+        "kind",
+        "exception_type",
+        "message",
+    }:
+        raise ValueError("capture failure fields are invalid")
+    if not all(isinstance(value, str) for value in failure.values()):
+        raise ValueError("capture failure fields must be strings")
+    envelope = raw["envelope"]
+    if not isinstance(envelope, dict) or set(envelope) != {"body", "meta", "attempts"}:
+        raise ValueError("capture envelope fields are invalid")
+    attempts = envelope["attempts"]
+    if isinstance(attempts, bool) or not isinstance(attempts, int) or attempts < 0:
+        raise ValueError("capture envelope attempts must be a non-negative integer")
+    decoded_meta = decode_value(envelope["meta"])
+    if not isinstance(decoded_meta, dict):
+        raise ValueError("capture envelope meta must decode to a mapping")
+    redacted_paths = raw["redacted_paths"]
+    if not isinstance(redacted_paths, list) or not all(
+        isinstance(item, str) and item.startswith("/") for item in redacted_paths
+    ):
+        raise ValueError("capture redacted_paths must be JSON Pointer strings")
+    return LoadedCapture(
+        app=app,
+        task=task,
+        stage=stage,
+        terminal=raw["terminal"],
+        failure=dict(failure),
+        envelope=Envelope(
+            body=decode_value(envelope["body"]),
+            meta=decoded_meta,
+            attempts=attempts,
+        ),
+        redacted_paths=tuple(redacted_paths),
+        captured_at=captured_at,
+    )
+
+
+__all__ = [
+    "CAPTURE_SCHEMA",
+    "CAPTURE_VERSION",
+    "FailureCaptureWriter",
+    "LoadedCapture",
+    "load_capture",
+    "redact_envelope",
+]

--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -6,6 +6,7 @@ import json
 import logging
 import math
 import sys
+from contextlib import redirect_stdout
 from importlib.metadata import PackageNotFoundError, version
 
 from .app import OneStepApp
@@ -369,7 +370,8 @@ def _run_task_command(args: argparse.Namespace) -> int:
                 send=args.send,
             )
         else:
-            app = load_diagnostic_target(args.target)
+            with redirect_stdout(sys.stderr):
+                app = load_diagnostic_target(args.target)
             load_capture(
                 args.capture_path,
                 expected_app=app.name,

--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -1,15 +1,26 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import logging
+import math
 import sys
 from importlib.metadata import PackageNotFoundError, version
 
 from .app import OneStepApp
 from .build import BuildOptions, BuildResult, build_worker_package
+from .capture import load_capture
 from .config import is_yaml_target, load_resource_catalog, load_yaml_app
-from .diagnostics.targets import _ensure_local_import_paths
+from .diagnostics.connectivity import check_connectivity
+from .diagnostics.models import (
+    ConnectivityReport,
+    DiagnosticReport,
+    DiagnosticRequest,
+)
+from .diagnostics.supervisor import supervise_diagnostic
+from .diagnostics.targets import _ensure_local_import_paths, load_diagnostic_target
+from .envelope import Envelope
 from .init_project import init_project
 
 _CLI_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
@@ -73,6 +84,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         dest="strict_env",
         default=None,
         help="Check that all ${VAR} references resolve to environment variables (YAML targets only)",
+    )
+    check_parser.add_argument(
+        "--connect",
+        action="store_true",
+        help="Probe open/close connectivity for lifecycle-capable resources",
+    )
+    check_parser.add_argument(
+        "--connect-timeout",
+        type=_positive_seconds,
+        default=10.0,
+        help="Per-resource open and close timeout in seconds (default: 10)",
     )
 
     init_parser = subparsers.add_parser("init", help="Create a minimal OneStep YAML project scaffold")
@@ -149,11 +171,43 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Filter resources by catalog role",
     )
 
+    task_parser = subparsers.add_parser(
+        "task",
+        help="Run local task diagnostics",
+    )
+    task_subparsers = task_parser.add_subparsers(
+        dest="task_command",
+        required=True,
+    )
+    task_run_parser = task_subparsers.add_parser(
+        "run",
+        help="Run one task attempt with a JSON input",
+    )
+    task_run_parser.add_argument("target")
+    task_run_parser.add_argument("--task", required=True, dest="task_name")
+    task_run_parser.add_argument("--input", required=True, dest="input_path")
+    _add_diagnostic_options(task_run_parser)
+
+    task_replay_parser = task_subparsers.add_parser(
+        "replay",
+        help="Replay one captured failure envelope",
+    )
+    task_replay_parser.add_argument("target")
+    task_replay_parser.add_argument("--task", required=True, dest="task_name")
+    task_replay_parser.add_argument(
+        "--envelope",
+        required=True,
+        dest="capture_path",
+    )
+    _add_diagnostic_options(task_replay_parser)
+
     return parser.parse_args(_normalize_argv(argv))
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    if args.command == "task":
+        return _run_task_command(args)
     if args.command == "init":
         try:
             result = init_project(args.path, force=args.force)
@@ -215,6 +269,19 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     if args.command == "check":
+        if args.connect:
+            try:
+                report = asyncio.run(
+                    check_connectivity(app, timeout_s=args.connect_timeout)
+                )
+            except Exception as exc:
+                print(
+                    f"onestep: connectivity check failed for {args.target}: {exc}",
+                    file=sys.stderr,
+                )
+                return 2
+            _print_connectivity_report(report, as_json=args.as_json)
+            return _connectivity_exit_code(report)
         _print_summary(args.target, app, as_json=getattr(args, "as_json", False))
         return 0
 
@@ -257,12 +324,86 @@ def _configure_run_logging(
     return handler, previous_root_level
 
 
+def _positive_seconds(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be a positive number of seconds"
+        ) from exc
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive number of seconds")
+    return parsed
+
+
+def _add_diagnostic_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--send",
+        action="store_true",
+        help="Perform selected sink sends instead of suppressing them",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=_positive_seconds,
+        default=60.0,
+        help="Overall diagnostic timeout in seconds (default: 60)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Emit the diagnostic report as JSON",
+    )
+
+
+def _run_task_command(args: argparse.Namespace) -> int:
+    try:
+        if args.task_command == "run":
+            with open(args.input_path, encoding="utf-8") as handle:
+                body = json.load(handle)
+            request = DiagnosticRequest(
+                operation="run",
+                target=args.target,
+                task=args.task_name,
+                envelope=Envelope(body=body),
+                send=args.send,
+            )
+        else:
+            app = load_diagnostic_target(args.target)
+            load_capture(
+                args.capture_path,
+                expected_app=app.name,
+                expected_task=args.task_name,
+            )
+            request = DiagnosticRequest(
+                operation="replay",
+                target=args.target,
+                task=args.task_name,
+                capture_path=args.capture_path,
+                send=args.send,
+            )
+        report = supervise_diagnostic(request, timeout_s=args.timeout)
+    except Exception as exc:
+        print(f"onestep: task diagnostic failed: {exc}", file=sys.stderr)
+        return 2
+    _print_diagnostic_report(args.target, report, as_json=args.as_json)
+    print(report.warning, file=sys.stderr)
+    return _diagnostic_exit_code(report)
+
+
 def _normalize_argv(argv: list[str] | None) -> list[str] | None:
     if argv is None:
         argv = sys.argv[1:]
     if not argv:
         return argv
-    if argv[0].startswith("-") or argv[0] in {"run", "check", "init", "build", "catalog"}:
+    if argv[0].startswith("-") or argv[0] in {
+        "run",
+        "check",
+        "init",
+        "build",
+        "catalog",
+        "task",
+    }:
         return argv
     return ["run", *argv]
 
@@ -305,6 +446,79 @@ def _print_summary(target: str, app: OneStepApp, *, as_json: bool) -> None:
         details = _format_task_details(task)
         if details:
             print(f"  {details}")
+
+
+def _print_diagnostic_report(
+    target: str,
+    report: DiagnosticReport,
+    *,
+    as_json: bool,
+) -> None:
+    if as_json:
+        print(json.dumps(report.to_dict(), indent=2))
+        return
+    print(f"Operation: {report.operation}")
+    print(f"Target: {target}")
+    print(f"App: {report.app}")
+    print(f"Task: {report.task}")
+    print(f"Mode: {report.mode}")
+    print(f"Completion: {report.completion}")
+    print(f"Failure stage: {report.failure_stage or '-'}")
+    print(f"Selected sinks: {','.join(report.selected_sinks) or '-'}")
+    print(f"Delivery action: {report.delivery_action or '-'} (predicted)")
+    print(
+        "Dead letter: "
+        f"attempted={report.dead_letter['attempted']} "
+        f"published={report.dead_letter['published']}"
+    )
+    print(f"Cleanup: {report.cleanup}")
+    print(f"Side-effect outcome: {report.side_effect_outcome}")
+    print(
+        "Last checkpoint: "
+        + (
+            json.dumps(report.last_checkpoint, sort_keys=True)
+            if report.last_checkpoint is not None
+            else "-"
+        )
+    )
+    print(f"Duration: {report.duration_s:.3f}s")
+    print(f"Warning: {report.warning}")
+
+
+def _print_connectivity_report(
+    report: ConnectivityReport,
+    *,
+    as_json: bool,
+) -> None:
+    if as_json:
+        print(json.dumps(report.to_dict(), indent=2))
+        return
+    print(f"App: {report.app}")
+    print(f"Connectivity: {'ok' if report.ok else 'failed'}")
+    print(f"Resources: {len(report.resources)}")
+    for resource in report.resources:
+        print(
+            f"- {','.join(resource.aliases)} roles={','.join(resource.roles)} "
+            f"type={resource.type_name} status={resource.status}"
+        )
+        if resource.open is not None:
+            print(f"  open: {_format_probe_outcome(resource.open)}")
+        if resource.close is not None:
+            print(f"  close: {_format_probe_outcome(resource.close)}")
+    for warning in report.warnings:
+        print(f"Warning: {warning}")
+
+
+def _format_probe_outcome(value: dict[str, object]) -> str:
+    return " ".join(f"{key}={item}" for key, item in value.items())
+
+
+def _diagnostic_exit_code(report: DiagnosticReport) -> int:
+    return 0 if report.completion == "succeeded" else 1
+
+
+def _connectivity_exit_code(report: ConnectivityReport) -> int:
+    return 0 if report.ok else 1
 
 
 def _print_build_summary(result: BuildResult, *, as_json: bool) -> None:

--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -3,16 +3,15 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import sys
 from importlib.metadata import PackageNotFoundError, version
 
 from .app import OneStepApp
 from .build import BuildOptions, BuildResult, build_worker_package
 from .config import is_yaml_target, load_resource_catalog, load_yaml_app
+from .diagnostics.targets import _ensure_local_import_paths
 from .init_project import init_project
 
-_PROJECT_MARKERS = ("pyproject.toml", "setup.py", "setup.cfg")
 _CLI_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
 
 
@@ -256,83 +255,6 @@ def _configure_run_logging(
     root_logger.setLevel(framework_logger.level)
     root_logger.addHandler(handler)
     return handler, previous_root_level
-
-
-def _ensure_local_import_paths(target: str | None = None) -> None:
-    cwd = os.getcwd()
-    if not cwd:
-        return
-    candidates: list[str] = []
-    seen: set[str] = set()
-
-    def add_candidates(base_dir: str | None) -> None:
-        if base_dir is None:
-            return
-        for path in _candidate_import_paths(base_dir):
-            normalized_path = os.path.normcase(os.path.abspath(path))
-            if normalized_path in seen:
-                continue
-            seen.add(normalized_path)
-            candidates.append(path)
-
-    add_candidates(_target_import_root(cwd, target))
-    add_candidates(cwd)
-
-    for path in reversed(candidates):
-        if _path_on_syspath(path):
-            continue
-        sys.path.insert(0, path)
-
-
-def _candidate_import_paths(cwd: str) -> list[str]:
-    candidates: list[str] = []
-    seen: set[str] = set()
-
-    def add(path: str) -> None:
-        absolute_path = os.path.abspath(path)
-        normalized_path = os.path.normcase(absolute_path)
-        if normalized_path in seen or not os.path.isdir(absolute_path):
-            return
-        seen.add(normalized_path)
-        candidates.append(absolute_path)
-
-    add(cwd)
-    add(os.path.join(cwd, "src"))
-
-    project_root = _find_project_root(cwd)
-    if project_root is not None:
-        add(project_root)
-        add(os.path.join(project_root, "src"))
-
-    return candidates
-
-
-def _target_import_root(cwd: str, target: str | None) -> str | None:
-    if not target or not is_yaml_target(target):
-        return None
-    if os.path.isabs(target):
-        return os.path.dirname(target)
-    return os.path.dirname(os.path.abspath(os.path.join(cwd, target)))
-
-
-def _find_project_root(start: str) -> str | None:
-    current = os.path.abspath(start)
-    while True:
-        if any(os.path.exists(os.path.join(current, marker)) for marker in _PROJECT_MARKERS):
-            return current
-        parent = os.path.dirname(current)
-        if parent == current:
-            return None
-        current = parent
-
-
-def _path_on_syspath(path: str) -> bool:
-    normalized_path = os.path.normcase(os.path.abspath(path))
-    for entry in sys.path:
-        current = entry or os.getcwd()
-        if os.path.normcase(os.path.abspath(current)) == normalized_path:
-            return True
-    return False
 
 
 def _normalize_argv(argv: list[str] | None) -> list[str] | None:

--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -6,12 +6,10 @@ import json
 import logging
 import math
 import sys
-from contextlib import redirect_stdout
 from importlib.metadata import PackageNotFoundError, version
 
 from .app import OneStepApp
 from .build import BuildOptions, BuildResult, build_worker_package
-from .capture import load_capture
 from .config import is_yaml_target, load_resource_catalog, load_yaml_app
 from .diagnostics.connectivity import check_connectivity
 from .diagnostics.models import (
@@ -20,7 +18,7 @@ from .diagnostics.models import (
     DiagnosticRequest,
 )
 from .diagnostics.supervisor import supervise_diagnostic
-from .diagnostics.targets import _ensure_local_import_paths, load_diagnostic_target
+from .diagnostics.targets import _ensure_local_import_paths
 from .envelope import Envelope
 from .init_project import init_project
 
@@ -370,13 +368,6 @@ def _run_task_command(args: argparse.Namespace) -> int:
                 send=args.send,
             )
         else:
-            with redirect_stdout(sys.stderr):
-                app = load_diagnostic_target(args.target)
-            load_capture(
-                args.capture_path,
-                expected_app=app.name,
-                expected_task=args.task_name,
-            )
             request = DiagnosticRequest(
                 operation="replay",
                 target=args.target,
@@ -516,7 +507,11 @@ def _format_probe_outcome(value: dict[str, object]) -> str:
 
 
 def _diagnostic_exit_code(report: DiagnosticReport) -> int:
-    return 0 if report.completion == "succeeded" else 1
+    if report.completion == "succeeded":
+        return 0
+    if report.completion == "validation_failed":
+        return 2
+    return 1
 
 
 def _connectivity_exit_code(report: ConnectivityReport) -> int:

--- a/src/onestep/config.py
+++ b/src/onestep/config.py
@@ -11,6 +11,7 @@ from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from .app import OneStepApp
+from .capture.config import FailureCaptureConfig
 from .connectors.base import Sink, Source
 from .reporter_registry import (
     ReporterRegistry,
@@ -72,7 +73,18 @@ _STRICT_TOP_LEVEL_FIELDS = frozenset(
         *_LEGACY_APP_FIELDS,
     }
 )
-_STRICT_APP_FIELDS = frozenset({"name", "shutdown_timeout_s", "config", "state", "logging", "env_file", "strict_env"})
+_STRICT_APP_FIELDS = frozenset(
+    {
+        "name",
+        "shutdown_timeout_s",
+        "config",
+        "state",
+        "logging",
+        "env_file",
+        "strict_env",
+        "failure_capture",
+    }
+)
 _STRICT_APP_LOGGING_FIELDS = frozenset({"level"})
 _STRICT_HANDLER_FIELDS = frozenset({"ref", "params"})
 _STRICT_EMIT_ROUTE_FIELDS = frozenset({"when", "then", "otherwise"})
@@ -323,10 +335,20 @@ def load_app_config(
     if not isinstance(app_config, Mapping):
         raise TypeError("'config' must be a mapping when provided")
 
+    raw_failure_capture = (
+        app_section.get("failure_capture") if app_section is not None else None
+    )
+    failure_capture = None
+    if raw_failure_capture is not None:
+        if not isinstance(raw_failure_capture, Mapping):
+            raise TypeError("'app.failure_capture' must be a mapping")
+        failure_capture = FailureCaptureConfig.from_mapping(raw_failure_capture)
+
     app = OneStepApp(
         app_name,
         config=dict(app_config),
         shutdown_timeout_s=shutdown_timeout_s,
+        failure_capture=failure_capture,
     )
     if source_path is not None:
         app.config.setdefault("config_path", source_path)
@@ -646,6 +668,11 @@ def validate_app_config(config: Mapping[str, Any], *, registry: ResourceRegistry
         _validate_app_logging(app_section.get("logging"))
         _validate_app_env_file(app_section.get("env_file"))
         _validate_app_strict_env(app_section.get("strict_env"))
+        raw_failure_capture = app_section.get("failure_capture")
+        if raw_failure_capture is not None:
+            if not isinstance(raw_failure_capture, Mapping):
+                raise TypeError("'app.failure_capture' must be a mapping")
+            FailureCaptureConfig.from_mapping(raw_failure_capture)
         legacy_fields = sorted(field for field in _LEGACY_APP_FIELDS if field in config)
         if legacy_fields:
             raise ValueError(

--- a/src/onestep/diagnostics/__init__.py
+++ b/src/onestep/diagnostics/__init__.py
@@ -1,0 +1,1 @@
+"""Internal local diagnostic support."""

--- a/src/onestep/diagnostics/connectivity.py
+++ b/src/onestep/diagnostics/connectivity.py
@@ -2,13 +2,21 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import threading
+import time
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, TypeVar
 
 from onestep.app import OneStepApp
 from onestep.resilience import ConnectorOperationError
 
 from .models import ConnectivityReport, ConnectivityResourceResult
+
+_T = TypeVar("_T")
+
+
+class _SyncLifecycleTimeout(asyncio.TimeoutError):
+    pass
 
 
 @dataclass
@@ -46,10 +54,103 @@ def inventory_resources(app: OneStepApp) -> tuple[_InventoryEntry, ...]:
     return tuple(entries.values())
 
 
-async def _invoke_lifecycle(method: Callable[[], Any]) -> None:
-    result = method()
+def _complete_sync_invocation(
+    future: asyncio.Future[tuple[bool, Any]],
+    outcome: tuple[bool, Any],
+) -> None:
+    if future.done():
+        result = outcome[1]
+        if outcome[0] and inspect.iscoroutine(result):
+            result.close()
+        return
+    future.set_result(outcome)
+
+
+async def _invoke_sync_lifecycle(
+    method: Callable[[], _T],
+    *,
+    timeout_s: float,
+    late_cleanup: Callable[[], Any] | None = None,
+) -> _T:
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[tuple[bool, Any]] = loop.create_future()
+    decision_made = threading.Event()
+    cleanup_required = threading.Event()
+
+    def invoke() -> None:
+        try:
+            outcome = (True, method())
+        except BaseException as exc:
+            outcome = (False, exc)
+        try:
+            loop.call_soon_threadsafe(_complete_sync_invocation, future, outcome)
+        except RuntimeError:
+            result = outcome[1]
+            if outcome[0] and inspect.iscoroutine(result):
+                result.close()
+        decision_made.wait()
+        if cleanup_required.is_set() and late_cleanup is not None:
+            _run_late_cleanup(late_cleanup)
+
+    threading.Thread(
+        target=invoke,
+        daemon=True,
+        name="onestep-connectivity-lifecycle",
+    ).start()
+    try:
+        done, _ = await asyncio.wait((future,), timeout=timeout_s)
+    except BaseException:
+        cleanup_required.set()
+        future.cancel()
+        decision_made.set()
+        raise
+    if not done:
+        cleanup_required.set()
+        future.cancel()
+        decision_made.set()
+        raise _SyncLifecycleTimeout
+    decision_made.set()
+    succeeded, value = future.result()
+    if not succeeded:
+        raise value
+    return value
+
+
+def _run_late_cleanup(method: Callable[[], Any]) -> None:
+    try:
+        result = method()
+        if inspect.isawaitable(result):
+            asyncio.run(_await_late_cleanup(result))
+    except BaseException:
+        return
+
+
+async def _await_late_cleanup(result: Any) -> None:
+    await result
+
+
+async def _invoke_lifecycle(
+    method: Callable[[], Any],
+    *,
+    timeout_s: float,
+    late_cleanup: Callable[[], Any] | None = None,
+) -> None:
+    started_at = time.monotonic()
+    if inspect.iscoroutinefunction(method):
+        result = method()
+    else:
+        result = await _invoke_sync_lifecycle(
+            method,
+            timeout_s=timeout_s,
+            late_cleanup=late_cleanup,
+        )
     if inspect.isawaitable(result):
-        await result
+        remaining_s = timeout_s - (time.monotonic() - started_at)
+        if remaining_s <= 0:
+            if inspect.iscoroutine(result):
+                result.close()
+            raise asyncio.TimeoutError
+        await asyncio.wait_for(result, timeout=remaining_s)
 
 
 def _error_result(exc: BaseException) -> dict[str, Any]:
@@ -88,8 +189,16 @@ async def _probe_entry(
 
     open_result: dict[str, Any]
     close_result: dict[str, Any]
+    close_deferred = False
     try:
-        await asyncio.wait_for(_invoke_lifecycle(opener), timeout=timeout_s)
+        await _invoke_lifecycle(
+            opener,
+            timeout_s=timeout_s,
+            late_cleanup=closer,
+        )
+    except _SyncLifecycleTimeout:
+        open_result = {"status": "timed_out"}
+        close_deferred = True
     except asyncio.TimeoutError:
         open_result = {"status": "timed_out"}
     except Exception as exc:
@@ -97,14 +206,17 @@ async def _probe_entry(
     else:
         open_result = {"status": "connected"}
 
-    try:
-        await asyncio.wait_for(_invoke_lifecycle(closer), timeout=timeout_s)
-    except asyncio.TimeoutError:
+    if close_deferred:
         close_result = {"status": "timed_out"}
-    except Exception as exc:
-        close_result = _error_result(exc)
     else:
-        close_result = {"status": "closed"}
+        try:
+            await _invoke_lifecycle(closer, timeout_s=timeout_s)
+        except asyncio.TimeoutError:
+            close_result = {"status": "timed_out"}
+        except Exception as exc:
+            close_result = _error_result(exc)
+        else:
+            close_result = {"status": "closed"}
 
     status = (
         "connected"

--- a/src/onestep/diagnostics/connectivity.py
+++ b/src/onestep/diagnostics/connectivity.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from onestep.app import OneStepApp
+from onestep.resilience import ConnectorOperationError
+
+from .models import ConnectivityReport, ConnectivityResourceResult
+
+
+@dataclass
+class _InventoryEntry:
+    resource: Any
+    aliases: list[str]
+    roles: list[str]
+
+
+def inventory_resources(app: OneStepApp) -> tuple[_InventoryEntry, ...]:
+    entries: dict[int, _InventoryEntry] = {}
+
+    def add(resource: Any, alias: str, role: str) -> None:
+        if resource is None:
+            return
+        entry = entries.setdefault(id(resource), _InventoryEntry(resource, [], []))
+        if alias not in entry.aliases:
+            entry.aliases.append(alias)
+        if role not in entry.roles:
+            entry.roles.append(role)
+
+    for name, resource in app.resources.items():
+        add(resource, name, "named")
+    add(app.state, "app.state", "state_store")
+    for task in app.tasks:
+        add(task.source, f"{task.name}.source", "source")
+        for index, sink in enumerate(task.sinks):
+            add(sink, f"{task.name}.emit[{index}]", "sink")
+        for index, sink in enumerate(task.dead_letter_sinks):
+            add(
+                sink,
+                f"{task.name}.dead_letter[{index}]",
+                "dead_letter_sink",
+            )
+    return tuple(entries.values())
+
+
+async def _invoke_lifecycle(method: Callable[[], Any]) -> None:
+    result = method()
+    if inspect.isawaitable(result):
+        await result
+
+
+def _error_result(exc: BaseException) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "status": "failed",
+        "exception_type": type(exc).__name__,
+    }
+    if isinstance(exc, ConnectorOperationError):
+        result.update(
+            {
+                "backend": exc.backend,
+                "operation": exc.operation.value,
+                "kind": exc.kind.value,
+            }
+        )
+    return result
+
+
+async def _probe_entry(
+    entry: _InventoryEntry,
+    *,
+    timeout_s: float,
+) -> ConnectivityResourceResult:
+    resource = entry.resource
+    type_name = f"{type(resource).__module__}.{type(resource).__qualname__}"
+    opener = getattr(resource, "open", None)
+    closer = getattr(resource, "close", None)
+    if not callable(opener) or not callable(closer):
+        return ConnectivityResourceResult(
+            aliases=tuple(entry.aliases),
+            roles=tuple(entry.roles),
+            type_name=type_name,
+            probe_kind="none",
+            status="not_probeable",
+        )
+
+    open_result: dict[str, Any]
+    close_result: dict[str, Any]
+    try:
+        await asyncio.wait_for(_invoke_lifecycle(opener), timeout=timeout_s)
+    except asyncio.TimeoutError:
+        open_result = {"status": "timed_out"}
+    except Exception as exc:
+        open_result = _error_result(exc)
+    else:
+        open_result = {"status": "connected"}
+
+    try:
+        await asyncio.wait_for(_invoke_lifecycle(closer), timeout=timeout_s)
+    except asyncio.TimeoutError:
+        close_result = {"status": "timed_out"}
+    except Exception as exc:
+        close_result = _error_result(exc)
+    else:
+        close_result = {"status": "closed"}
+
+    status = (
+        "connected"
+        if open_result["status"] == "connected"
+        and close_result["status"] == "closed"
+        else "failed"
+    )
+    return ConnectivityResourceResult(
+        aliases=tuple(entry.aliases),
+        roles=tuple(entry.roles),
+        type_name=type_name,
+        probe_kind="lifecycle",
+        status=status,
+        open=open_result,
+        close=close_result,
+    )
+
+
+async def check_connectivity(
+    app: OneStepApp,
+    *,
+    timeout_s: float,
+) -> ConnectivityReport:
+    if timeout_s <= 0:
+        raise ValueError("connect timeout must be > 0")
+    results = []
+    for entry in inventory_resources(app):
+        results.append(await _probe_entry(entry, timeout_s=timeout_s))
+    lifecycle_results = [item for item in results if item.probe_kind == "lifecycle"]
+    warnings = ()
+    if not lifecycle_results:
+        warnings = ("no connection was verified; all resources are not_probeable",)
+    return ConnectivityReport(
+        app=app.name,
+        resources=tuple(results),
+        ok=all(item.status == "connected" for item in lifecycle_results),
+        warnings=warnings,
+    )
+
+
+__all__ = ["check_connectivity", "inventory_resources"]

--- a/src/onestep/diagnostics/ipc.py
+++ b/src/onestep/diagnostics/ipc.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from .models import DiagnosticReport
+
+IPC_SCHEMA = "onestep/diagnostic-ipc"
+IPC_VERSION = 1
+STATUS_KINDS = frozenset({"checkpoint", "final"})
+CONTROL_KINDS = frozenset({"cancel"})
+_ALL_KINDS = STATUS_KINDS | CONTROL_KINDS
+_CHECKPOINT_FIELDS = frozenset(
+    {
+        "phase",
+        "transition",
+        "elapsed_s",
+        "app",
+        "task",
+        "resource",
+        "selected_sinks",
+        "completion",
+        "cleanup",
+    }
+)
+
+
+class IPCProtocolError(ValueError):
+    pass
+
+
+def encode_frame(
+    kind: str,
+    *,
+    sequence: int,
+    payload: Mapping[str, Any],
+) -> bytes:
+    frame = {
+        "schema": IPC_SCHEMA,
+        "version": IPC_VERSION,
+        "kind": kind,
+        "sequence": sequence,
+        "payload": dict(payload),
+    }
+    return json.dumps(frame, ensure_ascii=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+
+
+def decode_frame(data: bytes) -> dict[str, Any]:
+    try:
+        frame = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise IPCProtocolError("malformed JSON frame") from exc
+    if not isinstance(frame, dict):
+        raise IPCProtocolError("frame must be an object")
+    if set(frame) != {"schema", "version", "kind", "sequence", "payload"}:
+        raise IPCProtocolError("frame fields are invalid")
+    if frame["schema"] != IPC_SCHEMA or frame["version"] != IPC_VERSION:
+        raise IPCProtocolError("unsupported IPC schema or version")
+    if frame["kind"] not in _ALL_KINDS:
+        raise IPCProtocolError("invalid IPC kind")
+    return frame
+
+
+class FrameValidator:
+    def __init__(self, *, direction: Literal["status", "control"]) -> None:
+        if direction not in {"status", "control"}:
+            raise ValueError("IPC direction must be status or control")
+        self.direction = direction
+        self.last_sequence = 0
+
+    def accept(self, frame: Mapping[str, Any]) -> dict[str, Any]:
+        if set(frame) != {"schema", "version", "kind", "sequence", "payload"}:
+            raise IPCProtocolError("frame fields are invalid")
+        if frame["schema"] != IPC_SCHEMA or frame["version"] != IPC_VERSION:
+            raise IPCProtocolError("unsupported IPC schema or version")
+        sequence = frame["sequence"]
+        if (
+            isinstance(sequence, bool)
+            or not isinstance(sequence, int)
+            or sequence <= self.last_sequence
+        ):
+            raise IPCProtocolError("non-monotonic IPC sequence")
+        allowed = STATUS_KINDS if self.direction == "status" else CONTROL_KINDS
+        if frame["kind"] not in allowed:
+            raise IPCProtocolError("invalid IPC kind for direction")
+        payload = _validate_payload(frame["kind"], frame["payload"])
+        self.last_sequence = sequence
+        return payload
+
+
+def _validate_payload(kind: str, value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise IPCProtocolError("IPC payload must be an object")
+    if kind == "cancel":
+        if value:
+            raise IPCProtocolError("cancel payload must be empty")
+        return {}
+    if kind == "final":
+        try:
+            DiagnosticReport.from_dict(value)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise IPCProtocolError("final payload is not a diagnostic result") from exc
+        return dict(value)
+    if kind != "checkpoint":
+        raise IPCProtocolError("invalid IPC payload kind")
+    if not set(value).issubset(_CHECKPOINT_FIELDS):
+        raise IPCProtocolError("checkpoint fields are invalid")
+    if not isinstance(value.get("phase"), str) or not value["phase"]:
+        raise IPCProtocolError("checkpoint phase must be a non-empty string")
+    if value.get("transition") not in {"entered", "completed"}:
+        raise IPCProtocolError("checkpoint transition is invalid")
+    elapsed = value.get("elapsed_s")
+    if (
+        isinstance(elapsed, bool)
+        or not isinstance(elapsed, (int, float))
+        or elapsed < 0
+        or not math.isfinite(float(elapsed))
+    ):
+        raise IPCProtocolError("checkpoint elapsed_s is invalid")
+    for field in ("app", "task", "resource", "completion", "cleanup"):
+        if field in value and value[field] is not None and not isinstance(
+            value[field], str
+        ):
+            raise IPCProtocolError(f"checkpoint {field} must be a string")
+    selected = value.get("selected_sinks")
+    if selected is not None and (
+        not isinstance(selected, list)
+        or any(not isinstance(item, str) for item in selected)
+    ):
+        raise IPCProtocolError("checkpoint selected_sinks must be strings")
+    return dict(value)
+
+
+__all__ = [
+    "CONTROL_KINDS",
+    "IPC_SCHEMA",
+    "IPC_VERSION",
+    "STATUS_KINDS",
+    "FrameValidator",
+    "IPCProtocolError",
+    "decode_frame",
+    "encode_frame",
+]

--- a/src/onestep/diagnostics/models.py
+++ b/src/onestep/diagnostics/models.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal, Mapping
+
+from onestep.capture.codec import decode_value, encode_value
+from onestep.envelope import Envelope
+from onestep.events import TaskEvent, TaskEventKind
+from onestep.retry import FailureInfo, FailureKind
+
+DIAGNOSTIC_SCHEMA = "onestep/diagnostic-result"
+DIAGNOSTIC_VERSION = 1
+CONNECTIVITY_SCHEMA = "onestep/connectivity-result"
+CONNECTIVITY_VERSION = 1
+SIDE_EFFECT_WARNING = "handler and task hooks may perform external side effects"
+
+
+@dataclass(frozen=True)
+class DiagnosticRequest:
+    operation: Literal["run", "replay"]
+    target: str
+    task: str
+    envelope: Envelope | None = None
+    capture_path: str | None = None
+    send: bool = False
+
+    def __post_init__(self) -> None:
+        if self.operation == "run":
+            if self.envelope is None or self.capture_path is not None:
+                raise ValueError("run request requires an envelope only")
+        elif self.operation == "replay":
+            if self.capture_path is None or self.envelope is not None:
+                raise ValueError("replay request requires a capture path only")
+        else:
+            raise ValueError(f"unsupported diagnostic operation {self.operation!r}")
+
+
+@dataclass(frozen=True)
+class DiagnosticReport:
+    operation: str
+    app: str
+    task: str
+    mode: str
+    completion: str
+    attempts: int
+    selected_sinks: tuple[str, ...]
+    delivery_action: str | None
+    delivery_action_basis: str
+    dead_letter: dict[str, bool | None]
+    events: tuple[TaskEvent, ...]
+    duration_s: float
+    outputs: tuple[dict[str, Any], ...] = ()
+    warning: str = SIDE_EFFECT_WARNING
+    failure: dict[str, str] | None = None
+    failure_stage: str | None = None
+    cleanup: str = "complete"
+    side_effect_outcome: str = "not_attempted"
+    last_checkpoint: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": DIAGNOSTIC_SCHEMA,
+            "version": DIAGNOSTIC_VERSION,
+            "operation": self.operation,
+            "app": self.app,
+            "task": self.task,
+            "mode": self.mode,
+            "completion": self.completion,
+            "attempts": self.attempts,
+            "selected_sinks": list(self.selected_sinks),
+            "delivery_action": self.delivery_action,
+            "delivery_action_basis": self.delivery_action_basis,
+            "dead_letter": dict(self.dead_letter),
+            "events": [_event_to_dict(event) for event in self.events],
+            "duration_s": self.duration_s,
+            "outputs": [dict(item) for item in self.outputs],
+            "warning": self.warning,
+            "failure": dict(self.failure) if self.failure is not None else None,
+            "failure_stage": self.failure_stage,
+            "cleanup": self.cleanup,
+            "side_effect_outcome": self.side_effect_outcome,
+            "last_checkpoint": (
+                dict(self.last_checkpoint)
+                if self.last_checkpoint is not None
+                else None
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "DiagnosticReport":
+        _validate_diagnostic_result(value)
+        return cls(
+            operation=value["operation"],
+            app=value["app"],
+            task=value["task"],
+            mode=value["mode"],
+            completion=value["completion"],
+            attempts=value["attempts"],
+            selected_sinks=tuple(value["selected_sinks"]),
+            delivery_action=value["delivery_action"],
+            delivery_action_basis=value["delivery_action_basis"],
+            dead_letter=dict(value["dead_letter"]),
+            events=tuple(_event_from_dict(item) for item in value["events"]),
+            duration_s=value["duration_s"],
+            outputs=tuple(dict(item) for item in value["outputs"]),
+            warning=value["warning"],
+            failure=dict(value["failure"]) if value["failure"] is not None else None,
+            failure_stage=value["failure_stage"],
+            cleanup=value["cleanup"],
+            side_effect_outcome=value["side_effect_outcome"],
+            last_checkpoint=(
+                dict(value["last_checkpoint"])
+                if value["last_checkpoint"] is not None
+                else None
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ConnectivityResourceResult:
+    aliases: tuple[str, ...]
+    roles: tuple[str, ...]
+    type_name: str
+    probe_kind: str
+    status: str
+    open: dict[str, Any] | None = None
+    close: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "aliases": list(self.aliases),
+            "roles": list(self.roles),
+            "type": self.type_name,
+            "probe_kind": self.probe_kind,
+            "status": self.status,
+            "open": dict(self.open) if self.open is not None else None,
+            "close": dict(self.close) if self.close is not None else None,
+        }
+
+
+@dataclass(frozen=True)
+class ConnectivityReport:
+    app: str
+    resources: tuple[ConnectivityResourceResult, ...]
+    ok: bool
+    warnings: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": CONNECTIVITY_SCHEMA,
+            "version": CONNECTIVITY_VERSION,
+            "app": self.app,
+            "ok": self.ok,
+            "warnings": list(self.warnings),
+            "resources": [resource.to_dict() for resource in self.resources],
+        }
+
+
+def _event_to_dict(event: TaskEvent) -> dict[str, Any]:
+    failure = None
+    if event.failure is not None:
+        failure = {
+            "kind": event.failure.kind.value,
+            "exception_type": event.failure.exception_type,
+        }
+    return {
+        "kind": event.kind.value,
+        "app": event.app,
+        "task": event.task,
+        "source": event.source,
+        "attempts": event.attempts,
+        "emitted_at": event.emitted_at.isoformat(),
+        "duration_s": event.duration_s,
+        "failure": failure,
+        "meta": encode_value(event.meta),
+    }
+
+
+def _event_from_dict(value: Any) -> TaskEvent:
+    if not isinstance(value, Mapping):
+        raise ValueError("diagnostic event must be an object")
+    failure_value = value.get("failure")
+    failure = None
+    if failure_value is not None:
+        if not isinstance(failure_value, Mapping):
+            raise ValueError("diagnostic event failure must be an object")
+        failure = FailureInfo(
+            kind=FailureKind(failure_value["kind"]),
+            exception_type=failure_value["exception_type"],
+            message="",
+        )
+    emitted_at = datetime.fromisoformat(value["emitted_at"])
+    meta = decode_value(value["meta"])
+    if not isinstance(meta, dict):
+        raise ValueError("diagnostic event meta must decode to a mapping")
+    return TaskEvent(
+        kind=TaskEventKind(value["kind"]),
+        app=value["app"],
+        task=value["task"],
+        source=value["source"],
+        attempts=value["attempts"],
+        emitted_at=emitted_at,
+        duration_s=value["duration_s"],
+        failure=failure,
+        meta=meta,
+    )
+
+
+def _validate_diagnostic_result(value: Mapping[str, Any]) -> None:
+    if value.get("schema") != DIAGNOSTIC_SCHEMA:
+        raise ValueError("unsupported diagnostic result schema")
+    if value.get("version") != DIAGNOSTIC_VERSION:
+        raise ValueError("unsupported diagnostic result version")
+    required = {
+        "schema",
+        "version",
+        "operation",
+        "app",
+        "task",
+        "mode",
+        "completion",
+        "attempts",
+        "selected_sinks",
+        "delivery_action",
+        "delivery_action_basis",
+        "dead_letter",
+        "events",
+        "duration_s",
+        "outputs",
+        "warning",
+        "failure",
+        "failure_stage",
+        "cleanup",
+        "side_effect_outcome",
+        "last_checkpoint",
+    }
+    if set(value) != required:
+        raise ValueError("diagnostic result fields are invalid")
+    attempts = value["attempts"]
+    duration = value["duration_s"]
+    if isinstance(attempts, bool) or not isinstance(attempts, int) or attempts < 0:
+        raise ValueError("diagnostic attempts must be a non-negative integer")
+    if isinstance(duration, bool) or not isinstance(duration, (int, float)):
+        raise ValueError("diagnostic duration must be numeric")
+    if duration < 0 or not math.isfinite(float(duration)):
+        raise ValueError("diagnostic duration must be finite and non-negative")
+    if value["completion"] not in {
+        "succeeded",
+        "failed",
+        "timed_out",
+        "child_failed",
+        "cancelled",
+    }:
+        raise ValueError("diagnostic completion is invalid")
+    if not isinstance(value["selected_sinks"], list):
+        raise ValueError("diagnostic selected_sinks must be a list")
+    if not isinstance(value["events"], list) or not isinstance(value["outputs"], list):
+        raise ValueError("diagnostic events and outputs must be lists")
+
+
+def encode_request(request: DiagnosticRequest) -> bytes:
+    document: dict[str, Any] = {
+        "schema": "onestep/diagnostic-request",
+        "version": 1,
+        "operation": request.operation,
+        "target": request.target,
+        "task": request.task,
+        "send": request.send,
+        "capture_path": request.capture_path,
+        "envelope": None,
+    }
+    if request.envelope is not None:
+        document["envelope"] = {
+            "body": encode_value(request.envelope.body),
+            "meta": encode_value(request.envelope.meta),
+            "attempts": request.envelope.attempts,
+        }
+    return json.dumps(document, ensure_ascii=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+
+
+def decode_request(data: bytes) -> DiagnosticRequest:
+    try:
+        value = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("malformed diagnostic request") from exc
+    if not isinstance(value, dict) or set(value) != {
+        "schema",
+        "version",
+        "operation",
+        "target",
+        "task",
+        "send",
+        "capture_path",
+        "envelope",
+    }:
+        raise ValueError("diagnostic request fields are invalid")
+    if value["schema"] != "onestep/diagnostic-request" or value["version"] != 1:
+        raise ValueError("unsupported diagnostic request schema or version")
+    if not isinstance(value["target"], str) or not isinstance(value["task"], str):
+        raise ValueError("diagnostic request target and task must be strings")
+    if not isinstance(value["send"], bool):
+        raise ValueError("diagnostic request send must be boolean")
+    envelope = None
+    if value["envelope"] is not None:
+        raw_envelope = value["envelope"]
+        if not isinstance(raw_envelope, dict) or set(raw_envelope) != {
+            "body",
+            "meta",
+            "attempts",
+        }:
+            raise ValueError("diagnostic request envelope is invalid")
+        attempts = raw_envelope["attempts"]
+        if isinstance(attempts, bool) or not isinstance(attempts, int) or attempts < 0:
+            raise ValueError("diagnostic request attempts must be non-negative")
+        meta = decode_value(raw_envelope["meta"])
+        if not isinstance(meta, dict):
+            raise ValueError("diagnostic request meta must decode to a mapping")
+        envelope = Envelope(
+            body=decode_value(raw_envelope["body"]),
+            meta=meta,
+            attempts=attempts,
+        )
+    capture_path = value["capture_path"]
+    if capture_path is not None and not isinstance(capture_path, str):
+        raise ValueError("diagnostic request capture_path must be a string")
+    return DiagnosticRequest(
+        operation=value["operation"],
+        target=value["target"],
+        task=value["task"],
+        envelope=envelope,
+        capture_path=capture_path,
+        send=value["send"],
+    )
+
+
+__all__ = [
+    "CONNECTIVITY_SCHEMA",
+    "CONNECTIVITY_VERSION",
+    "DIAGNOSTIC_SCHEMA",
+    "DIAGNOSTIC_VERSION",
+    "SIDE_EFFECT_WARNING",
+    "ConnectivityReport",
+    "ConnectivityResourceResult",
+    "DiagnosticReport",
+    "DiagnosticRequest",
+    "decode_request",
+    "encode_request",
+]

--- a/src/onestep/diagnostics/models.py
+++ b/src/onestep/diagnostics/models.py
@@ -182,6 +182,7 @@ def _event_to_dict(event: TaskEvent) -> dict[str, Any]:
 def _event_from_dict(value: Any) -> TaskEvent:
     if not isinstance(value, Mapping):
         raise ValueError("diagnostic event must be an object")
+    _validate_event(value)
     failure_value = value.get("failure")
     failure = None
     if failure_value is not None:
@@ -255,10 +256,135 @@ def _validate_diagnostic_result(value: Mapping[str, Any]) -> None:
         "cancelled",
     }:
         raise ValueError("diagnostic completion is invalid")
-    if not isinstance(value["selected_sinks"], list):
+    for field in ("operation", "app", "task", "mode", "delivery_action_basis"):
+        if not isinstance(value[field], str):
+            raise ValueError(f"diagnostic {field} must be a string")
+    if value["operation"] not in {"run", "replay"}:
+        raise ValueError("diagnostic operation is invalid")
+    if value["mode"] not in {"dry-run", "send"}:
+        raise ValueError("diagnostic mode is invalid")
+    if value["delivery_action_basis"] != "predicted":
+        raise ValueError("diagnostic delivery_action_basis is invalid")
+    if value["delivery_action"] not in {
+        None,
+        "would_ack",
+        "would_retry",
+        "would_dead_letter",
+        "would_fail",
+    }:
+        raise ValueError("diagnostic delivery_action is invalid")
+    if not isinstance(value["selected_sinks"], list) or any(
+        not isinstance(item, str) for item in value["selected_sinks"]
+    ):
         raise ValueError("diagnostic selected_sinks must be a list")
     if not isinstance(value["events"], list) or not isinstance(value["outputs"], list):
         raise ValueError("diagnostic events and outputs must be lists")
+    for event in value["events"]:
+        if not isinstance(event, Mapping):
+            raise ValueError("diagnostic event must be an object")
+        _validate_event(event)
+    for output in value["outputs"]:
+        _validate_output(output)
+    dead_letter = value["dead_letter"]
+    if not isinstance(dead_letter, dict) or set(dead_letter) != {
+        "attempted",
+        "published",
+    }:
+        raise ValueError("diagnostic dead_letter is invalid")
+    published = dead_letter["published"]
+    if not isinstance(dead_letter["attempted"], bool) or (
+        published is not None and not isinstance(published, bool)
+    ):
+        raise ValueError("diagnostic dead_letter values are invalid")
+    failure = value["failure"]
+    if failure is not None and (
+        not isinstance(failure, dict)
+        or any(not isinstance(key, str) for key in failure)
+        or any(not isinstance(item, str) for item in failure.values())
+    ):
+        raise ValueError("diagnostic failure is invalid")
+    if value["failure_stage"] is not None and not isinstance(
+        value["failure_stage"], str
+    ):
+        raise ValueError("diagnostic failure_stage is invalid")
+    if value["cleanup"] not in {"complete", "failed", "incomplete"}:
+        raise ValueError("diagnostic cleanup is invalid")
+    if value["side_effect_outcome"] not in {
+        "not_attempted",
+        "completed",
+        "unknown",
+    }:
+        raise ValueError("diagnostic side_effect_outcome is invalid")
+    if not isinstance(value["warning"], str):
+        raise ValueError("diagnostic warning must be a string")
+    checkpoint = value["last_checkpoint"]
+    if checkpoint is not None and not isinstance(checkpoint, dict):
+        raise ValueError("diagnostic last_checkpoint must be an object")
+
+
+def _validate_event(value: Mapping[str, Any]) -> None:
+    if set(value) != {
+        "kind",
+        "app",
+        "task",
+        "source",
+        "attempts",
+        "emitted_at",
+        "duration_s",
+        "failure",
+        "meta",
+    }:
+        raise ValueError("diagnostic event fields are invalid")
+    for field in ("kind", "app", "task", "emitted_at"):
+        if not isinstance(value[field], str):
+            raise ValueError(f"diagnostic event {field} must be a string")
+    if value["source"] is not None and not isinstance(value["source"], str):
+        raise ValueError("diagnostic event source must be a string")
+    attempts = value["attempts"]
+    if isinstance(attempts, bool) or not isinstance(attempts, int) or attempts < 0:
+        raise ValueError("diagnostic event attempts must be non-negative")
+    duration = value["duration_s"]
+    if duration is not None and (
+        isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or duration < 0
+        or not math.isfinite(float(duration))
+    ):
+        raise ValueError("diagnostic event duration_s is invalid")
+    failure = value["failure"]
+    if failure is not None:
+        if not isinstance(failure, Mapping) or set(failure) != {
+            "kind",
+            "exception_type",
+        }:
+            raise ValueError("diagnostic event failure is invalid")
+        if not all(isinstance(item, str) for item in failure.values()):
+            raise ValueError("diagnostic event failure values are invalid")
+    try:
+        TaskEventKind(value["kind"])
+        datetime.fromisoformat(value["emitted_at"])
+    except (TypeError, ValueError) as exc:
+        raise ValueError("diagnostic event value is invalid") from exc
+
+
+def _validate_output(value: Any) -> None:
+    if not isinstance(value, dict) or set(value) != {"sink", "kind", "envelope"}:
+        raise ValueError("diagnostic output is invalid")
+    if not isinstance(value["sink"], str) or value["kind"] not in {
+        "emit",
+        "dead_letter",
+    }:
+        raise ValueError("diagnostic output sink or kind is invalid")
+    envelope = value["envelope"]
+    if not isinstance(envelope, dict) or set(envelope) != {
+        "body",
+        "meta",
+        "attempts",
+    }:
+        raise ValueError("diagnostic output envelope is invalid")
+    attempts = envelope["attempts"]
+    if isinstance(attempts, bool) or not isinstance(attempts, int) or attempts < 0:
+        raise ValueError("diagnostic output attempts must be non-negative")
 
 
 def encode_request(request: DiagnosticRequest) -> bytes:

--- a/src/onestep/diagnostics/models.py
+++ b/src/onestep/diagnostics/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Literal, Mapping
 
@@ -253,6 +253,7 @@ def _validate_diagnostic_result(value: Mapping[str, Any]) -> None:
         "failed",
         "timed_out",
         "child_failed",
+        "validation_failed",
         "cancelled",
     }:
         raise ValueError("diagnostic completion is invalid")

--- a/src/onestep/diagnostics/runner.py
+++ b/src/onestep/diagnostics/runner.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import copy
+import time
+from typing import Any
+
+from onestep.app import OneStepApp
+from onestep.capture.codec import encode_value
+from onestep.connectors.base import Delivery, Sink
+from onestep.envelope import Envelope
+from onestep.events import TaskEvent
+from onestep.runtime.executor import (
+    Checkpoint,
+    DeliveryAction,
+    DeliveryExecutor,
+    ExecutionOutcome,
+)
+
+from .models import DiagnosticReport
+
+
+async def _noop_checkpoint(phase, transition, details) -> None:
+    return None
+
+
+class _DiagnosticDelivery(Delivery):
+    async def ack(self) -> None:
+        return None
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        return None
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        return None
+
+
+class DiagnosticRunner:
+    def __init__(
+        self,
+        app: OneStepApp,
+        *,
+        checkpoint: Checkpoint | None = None,
+    ) -> None:
+        self.app = app
+        self.checkpoint = checkpoint or _noop_checkpoint
+        self._send = False
+        self._opened: list[Sink] = []
+        self._opened_ids: set[int] = set()
+        self._outputs: list[dict[str, Any]] = []
+        self._real_sends = 0
+
+    async def run(
+        self,
+        *,
+        task_name: str,
+        envelope: Envelope,
+        send: bool,
+        operation: str = "run",
+    ) -> DiagnosticReport:
+        task = self._resolve_task(task_name)
+        events: list[TaskEvent] = []
+        delivery = _DiagnosticDelivery(envelope)
+        self._send = send
+        self._opened = []
+        self._opened_ids = set()
+        self._outputs = []
+        self._real_sends = 0
+
+        async def emit_event(event: TaskEvent) -> None:
+            events.append(event)
+
+        executor = DeliveryExecutor(
+            self.app,
+            task,
+            emit_event=emit_event,
+            dispatch_sink=self._dispatch_sink,
+            apply_delivery_actions=False,
+            checkpoint=self.checkpoint,
+        )
+        started_at = time.perf_counter()
+        cleanup_errors: list[Exception] = []
+        outcome: ExecutionOutcome | None = None
+        try:
+            outcome = await executor.execute(delivery)
+        finally:
+            for sink in reversed(self._opened):
+                sink_name = getattr(sink, "name", type(sink).__name__)
+                try:
+                    await self.checkpoint(
+                        "cleanup",
+                        "entered",
+                        {"resource": sink_name},
+                    )
+                except Exception as exc:
+                    cleanup_errors.append(exc)
+                try:
+                    await sink.close()
+                except Exception as exc:
+                    cleanup_errors.append(exc)
+                try:
+                    await self.checkpoint(
+                        "cleanup",
+                        "completed",
+                        {
+                            "resource": sink_name,
+                            "cleanup": (
+                                "failed" if cleanup_errors else "complete"
+                            ),
+                        },
+                    )
+                except Exception as exc:
+                    cleanup_errors.append(exc)
+        assert outcome is not None
+        return self._build_report(
+            operation=operation,
+            task_name=task_name,
+            send=send,
+            envelope=envelope,
+            events=events,
+            outcome=outcome,
+            cleanup_errors=cleanup_errors,
+            duration_s=time.perf_counter() - started_at,
+        )
+
+    def _resolve_task(self, task_name: str):
+        matches = [task for task in self.app.tasks if task.name == task_name]
+        if len(matches) != 1:
+            raise ValueError(
+                f"expected exactly one task named {task_name!r}, found {len(matches)}"
+            )
+        return matches[0]
+
+    async def _dispatch_sink(
+        self,
+        sink: Sink,
+        envelope: Envelope,
+        kind: str,
+    ) -> bool:
+        sink_name = getattr(sink, "name", type(sink).__name__)
+        output = {
+            "sink": sink_name,
+            "kind": kind,
+            "envelope": {
+                "body": encode_value(self._report_body(envelope.body, kind=kind)),
+                "meta": encode_value(envelope.meta),
+                "attempts": envelope.attempts,
+            },
+        }
+        self._outputs.append(output)
+        if not self._send:
+            return False
+        if id(sink) not in self._opened_ids:
+            self._opened_ids.add(id(sink))
+            self._opened.append(sink)
+            await self.checkpoint("sink_open", "entered", {"resource": sink_name})
+            await sink.open()
+            await self.checkpoint("sink_open", "completed", {"resource": sink_name})
+        await self.checkpoint("sink", "entered", {"resource": sink_name})
+        await sink.send(envelope)
+        self._real_sends += 1
+        await self.checkpoint("sink", "completed", {"resource": sink_name})
+        return True
+
+    @staticmethod
+    def _report_body(body: Any, *, kind: str) -> Any:
+        if kind != "dead_letter" or not isinstance(body, dict):
+            return body
+        sanitized = copy.deepcopy(body)
+        failure = sanitized.get("failure")
+        if isinstance(failure, dict):
+            failure.pop("message", None)
+            failure.pop("traceback", None)
+        return sanitized
+
+    def _build_report(
+        self,
+        *,
+        operation: str,
+        task_name: str,
+        send: bool,
+        envelope: Envelope,
+        events: list[TaskEvent],
+        outcome: ExecutionOutcome,
+        cleanup_errors: list[Exception],
+        duration_s: float,
+    ) -> DiagnosticReport:
+        action_map = {
+            DeliveryAction.ACK: "would_ack",
+            DeliveryAction.RETRY: "would_retry",
+            DeliveryAction.DEAD_LETTER: "would_dead_letter",
+            DeliveryAction.FAIL: "would_fail",
+            None: None,
+        }
+        completion = outcome.completion
+        if cleanup_errors:
+            completion = "failed"
+        return DiagnosticReport(
+            operation=operation,
+            app=self.app.name,
+            task=task_name,
+            mode="send" if send else "dry-run",
+            completion=completion,
+            attempts=envelope.attempts,
+            selected_sinks=tuple(outcome.selected_sinks),
+            delivery_action=action_map[outcome.delivery_action],
+            delivery_action_basis="predicted",
+            dead_letter={
+                "attempted": outcome.dead_letter_attempted,
+                "published": outcome.dead_letter_published,
+            },
+            events=tuple(events),
+            duration_s=duration_s,
+            outputs=tuple(self._outputs),
+            failure=outcome.public_failure,
+            failure_stage=outcome.failure_stage,
+            cleanup="failed" if cleanup_errors else "complete",
+            side_effect_outcome=(
+                "completed"
+                if self._real_sends
+                else "not_attempted"
+            ),
+        )
+__all__ = ["DiagnosticRunner"]

--- a/src/onestep/diagnostics/supervisor.py
+++ b/src/onestep/diagnostics/supervisor.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import math
+import multiprocessing
+import os
+import sys
+import tempfile
+import time
+from dataclasses import replace
+from multiprocessing.connection import Connection
+from multiprocessing.context import BaseContext
+from typing import Any
+
+from .ipc import FrameValidator, IPCProtocolError, decode_frame, encode_frame
+from .models import SIDE_EFFECT_WARNING, DiagnosticReport, DiagnosticRequest, encode_request
+from .worker import diagnostic_worker_main
+
+_PARTIAL_SEND_WARNING = (
+    f"{SIDE_EFFECT_WARNING}; forced termination during --send may leave a partial "
+    "external write and a retry may create a duplicate"
+)
+
+
+def supervise_diagnostic(
+    request: DiagnosticRequest,
+    *,
+    timeout_s: float = 60.0,
+    grace_s: float = 5.0,
+) -> DiagnosticReport:
+    if (
+        isinstance(timeout_s, bool)
+        or not isinstance(timeout_s, (int, float))
+        or timeout_s <= 0
+        or not math.isfinite(float(timeout_s))
+        or isinstance(grace_s, bool)
+        or not isinstance(grace_s, (int, float))
+        or grace_s < 0
+        or not math.isfinite(float(grace_s))
+    ):
+        raise ValueError("diagnostic timeout must be > 0 and grace must be >= 0")
+    return _SpawnSupervisor(
+        request,
+        timeout_s=float(timeout_s),
+        grace_s=float(grace_s),
+    ).run()
+
+
+class _SpawnSupervisor:
+    def __init__(
+        self,
+        request: DiagnosticRequest,
+        *,
+        timeout_s: float,
+        grace_s: float,
+    ) -> None:
+        self.request = request
+        self.timeout_s = timeout_s
+        self.grace_s = grace_s
+        self.validator = FrameValidator(direction="status")
+        self.last_checkpoint: dict[str, Any] | None = None
+        self.send_incomplete = False
+        self.any_send_completed = False
+        self.selected_sinks: tuple[str, ...] = ()
+
+    def run(self) -> DiagnosticReport:
+        ctx = multiprocessing.get_context("spawn")
+        control_rx, control_tx = ctx.Pipe(duplex=False)
+        status_rx, status_tx = ctx.Pipe(duplex=False)
+        process = None
+        started = False
+        child_log = tempfile.TemporaryFile(mode="w+b")
+        stderr_handle = _duplicate_stderr_handle(ctx, child_log.fileno())
+        started_at = time.monotonic()
+        try:
+            process = ctx.Process(
+                target=diagnostic_worker_main,
+                args=(
+                    encode_request(self.request),
+                    control_rx,
+                    status_tx,
+                    stderr_handle,
+                ),
+                name="onestep-diagnostic",
+            )
+            process.start()
+            started = True
+            deadline = time.monotonic() + self.timeout_s
+            control_rx.close()
+            status_tx.close()
+
+            report = self._wait_for_final(
+                status_rx,
+                process,
+                deadline=deadline,
+            )
+            if report is not None:
+                return self._with_last_checkpoint(report)
+
+            try:
+                control_tx.send_bytes(
+                    encode_frame("cancel", sequence=1, payload={})
+                )
+            except (BrokenPipeError, EOFError, OSError):
+                pass
+            grace_deadline = time.monotonic() + self.grace_s
+            report = self._wait_for_final(
+                status_rx,
+                process,
+                deadline=grace_deadline,
+                child_exit_is_failure=False,
+            )
+            if report is not None:
+                report = self._with_last_checkpoint(report)
+                return replace(
+                    report,
+                    completion="timed_out",
+                    duration_s=time.monotonic() - started_at,
+                    warning=(
+                        _PARTIAL_SEND_WARNING
+                        if self.send_incomplete
+                        else report.warning
+                    ),
+                    side_effect_outcome=(
+                        "unknown"
+                        if self.send_incomplete
+                        else report.side_effect_outcome
+                    ),
+                )
+            return self._synthesize(
+                completion="timed_out",
+                duration_s=time.monotonic() - started_at,
+            )
+        except IPCProtocolError:
+            return self._synthesize(
+                completion="child_failed",
+                duration_s=time.monotonic() - started_at,
+            )
+        except (EOFError, BrokenPipeError, OSError):
+            return self._synthesize(
+                completion="child_failed",
+                duration_s=time.monotonic() - started_at,
+            )
+        finally:
+            for endpoint in (control_tx, control_rx, status_tx, status_rx):
+                try:
+                    endpoint.close()
+                except OSError:
+                    pass
+            if started and process is not None:
+                if process.is_alive():
+                    process.terminate()
+                process.join(timeout=self.grace_s)
+                if process.is_alive() and hasattr(process, "kill"):
+                    process.kill()
+                    process.join()
+            _forward_child_log(child_log)
+
+    def _wait_for_final(
+        self,
+        status_rx: Connection,
+        process: Any,
+        *,
+        deadline: float,
+        child_exit_is_failure: bool = True,
+    ) -> DiagnosticReport | None:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            if status_rx.poll(min(remaining, 0.05)):
+                frame = decode_frame(status_rx.recv_bytes())
+                payload = self.validator.accept(frame)
+                if frame["kind"] == "checkpoint":
+                    self._retain_checkpoint(payload)
+                    continue
+                return DiagnosticReport.from_dict(payload)
+            if not process.is_alive():
+                if status_rx.poll(0):
+                    continue
+                if child_exit_is_failure:
+                    raise EOFError("diagnostic child exited without a final frame")
+                return None
+
+    def _retain_checkpoint(self, checkpoint: dict[str, Any]) -> None:
+        self.last_checkpoint = dict(checkpoint)
+        selected = checkpoint.get("selected_sinks")
+        if isinstance(selected, list):
+            self.selected_sinks = tuple(selected)
+        if checkpoint["phase"] != "sink":
+            return
+        if checkpoint["transition"] == "entered":
+            self.send_incomplete = True
+        else:
+            self.send_incomplete = False
+            self.any_send_completed = True
+
+    def _with_last_checkpoint(self, report: DiagnosticReport) -> DiagnosticReport:
+        if report.last_checkpoint is not None or self.last_checkpoint is None:
+            return report
+        return replace(report, last_checkpoint=dict(self.last_checkpoint))
+
+    def _synthesize(self, *, completion: str, duration_s: float) -> DiagnosticReport:
+        checkpoint = self.last_checkpoint or {
+            "phase": "child_start",
+            "transition": "entered",
+            "elapsed_s": 0.0,
+        }
+        if self.send_incomplete:
+            side_effect_outcome = "unknown"
+        elif self.any_send_completed:
+            side_effect_outcome = "completed"
+        else:
+            side_effect_outcome = "not_attempted"
+        return DiagnosticReport(
+            operation=self.request.operation,
+            app=str(checkpoint.get("app", "")),
+            task=self.request.task,
+            mode="send" if self.request.send else "dry-run",
+            completion=completion,
+            attempts=(
+                self.request.envelope.attempts
+                if self.request.envelope is not None
+                else 0
+            ),
+            selected_sinks=self.selected_sinks,
+            delivery_action=None,
+            delivery_action_basis="predicted",
+            dead_letter={"attempted": False, "published": None},
+            events=(),
+            duration_s=duration_s,
+            warning=(
+                _PARTIAL_SEND_WARNING
+                if self.send_incomplete
+                else SIDE_EFFECT_WARNING
+            ),
+            failure=None,
+            failure_stage=str(checkpoint.get("phase", "child_start")),
+            cleanup="incomplete",
+            side_effect_outcome=side_effect_outcome,
+            last_checkpoint=dict(checkpoint),
+        )
+
+
+def _duplicate_stderr_handle(ctx: BaseContext, fd: int) -> Any:
+    if os.name != "nt":
+        from multiprocessing.reduction import DupFd
+
+        return DupFd(fd)
+    import msvcrt
+    from multiprocessing.reduction import DupHandle
+
+    return DupHandle(msvcrt.get_osfhandle(fd))
+
+
+def _forward_child_log(handle: Any) -> None:
+    try:
+        handle.seek(0)
+        data = handle.read()
+    finally:
+        handle.close()
+    if not data:
+        return
+    stream = getattr(sys.stderr, "buffer", sys.stderr)
+    if stream is sys.stderr:
+        stream.write(data.decode("utf-8", errors="replace"))
+    else:
+        stream.write(data)
+    sys.stderr.flush()
+
+
+__all__ = ["supervise_diagnostic"]

--- a/src/onestep/diagnostics/targets.py
+++ b/src/onestep/diagnostics/targets.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import os
+import sys
+
+from onestep.app import OneStepApp
+from onestep.config import is_yaml_target, load_yaml_app
+
+_PROJECT_MARKERS = ("pyproject.toml", "setup.py", "setup.cfg")
+
+
+def load_diagnostic_target(target: str) -> OneStepApp:
+    _ensure_local_import_paths(target)
+    if is_yaml_target(target):
+        return load_yaml_app(target)
+    return OneStepApp.load(target)
+
+
+def _ensure_local_import_paths(target: str | None = None) -> None:
+    cwd = os.getcwd()
+    if not cwd:
+        return
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def add_candidates(base_dir: str | None) -> None:
+        if base_dir is None:
+            return
+        for path in _candidate_import_paths(base_dir):
+            normalized_path = os.path.normcase(os.path.abspath(path))
+            if normalized_path in seen:
+                continue
+            seen.add(normalized_path)
+            candidates.append(path)
+
+    add_candidates(_target_import_root(cwd, target))
+    add_candidates(cwd)
+
+    for path in reversed(candidates):
+        if _path_on_syspath(path):
+            continue
+        sys.path.insert(0, path)
+
+
+def _candidate_import_paths(cwd: str) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def add(path: str) -> None:
+        absolute_path = os.path.abspath(path)
+        normalized_path = os.path.normcase(absolute_path)
+        if normalized_path in seen or not os.path.isdir(absolute_path):
+            return
+        seen.add(normalized_path)
+        candidates.append(absolute_path)
+
+    add(cwd)
+    add(os.path.join(cwd, "src"))
+
+    project_root = _find_project_root(cwd)
+    if project_root is not None:
+        add(project_root)
+        add(os.path.join(project_root, "src"))
+
+    return candidates
+
+
+def _target_import_root(cwd: str, target: str | None) -> str | None:
+    if not target or not is_yaml_target(target):
+        return None
+    if os.path.isabs(target):
+        return os.path.dirname(target)
+    return os.path.dirname(os.path.abspath(os.path.join(cwd, target)))
+
+
+def _find_project_root(start: str) -> str | None:
+    current = os.path.abspath(start)
+    while True:
+        if any(
+            os.path.exists(os.path.join(current, marker))
+            for marker in _PROJECT_MARKERS
+        ):
+            return current
+        parent = os.path.dirname(current)
+        if parent == current:
+            return None
+        current = parent
+
+
+def _path_on_syspath(path: str) -> bool:
+    normalized_path = os.path.normcase(os.path.abspath(path))
+    for entry in sys.path:
+        current = entry or os.getcwd()
+        if os.path.normcase(os.path.abspath(current)) == normalized_path:
+            return True
+    return False
+
+
+__all__ = ["load_diagnostic_target"]

--- a/src/onestep/diagnostics/worker.py
+++ b/src/onestep/diagnostics/worker.py
@@ -94,6 +94,7 @@ async def _run_worker(
     send = False
     attempts = 0
     send_incomplete = False
+    validation_complete = False
 
     def send_status(kind: str, payload: dict[str, Any]) -> None:
         nonlocal sequence
@@ -154,6 +155,12 @@ async def _run_worker(
             assert request.envelope is not None
             envelope = request.envelope
         attempts = envelope.attempts
+        matches = [task for task in app.tasks if task.name == request.task]
+        if len(matches) != 1:
+            raise ValueError(
+                f"expected exactly one task named {request.task!r}, found {len(matches)}"
+            )
+        validation_complete = True
         report = await DiagnosticRunner(app, checkpoint=checkpoint).run(
             task_name=request.task,
             envelope=envelope,
@@ -181,7 +188,9 @@ async def _run_worker(
             task=task_name,
             send=send,
             attempts=attempts,
-            completion="child_failed",
+            completion=(
+                "child_failed" if validation_complete else "validation_failed"
+            ),
             last_checkpoint=last_checkpoint,
             side_effect_unknown=send_incomplete,
             failure_type=type(exc).__name__,

--- a/src/onestep/diagnostics/worker.py
+++ b/src/onestep/diagnostics/worker.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import threading
+import time
+import traceback
+from dataclasses import replace
+from multiprocessing.connection import Connection
+from typing import Any
+
+from onestep.capture import load_capture
+
+from .ipc import FrameValidator, decode_frame, encode_frame
+from .models import (
+    SIDE_EFFECT_WARNING,
+    DiagnosticReport,
+    decode_request,
+)
+from .runner import DiagnosticRunner
+from .targets import load_diagnostic_target
+
+_PARTIAL_SEND_WARNING = (
+    f"{SIDE_EFFECT_WARNING}; forced termination during --send may leave a partial "
+    "external write and a retry may create a duplicate"
+)
+
+
+def diagnostic_worker_main(
+    request_bytes: bytes,
+    control_rx: Connection,
+    status_tx: Connection,
+    stderr_handle: Any,
+) -> None:
+    stderr_fd = _detach_stderr_fd(stderr_handle)
+    try:
+        os.dup2(stderr_fd, 1)
+        os.dup2(stderr_fd, 2)
+    finally:
+        if stderr_fd not in {1, 2}:
+            os.close(stderr_fd)
+    sys.stdout = os.fdopen(1, "w", buffering=1, closefd=False)
+    sys.stderr = os.fdopen(2, "w", buffering=1, closefd=False)
+    try:
+        asyncio.run(_run_worker(request_bytes, control_rx, status_tx))
+    finally:
+        control_rx.close()
+        status_tx.close()
+
+
+def _detach_stderr_fd(stderr_handle: Any) -> int:
+    detached = stderr_handle.detach()
+    if os.name != "nt":
+        return detached
+    import msvcrt
+
+    return msvcrt.open_osfhandle(detached, os.O_WRONLY)
+
+
+def _peek_request(data: bytes) -> tuple[str, str, str, bool]:
+    try:
+        value = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("malformed diagnostic request") from exc
+    if not isinstance(value, dict):
+        raise ValueError("diagnostic request must be an object")
+    target = value.get("target")
+    operation = value.get("operation")
+    task = value.get("task")
+    send = value.get("send")
+    if (
+        not isinstance(target, str)
+        or operation not in {"run", "replay"}
+        or not isinstance(task, str)
+        or not isinstance(send, bool)
+    ):
+        raise ValueError("diagnostic request routing fields are invalid")
+    return target, operation, task, send
+
+
+async def _run_worker(
+    request_bytes: bytes,
+    control_rx: Connection,
+    status_tx: Connection,
+) -> None:
+    started_at = time.monotonic()
+    sequence = 0
+    last_checkpoint: dict[str, Any] | None = None
+    app_name = ""
+    task_name = ""
+    operation = "run"
+    send = False
+    attempts = 0
+    send_incomplete = False
+
+    def send_status(kind: str, payload: dict[str, Any]) -> None:
+        nonlocal sequence
+        sequence += 1
+        status_tx.send_bytes(
+            encode_frame(kind, sequence=sequence, payload=payload)
+        )
+
+    async def checkpoint(
+        phase: str,
+        transition: str,
+        details: Any,
+    ) -> None:
+        nonlocal last_checkpoint, send_incomplete
+        payload: dict[str, Any] = {
+            "phase": phase,
+            "transition": transition,
+            "elapsed_s": time.monotonic() - started_at,
+        }
+        if app_name:
+            payload["app"] = app_name
+        if task_name:
+            payload["task"] = task_name
+        for key in ("resource", "selected_sinks", "completion", "cleanup"):
+            value = details.get(key) if hasattr(details, "get") else None
+            if value is not None:
+                payload[key] = value
+        if phase == "sink":
+            send_incomplete = transition == "entered"
+        last_checkpoint = payload
+        send_status("checkpoint", payload)
+
+    await checkpoint("child_start", "entered", {})
+    current_task = asyncio.current_task()
+    assert current_task is not None
+    control_thread = threading.Thread(
+        target=_listen_for_cancel,
+        args=(control_rx, asyncio.get_running_loop(), current_task),
+        daemon=True,
+        name="onestep-diagnostic-control",
+    )
+    control_thread.start()
+
+    try:
+        target, operation, task_name, send = _peek_request(request_bytes)
+        app = load_diagnostic_target(target)
+        app_name = app.name
+        request = decode_request(request_bytes)
+        await checkpoint("child_start", "completed", {})
+        if request.operation == "replay":
+            capture = load_capture(
+                request.capture_path,
+                expected_app=app.name,
+                expected_task=request.task,
+            )
+            envelope = capture.envelope
+        else:
+            assert request.envelope is not None
+            envelope = request.envelope
+        attempts = envelope.attempts
+        report = await DiagnosticRunner(app, checkpoint=checkpoint).run(
+            task_name=request.task,
+            envelope=envelope,
+            send=request.send,
+            operation=request.operation,
+        )
+        report = replace(report, last_checkpoint=last_checkpoint)
+    except asyncio.CancelledError:
+        report = _fallback_report(
+            operation=operation,
+            app=app_name,
+            task=task_name,
+            send=send,
+            attempts=attempts,
+            completion="cancelled",
+            last_checkpoint=last_checkpoint,
+            side_effect_unknown=send_incomplete,
+            cleanup="complete",
+        )
+    except BaseException as exc:
+        traceback.print_exc(file=sys.stderr)
+        report = _fallback_report(
+            operation=operation,
+            app=app_name,
+            task=task_name,
+            send=send,
+            attempts=attempts,
+            completion="child_failed",
+            last_checkpoint=last_checkpoint,
+            side_effect_unknown=send_incomplete,
+            failure_type=type(exc).__name__,
+        )
+    try:
+        send_status("final", report.to_dict())
+    except (BrokenPipeError, EOFError, OSError):
+        return
+
+
+def _listen_for_cancel(
+    control_rx: Connection,
+    loop: asyncio.AbstractEventLoop,
+    task: asyncio.Task[Any],
+) -> None:
+    validator = FrameValidator(direction="control")
+    try:
+        while True:
+            frame = decode_frame(control_rx.recv_bytes())
+            validator.accept(frame)
+            if frame["kind"] == "cancel":
+                loop.call_soon_threadsafe(task.cancel)
+                return
+    except (EOFError, OSError, ValueError):
+        return
+
+
+def _fallback_report(
+    *,
+    operation: str,
+    app: str,
+    task: str,
+    send: bool,
+    attempts: int,
+    completion: str,
+    last_checkpoint: dict[str, Any] | None,
+    side_effect_unknown: bool,
+    cleanup: str = "incomplete",
+    failure_type: str | None = None,
+) -> DiagnosticReport:
+    checkpoint = last_checkpoint or {
+        "phase": "child_start",
+        "transition": "entered",
+        "elapsed_s": 0.0,
+    }
+    return DiagnosticReport(
+        operation=operation,
+        app=app,
+        task=task,
+        mode="send" if send else "dry-run",
+        completion=completion,
+        attempts=attempts,
+        selected_sinks=(),
+        delivery_action=None,
+        delivery_action_basis="predicted",
+        dead_letter={"attempted": False, "published": None},
+        events=(),
+        duration_s=float(checkpoint.get("elapsed_s", 0.0)),
+        warning=_PARTIAL_SEND_WARNING if side_effect_unknown else SIDE_EFFECT_WARNING,
+        failure=(
+            {"failure_kind": "error", "exception_type": failure_type}
+            if failure_type is not None
+            else None
+        ),
+        failure_stage=str(checkpoint.get("phase", "child_start")),
+        cleanup=cleanup,
+        side_effect_outcome=("unknown" if side_effect_unknown else "not_attempted"),
+        last_checkpoint=dict(checkpoint),
+    )
+
+
+__all__ = ["diagnostic_worker_main"]

--- a/src/onestep/runtime/executor.py
+++ b/src/onestep/runtime/executor.py
@@ -1,0 +1,641 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import inspect
+import logging
+import math
+import time
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from onestep.capture.codec import CaptureEncodingError
+from onestep.connectors.base import Delivery, Sink
+from onestep.context import TaskContext
+from onestep.envelope import Envelope
+from onestep.events import TaskEvent, TaskEventKind
+from onestep.invoke import invoke_callback
+from onestep.resilience import (
+    ConnectorOperationError,
+    connector_retry_delay,
+    is_retryable_connector_error,
+)
+from onestep.retry import FailureInfo, FailureKind, RetryDecision, resolve_retry_action
+from onestep.task import TaskSpec
+
+if TYPE_CHECKING:
+    from onestep.app import OneStepApp
+
+
+_INVALID_NOTIFICATION_VALUE = object()
+
+
+class DeliveryAction(str, Enum):
+    ACK = "ack"
+    RETRY = "retry"
+    DEAD_LETTER = "dead_letter"
+    FAIL = "fail"
+
+
+@dataclass
+class ExecutionOutcome:
+    completion: str
+    handler_result: Any = None
+    selected_sinks: list[str] = field(default_factory=list)
+    delivery_action: DeliveryAction | None = None
+    retry_delay_s: float | None = None
+    failure: FailureInfo | None = None
+    public_failure: dict[str, str] | None = None
+    failure_stage: str | None = None
+    dead_letter_attempted: bool = False
+    dead_letter_published: bool | None = None
+    terminal: bool = False
+    capture_envelope: Envelope | None = None
+
+
+EventEmitter = Callable[[TaskEvent], Awaitable[None]]
+SinkDispatcher = Callable[[Sink, Envelope, str], Awaitable[bool]]
+Checkpoint = Callable[[str, str, Mapping[str, Any]], Awaitable[None]]
+
+
+async def _noop_checkpoint(
+    phase: str,
+    transition: str,
+    details: Mapping[str, Any],
+) -> None:
+    return None
+
+
+class DeliveryExecutor:
+    _SEND_ATTEMPTS = 2
+
+    def __init__(
+        self,
+        app: "OneStepApp",
+        task: TaskSpec,
+        *,
+        emit_event: EventEmitter | None = None,
+        dispatch_sink: SinkDispatcher | None = None,
+        apply_delivery_actions: bool = True,
+        checkpoint: Checkpoint | None = None,
+    ) -> None:
+        self.app = app
+        self.task = task
+        self._event_emitter = emit_event or app.emit_event
+        self._sink_dispatcher = dispatch_sink or self._dispatch_production_sink
+        self.apply_delivery_actions = apply_delivery_actions
+        self.checkpoint = checkpoint or _noop_checkpoint
+        self.logger = logging.getLogger(f"onestep.{app.name}.{task.name}")
+
+    async def execute(self, delivery: Delivery) -> ExecutionOutcome:
+        outcome = ExecutionOutcome(completion="running")
+        ctx = TaskContext(app=self.app, task=self.task, delivery=delivery)
+        started_at = time.perf_counter()
+        active_stage = "delivery_action"
+        try:
+            await delivery.start_processing()
+            await self.emit(TaskEventKind.STARTED, delivery)
+
+            active_stage = "before_hook"
+            await self.checkpoint(active_stage, "entered", {})
+            await self._run_hooks(self.task.hooks.before, ctx, delivery.payload)
+            await self.checkpoint(active_stage, "completed", {})
+
+            active_stage = "handler"
+            await self.checkpoint(active_stage, "entered", {})
+            outcome.handler_result = await self._invoke_handler(ctx, delivery)
+            await self.checkpoint(active_stage, "completed", {})
+
+            active_stage = "after_success_hook"
+            await self.checkpoint(active_stage, "entered", {})
+            await self._run_hooks(
+                self.task.hooks.after_success,
+                ctx,
+                delivery.payload,
+                outcome.handler_result,
+            )
+            await self.checkpoint(active_stage, "completed", {})
+
+            if outcome.handler_result is not None and self.task.emit_routes:
+                active_stage = "route"
+                await self.checkpoint(active_stage, "entered", {})
+                selected = await self._select_emit_sinks(
+                    ctx,
+                    delivery.payload,
+                    outcome.handler_result,
+                )
+                outcome.selected_sinks = [
+                    getattr(sink, "name", type(sink).__name__) for sink in selected
+                ]
+                await self.checkpoint(
+                    active_stage,
+                    "completed",
+                    {"selected_sinks": outcome.selected_sinks},
+                )
+                emitted = Envelope(body=outcome.handler_result)
+                for sink in selected:
+                    active_stage = "sink"
+                    await self._sink_dispatcher(sink, emitted, "emit")
+
+            active_stage = "ack"
+            outcome.delivery_action = DeliveryAction.ACK
+            await self.checkpoint(active_stage, "entered", {})
+            if self.apply_delivery_actions:
+                await delivery.ack()
+            await self.checkpoint(active_stage, "completed", {})
+            await self.emit(
+                TaskEventKind.SUCCEEDED,
+                delivery,
+                duration_s=time.perf_counter() - started_at,
+                event_meta=self._build_succeeded_event_meta(
+                    delivery,
+                    outcome.handler_result,
+                ),
+            )
+            outcome.completion = "succeeded"
+            outcome.terminal = True
+            return outcome
+        except asyncio.CancelledError:
+            outcome.failure_stage = active_stage
+            await self._handle_cancelled(delivery, outcome, started_at)
+            raise
+        except asyncio.TimeoutError as exc:
+            outcome.failure_stage = active_stage
+            return await self._handle_failure(
+                ctx,
+                delivery,
+                exc,
+                FailureKind.TIMEOUT,
+                outcome,
+                started_at,
+            )
+        except Exception as exc:
+            outcome.failure_stage = active_stage
+            return await self._handle_failure(
+                ctx,
+                delivery,
+                exc,
+                FailureKind.ERROR,
+                outcome,
+                started_at,
+            )
+
+    async def emit(
+        self,
+        kind: TaskEventKind,
+        delivery: Delivery,
+        *,
+        duration_s: float | None = None,
+        failure: FailureInfo | None = None,
+        event_meta: dict[str, Any] | None = None,
+    ) -> None:
+        event = TaskEvent(
+            kind=kind,
+            app=self.app.name,
+            task=self.task.name,
+            source=self.task.source.name if self.task.source is not None else None,
+            attempts=delivery.envelope.attempts,
+            duration_s=duration_s,
+            failure=failure,
+            meta=(
+                copy.deepcopy(event_meta)
+                if event_meta is not None
+                else copy.deepcopy(delivery.envelope.meta)
+            ),
+        )
+        await self._event_emitter(event)
+
+    async def _invoke_handler(self, ctx: TaskContext, delivery: Delivery) -> Any:
+        result = self.task.handler(ctx, delivery.payload)
+        if inspect.isawaitable(result):
+            if self.task.timeout_s is not None:
+                return await asyncio.wait_for(result, timeout=self.task.timeout_s)
+            return await result
+        return result
+
+    async def _select_emit_sinks(
+        self,
+        ctx: TaskContext,
+        payload: Any,
+        result: Any,
+    ) -> tuple[Sink, ...]:
+        sinks: list[Sink] = []
+        for route in self.task.emit_routes:
+            if route.predicate is None:
+                sinks.extend(route.then_sinks)
+                continue
+            predicate_result = invoke_callback(route.predicate, ctx, payload, result)
+            if inspect.isawaitable(predicate_result):
+                predicate_result = await predicate_result
+            if predicate_result:
+                sinks.extend(route.then_sinks)
+            else:
+                sinks.extend(route.otherwise_sinks)
+        return tuple(sinks)
+
+    async def _handle_cancelled(
+        self,
+        delivery: Delivery,
+        outcome: ExecutionOutcome,
+        started_at: float,
+    ) -> None:
+        failure = FailureInfo.from_exception(
+            asyncio.CancelledError(),
+            kind=FailureKind.CANCELLED,
+        )
+        outcome.failure = failure
+        outcome.capture_envelope = copy.deepcopy(delivery.envelope)
+        outcome.public_failure = self._public_failure(failure, None)
+        outcome.delivery_action = DeliveryAction.RETRY
+        outcome.completion = "cancelled"
+        self.logger.warning(
+            "task cancelled",
+            extra={"failure_kind": failure.kind.value},
+        )
+        duration_s = time.perf_counter() - started_at
+        await self.emit(
+            TaskEventKind.CANCELLED,
+            delivery,
+            failure=failure,
+            duration_s=duration_s,
+        )
+        if self.apply_delivery_actions:
+            await delivery.retry()
+        await self.emit(
+            TaskEventKind.RETRIED,
+            delivery,
+            failure=failure,
+            duration_s=duration_s,
+        )
+        await self._capture_failure(delivery, outcome)
+
+    async def _handle_failure(
+        self,
+        ctx: TaskContext,
+        delivery: Delivery,
+        exc: Exception,
+        kind: FailureKind,
+        outcome: ExecutionOutcome,
+        started_at: float,
+    ) -> ExecutionOutcome:
+        duration_s = time.perf_counter() - started_at
+        failure = FailureInfo.from_exception(exc, kind=kind)
+        outcome.failure = failure
+        outcome.capture_envelope = copy.deepcopy(delivery.envelope)
+        outcome.public_failure = self._public_failure(failure, exc)
+        outcome.completion = "failed"
+        ctx.logger.exception(
+            "task failed",
+            extra={"failure_kind": failure.kind.value},
+        )
+        await self.checkpoint("failure_hook", "entered", {})
+        await self._run_hooks(
+            self.task.hooks.on_failure,
+            ctx,
+            delivery.payload,
+            failure,
+            suppress_exceptions=True,
+            logger=ctx.logger,
+            message="task failure hook failed",
+        )
+        await self.checkpoint("failure_hook", "completed", {})
+
+        action = resolve_retry_action(self.task.retry, delivery.envelope, exc, failure)
+        if action.decision is RetryDecision.RETRY:
+            outcome.delivery_action = DeliveryAction.RETRY
+            outcome.retry_delay_s = action.delay_s
+            await self._apply_retry(delivery, delay_s=action.delay_s)
+            await self.emit(
+                TaskEventKind.RETRIED,
+                delivery,
+                failure=failure,
+                duration_s=duration_s,
+            )
+            await self._capture_failure(delivery, outcome)
+            return outcome
+
+        if self.task.dead_letter_sinks:
+            outcome.delivery_action = DeliveryAction.DEAD_LETTER
+            published = await self._publish_dead_letter(
+                ctx,
+                delivery,
+                failure,
+                outcome,
+                duration_s=duration_s,
+            )
+            if not published:
+                await self._capture_failure(delivery, outcome)
+                return outcome
+        else:
+            outcome.delivery_action = DeliveryAction.FAIL
+
+        outcome.terminal = await self._fail_delivery(ctx, delivery, exc)
+        if not outcome.terminal:
+            outcome.delivery_action = DeliveryAction.RETRY
+        await self.emit(
+            TaskEventKind.FAILED,
+            delivery,
+            failure=failure,
+            duration_s=duration_s,
+        )
+        await self._capture_failure(delivery, outcome)
+        return outcome
+
+    async def _publish_dead_letter(
+        self,
+        ctx: TaskContext,
+        delivery: Delivery,
+        failure: FailureInfo,
+        outcome: ExecutionOutcome,
+        *,
+        duration_s: float | None,
+    ) -> bool:
+        envelope = Envelope(
+            body={
+                "payload": copy.deepcopy(delivery.envelope.body),
+                "failure": failure.as_dict(),
+            },
+            meta={
+                "app": self.app.name,
+                "task": self.task.name,
+                "source": (
+                    self.task.source.name if self.task.source is not None else None
+                ),
+                "original_meta": copy.deepcopy(delivery.envelope.meta),
+                "original_attempts": delivery.envelope.attempts,
+            },
+            attempts=0,
+        )
+        any_real_send = False
+        try:
+            for sink in self.task.dead_letter_sinks:
+                sent = await self._sink_dispatcher(sink, envelope, "dead_letter")
+                any_real_send = any_real_send or sent
+        except Exception:
+            outcome.dead_letter_attempted = True
+            outcome.dead_letter_published = False
+            outcome.delivery_action = DeliveryAction.RETRY
+            ctx.logger.exception(
+                "dead-letter publish failed; retrying original delivery"
+            )
+            await self._apply_retry(delivery)
+            await self.emit(
+                TaskEventKind.RETRIED,
+                delivery,
+                failure=failure,
+                duration_s=duration_s,
+            )
+            return False
+        outcome.dead_letter_attempted = any_real_send
+        outcome.dead_letter_published = True if any_real_send else None
+        await self.emit(
+            TaskEventKind.DEAD_LETTERED,
+            delivery,
+            failure=failure,
+            duration_s=duration_s,
+        )
+        return True
+
+    async def _apply_retry(
+        self,
+        delivery: Delivery,
+        *,
+        delay_s: float | None = None,
+    ) -> None:
+        await self.checkpoint("delivery_action", "entered", {})
+        if self.apply_delivery_actions:
+            await delivery.retry(delay_s=delay_s)
+        await self.checkpoint("delivery_action", "completed", {})
+
+    async def _fail_delivery(
+        self,
+        ctx: TaskContext,
+        delivery: Delivery,
+        exc: Exception,
+    ) -> bool:
+        if not self.apply_delivery_actions:
+            return True
+        await self.checkpoint("delivery_action", "entered", {})
+        try:
+            await delivery.fail(exc)
+        except Exception:
+            ctx.logger.exception(
+                "delivery fail action failed; retrying original delivery"
+            )
+            await delivery.retry()
+            await self.checkpoint("delivery_action", "completed", {})
+            return False
+        await self.checkpoint("delivery_action", "completed", {})
+        return True
+
+    async def _dispatch_production_sink(
+        self,
+        sink: Sink,
+        envelope: Envelope,
+        kind: str,
+    ) -> bool:
+        if kind == "dead_letter":
+            await sink.send(envelope)
+        else:
+            await self._send_to_sink(sink, envelope)
+        return True
+
+    async def _send_to_sink(self, sink: Sink, envelope: Envelope) -> None:
+        fallback_s = getattr(sink, "poll_interval_s", 1.0)
+        for attempt in range(self._SEND_ATTEMPTS):
+            try:
+                await sink.send(envelope)
+                self.logger.debug(
+                    "sink send succeeded",
+                    extra={
+                        "sink_name": getattr(
+                            sink,
+                            "name",
+                            sink.__class__.__name__,
+                        ),
+                        "sink_kind": sink.__class__.__name__,
+                        "connector_backend": (
+                            getattr(
+                                getattr(sink, "connector", None),
+                                "__class__",
+                                type(None),
+                            ).__name__
+                            if getattr(sink, "connector", None) is not None
+                            else None
+                        ),
+                        "delivery_attempts": envelope.attempts,
+                    },
+                )
+                return
+            except ConnectorOperationError as exc:
+                if (
+                    not is_retryable_connector_error(exc)
+                    or attempt == self._SEND_ATTEMPTS - 1
+                ):
+                    raise
+                delay_s = connector_retry_delay(exc, fallback_s=fallback_s)
+                self.logger.warning(
+                    "sink send degraded; retrying",
+                    extra={
+                        "connector_backend": exc.backend,
+                        "connector_operation": exc.operation.value,
+                        "connector_kind": exc.kind.value,
+                        "connector_retry_delay_s": delay_s,
+                    },
+                    exc_info=exc,
+                )
+                if delay_s <= 0 or self.app.is_stopping:
+                    continue
+                try:
+                    await asyncio.wait_for(
+                        self.app.wait_for_shutdown(),
+                        timeout=delay_s,
+                    )
+                except asyncio.TimeoutError:
+                    continue
+                raise
+
+    async def _run_hooks(
+        self,
+        hooks: Sequence[Callable[..., Any]],
+        *args: Any,
+        suppress_exceptions: bool = False,
+        logger: logging.Logger | None = None,
+        message: str = "task hook failed",
+    ) -> None:
+        for hook in hooks:
+            try:
+                result = invoke_callback(hook, *args)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                if not suppress_exceptions:
+                    raise
+                active_logger = logger or self.logger
+                active_logger.exception(
+                    message,
+                    extra={
+                        "task_hook": getattr(
+                            hook,
+                            "__name__",
+                            hook.__class__.__name__,
+                        )
+                    },
+                )
+
+    def _build_succeeded_event_meta(
+        self,
+        delivery: Delivery,
+        result: Any,
+    ) -> dict[str, Any]:
+        event_meta = copy.deepcopy(delivery.envelope.meta)
+        notification = self._extract_notification_payload(result)
+        if notification is not None:
+            event_meta["notification"] = notification
+        return event_meta
+
+    def _extract_notification_payload(self, result: Any) -> dict[str, Any] | None:
+        if not isinstance(result, Mapping):
+            return None
+        notification = result.get("notification")
+        if not isinstance(notification, Mapping):
+            return None
+        sanitized = self._sanitize_notification_value(notification)
+        if not isinstance(sanitized, dict) or not sanitized:
+            return None
+        return sanitized
+
+    def _sanitize_notification_value(self, value: Any) -> Any:
+        if value is None or isinstance(value, (str, bool, int)):
+            return value
+        if isinstance(value, float):
+            return value if math.isfinite(value) else _INVALID_NOTIFICATION_VALUE
+        if isinstance(value, Mapping):
+            sanitized: dict[str, Any] = {}
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    continue
+                clean_item = self._sanitize_notification_value(item)
+                if clean_item is _INVALID_NOTIFICATION_VALUE:
+                    continue
+                sanitized[key] = clean_item
+            return sanitized
+        if isinstance(value, (list, tuple)):
+            sanitized_items = []
+            for item in value:
+                clean_item = self._sanitize_notification_value(item)
+                if clean_item is _INVALID_NOTIFICATION_VALUE:
+                    continue
+                sanitized_items.append(clean_item)
+            return sanitized_items
+        return _INVALID_NOTIFICATION_VALUE
+
+    def _public_failure(
+        self,
+        failure: FailureInfo,
+        exc: Exception | None,
+    ) -> dict[str, str]:
+        result = {
+            "failure_kind": failure.kind.value,
+            "exception_type": failure.exception_type,
+        }
+        if isinstance(exc, ConnectorOperationError):
+            result.update(
+                {
+                    "backend": exc.backend,
+                    "operation": exc.operation.value,
+                    "connector_kind": exc.kind.value,
+                }
+            )
+        return result
+
+    async def _capture_failure(
+        self,
+        delivery: Delivery,
+        outcome: ExecutionOutcome,
+    ) -> None:
+        writer = getattr(self.app, "_failure_capture_writer", None)
+        config = self.app.failure_capture
+        if writer is None or config is None or outcome.failure is None:
+            return
+        if config.mode == "terminal" and not outcome.terminal:
+            return
+        try:
+            await writer.write(
+                app=self.app.name,
+                task=self.task.name,
+                stage=outcome.failure_stage or "delivery_action",
+                terminal=outcome.terminal,
+                failure=outcome.failure,
+                envelope=outcome.capture_envelope or delivery.envelope,
+            )
+        except CaptureEncodingError as exc:
+            self.logger.error(
+                "failure capture encoding failed",
+                extra={
+                    "app_name": self.app.name,
+                    "task_name": self.task.name,
+                    "failure_stage": outcome.failure_stage,
+                    "capture_type": exc.type_name,
+                    "capture_path": exc.path,
+                },
+            )
+        except Exception:
+            self.logger.exception(
+                "failure capture persistence failed",
+                extra={
+                    "app_name": self.app.name,
+                    "task_name": self.task.name,
+                },
+            )
+
+
+__all__ = [
+    "Checkpoint",
+    "DeliveryAction",
+    "DeliveryExecutor",
+    "ExecutionOutcome",
+    "SinkDispatcher",
+]

--- a/src/onestep/runtime/executor.py
+++ b/src/onestep/runtime/executor.py
@@ -53,6 +53,7 @@ class ExecutionOutcome:
     dead_letter_published: bool | None = None
     terminal: bool = False
     capture_envelope: Envelope | None = None
+    capture_snapshot_error_type: str | None = None
 
 
 EventEmitter = Callable[[TaskEvent], Awaitable[None]]
@@ -246,7 +247,7 @@ class DeliveryExecutor:
             kind=FailureKind.CANCELLED,
         )
         outcome.failure = failure
-        outcome.capture_envelope = copy.deepcopy(delivery.envelope)
+        self._snapshot_capture_envelope(delivery, outcome)
         outcome.public_failure = self._public_failure(failure, None)
         outcome.delivery_action = DeliveryAction.RETRY
         outcome.completion = "cancelled"
@@ -283,7 +284,7 @@ class DeliveryExecutor:
         duration_s = time.perf_counter() - started_at
         failure = FailureInfo.from_exception(exc, kind=kind)
         outcome.failure = failure
-        outcome.capture_envelope = copy.deepcopy(delivery.envelope)
+        self._snapshot_capture_envelope(delivery, outcome)
         outcome.public_failure = self._public_failure(failure, exc)
         outcome.completion = "failed"
         ctx.logger.exception(
@@ -602,6 +603,17 @@ class DeliveryExecutor:
             return
         if config.mode == "terminal" and not outcome.terminal:
             return
+        if outcome.capture_snapshot_error_type is not None:
+            self.logger.error(
+                "failure capture snapshot failed",
+                extra={
+                    "app_name": self.app.name,
+                    "task_name": self.task.name,
+                    "failure_stage": outcome.failure_stage,
+                    "capture_type": outcome.capture_snapshot_error_type,
+                },
+            )
+            return
         try:
             await writer.write(
                 app=self.app.name,
@@ -630,6 +642,22 @@ class DeliveryExecutor:
                     "task_name": self.task.name,
                 },
             )
+
+    def _snapshot_capture_envelope(
+        self,
+        delivery: Delivery,
+        outcome: ExecutionOutcome,
+    ) -> None:
+        if self.app.failure_capture is None or getattr(
+            self.app,
+            "_failure_capture_writer",
+            None,
+        ) is None:
+            return
+        try:
+            outcome.capture_envelope = copy.deepcopy(delivery.envelope)
+        except Exception as exc:
+            outcome.capture_snapshot_error_type = type(exc).__name__
 
 
 __all__ = [

--- a/src/onestep/runtime/runner.py
+++ b/src/onestep/runtime/runner.py
@@ -1,34 +1,27 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
 import copy
 import inspect
 import logging
-import math
-import time
 from typing import TYPE_CHECKING, Any
 
-from onestep.context import TaskContext
-from onestep.envelope import Envelope
 from onestep.events import TaskEvent, TaskEventKind
-from onestep.invoke import invoke_callback
-from onestep.resilience import ConnectorOperationError, connector_retry_delay, is_retryable_connector_error
-from onestep.retry import FailureInfo, FailureKind, RetryDecision, resolve_retry_action
+from onestep.resilience import (
+    ConnectorOperationError,
+    connector_retry_delay,
+    is_retryable_connector_error,
+)
 from onestep.task import TaskSpec
 
 from .executor import DeliveryExecutor
 
 if TYPE_CHECKING:
     from onestep.app import OneStepApp
-    from onestep.connectors.base import Delivery, Sink
-
-
-_INVALID_NOTIFICATION_VALUE = object()
+    from onestep.connectors.base import Delivery
 
 
 class TaskRunner:
-    _SEND_ATTEMPTS = 2
     def __init__(self, app: "OneStepApp", task: TaskSpec) -> None:
         self.app = app
         self.task = task
@@ -244,167 +237,8 @@ class TaskRunner:
         except asyncio.TimeoutError:
             return
 
-    async def _send_to_sink(self, sink, envelope: Envelope) -> None:
-        fallback_s = getattr(sink, "poll_interval_s", 1.0)
-        for attempt in range(self._SEND_ATTEMPTS):
-            try:
-                await sink.send(envelope)
-                self._logger.debug(
-                    "sink send succeeded",
-                    extra={
-                        "sink_name": getattr(sink, "name", sink.__class__.__name__),
-                        "sink_kind": sink.__class__.__name__,
-                        "connector_backend": getattr(getattr(sink, "connector", None), "__class__", type(None)).__name__
-                        if getattr(sink, "connector", None) is not None
-                        else None,
-                        "delivery_attempts": envelope.attempts,
-                    },
-                )
-                return
-            except ConnectorOperationError as exc:
-                if not is_retryable_connector_error(exc) or attempt == self._SEND_ATTEMPTS - 1:
-                    raise
-                delay_s = connector_retry_delay(exc, fallback_s=fallback_s)
-                self._logger.warning(
-                    "sink send degraded; retrying",
-                    extra={
-                        "connector_backend": exc.backend,
-                        "connector_operation": exc.operation.value,
-                        "connector_kind": exc.kind.value,
-                        "connector_retry_delay_s": delay_s,
-                    },
-                    exc_info=exc,
-                )
-                if delay_s <= 0 or self.app.is_stopping:
-                    continue
-                try:
-                    await asyncio.wait_for(self.app.wait_for_shutdown(), timeout=delay_s)
-                except asyncio.TimeoutError:
-                    continue
-                raise
-
     async def _handle_delivery(self, delivery: "Delivery") -> None:
         await self._executor.execute(delivery)
-
-    async def _invoke_handler(self, ctx: TaskContext, delivery: "Delivery"):
-        result = self.task.handler(ctx, delivery.payload)
-        if inspect.isawaitable(result):
-            if self.task.timeout_s is not None:
-                return await asyncio.wait_for(result, timeout=self.task.timeout_s)
-            return await result
-        return result
-
-    async def _select_emit_sinks(self, ctx: TaskContext, payload: Any, result: Any) -> tuple["Sink", ...]:
-        sinks: list["Sink"] = []
-        for route in self.task.emit_routes:
-            if route.predicate is None:
-                sinks.extend(route.then_sinks)
-                continue
-            predicate_result = invoke_callback(route.predicate, ctx, payload, result)
-            if inspect.isawaitable(predicate_result):
-                predicate_result = await predicate_result
-            if predicate_result:
-                sinks.extend(route.then_sinks)
-            else:
-                sinks.extend(route.otherwise_sinks)
-        return tuple(sinks)
-
-    async def _handle_failure(
-        self,
-        ctx: TaskContext,
-        delivery: "Delivery",
-        exc: Exception,
-        kind: FailureKind,
-        *,
-        duration_s: float | None,
-    ) -> None:
-        failure = FailureInfo.from_exception(exc, kind=kind)
-        ctx.logger.exception("task failed", extra={"failure_kind": failure.kind.value})
-        await self._run_task_hooks(
-            self.task.hooks.on_failure,
-            ctx,
-            delivery.payload,
-            failure,
-            suppress_exceptions=True,
-            logger=ctx.logger,
-            message="task failure hook failed",
-        )
-        action = resolve_retry_action(self.task.retry, delivery.envelope, exc, failure)
-        if action.decision is RetryDecision.RETRY:
-            await delivery.retry(delay_s=action.delay_s)
-            await self._emit_event(
-                TaskEventKind.RETRIED,
-                delivery,
-                failure=failure,
-                duration_s=duration_s,
-            )
-            return
-        if self.task.dead_letter_sinks:
-            published = await self._publish_dead_letter(
-                ctx,
-                delivery,
-                failure,
-                duration_s=duration_s,
-            )
-            if not published:
-                return
-        await self._fail_delivery(ctx, delivery, exc)
-        await self._emit_event(
-            TaskEventKind.FAILED,
-            delivery,
-            failure=failure,
-            duration_s=duration_s,
-        )
-
-    async def _publish_dead_letter(
-        self,
-        ctx: TaskContext,
-        delivery: "Delivery",
-        failure: FailureInfo,
-        *,
-        duration_s: float | None,
-    ) -> bool:
-        envelope = Envelope(
-            body={
-                "payload": copy.deepcopy(delivery.envelope.body),
-                "failure": failure.as_dict(),
-            },
-            meta={
-                "app": self.app.name,
-                "task": self.task.name,
-                "source": self.task.source.name if self.task.source is not None else None,
-                "original_meta": copy.deepcopy(delivery.envelope.meta),
-                "original_attempts": delivery.envelope.attempts,
-            },
-            attempts=0,
-        )
-        try:
-            for sink in self.task.dead_letter_sinks:
-                await sink.send(envelope)
-        except Exception:
-            ctx.logger.exception("dead-letter publish failed; retrying original delivery")
-            await delivery.retry()
-            await self._emit_event(
-                TaskEventKind.RETRIED,
-                delivery,
-                failure=failure,
-                duration_s=duration_s,
-            )
-            return False
-        await self._emit_event(
-            TaskEventKind.DEAD_LETTERED,
-            delivery,
-            failure=failure,
-            duration_s=duration_s,
-        )
-        return True
-
-    async def _fail_delivery(self, ctx: TaskContext, delivery: "Delivery", exc: Exception) -> None:
-        try:
-            await delivery.fail(exc)
-        except Exception:
-            ctx.logger.exception("delivery fail action failed; retrying original delivery")
-            await delivery.retry()
 
     async def _drain_inflight(self) -> None:
         if not self._inflight:
@@ -424,36 +258,10 @@ class TaskRunner:
         for delivery in deliveries:
             await self._emit_event(kind, delivery)
 
-    async def _run_task_hooks(
-        self,
-        hooks,
-        *args,
-        suppress_exceptions: bool = False,
-        logger: logging.Logger | None = None,
-        message: str = "task hook failed",
-    ) -> None:
-        for hook in hooks:
-            try:
-                result = invoke_callback(hook, *args)
-                if inspect.isawaitable(result):
-                    await result
-            except Exception:
-                if not suppress_exceptions:
-                    raise
-                active_logger = logger or self._logger
-                active_logger.exception(
-                    message,
-                    extra={"task_hook": getattr(hook, "__name__", hook.__class__.__name__)},
-                )
-
     async def _emit_event(
         self,
         kind: TaskEventKind,
         delivery: "Delivery",
-        *,
-        duration_s: float | None = None,
-        failure: FailureInfo | None = None,
-        event_meta: dict[str, Any] | None = None,
     ) -> None:
         event = TaskEvent(
             kind=kind,
@@ -461,51 +269,6 @@ class TaskRunner:
             task=self.task.name,
             source=self.task.source.name if self.task.source is not None else None,
             attempts=delivery.envelope.attempts,
-            duration_s=duration_s,
-            failure=failure,
-            meta=copy.deepcopy(event_meta) if event_meta is not None else copy.deepcopy(delivery.envelope.meta),
+            meta=copy.deepcopy(delivery.envelope.meta),
         )
         await self.app.emit_event(event)
-
-    def _build_succeeded_event_meta(self, delivery: "Delivery", result: Any) -> dict[str, Any]:
-        event_meta = copy.deepcopy(delivery.envelope.meta)
-        notification = self._extract_notification_payload(result)
-        if notification is not None:
-            event_meta["notification"] = notification
-        return event_meta
-
-    def _extract_notification_payload(self, result: Any) -> dict[str, Any] | None:
-        if not isinstance(result, Mapping):
-            return None
-        notification = result.get("notification")
-        if not isinstance(notification, Mapping):
-            return None
-        sanitized = self._sanitize_notification_value(notification)
-        if not isinstance(sanitized, dict) or not sanitized:
-            return None
-        return sanitized
-
-    def _sanitize_notification_value(self, value: Any) -> Any:
-        if value is None or isinstance(value, (str, bool, int)):
-            return value
-        if isinstance(value, float):
-            return value if math.isfinite(value) else _INVALID_NOTIFICATION_VALUE
-        if isinstance(value, Mapping):
-            sanitized: dict[str, Any] = {}
-            for key, item in value.items():
-                if not isinstance(key, str):
-                    continue
-                clean_item = self._sanitize_notification_value(item)
-                if clean_item is _INVALID_NOTIFICATION_VALUE:
-                    continue
-                sanitized[key] = clean_item
-            return sanitized
-        if isinstance(value, (list, tuple)):
-            sanitized_items = []
-            for item in value:
-                clean_item = self._sanitize_notification_value(item)
-                if clean_item is _INVALID_NOTIFICATION_VALUE:
-                    continue
-                sanitized_items.append(clean_item)
-            return sanitized_items
-        return _INVALID_NOTIFICATION_VALUE

--- a/src/onestep/runtime/runner.py
+++ b/src/onestep/runtime/runner.py
@@ -17,6 +17,8 @@ from onestep.resilience import ConnectorOperationError, connector_retry_delay, i
 from onestep.retry import FailureInfo, FailureKind, RetryDecision, resolve_retry_action
 from onestep.task import TaskSpec
 
+from .executor import DeliveryExecutor
+
 if TYPE_CHECKING:
     from onestep.app import OneStepApp
     from onestep.connectors.base import Delivery, Sink
@@ -35,6 +37,7 @@ class TaskRunner:
         self._drain_parked = False
         self._pause_parked = False
         self._logger = logging.getLogger(f"onestep.{app.name}.{task.name}")
+        self._executor = DeliveryExecutor(app, task)
 
     @property
     def inflight_count(self) -> int:
@@ -281,60 +284,7 @@ class TaskRunner:
                 raise
 
     async def _handle_delivery(self, delivery: "Delivery") -> None:
-        ctx = TaskContext(app=self.app, task=self.task, delivery=delivery)
-        started_at = time.perf_counter()
-        try:
-            await delivery.start_processing()
-            await self._emit_event(TaskEventKind.STARTED, delivery)
-            await self._run_task_hooks(self.task.hooks.before, ctx, delivery.payload)
-            result = await self._invoke_handler(ctx, delivery)
-            await self._run_task_hooks(self.task.hooks.after_success, ctx, delivery.payload, result)
-            if result is not None and self.task.emit_routes:
-                envelope = Envelope(body=result)
-                for sink in await self._select_emit_sinks(ctx, delivery.payload, result):
-                    await self._send_to_sink(sink, envelope)
-            await delivery.ack()
-            event_meta = self._build_succeeded_event_meta(delivery, result)
-            await self._emit_event(
-                TaskEventKind.SUCCEEDED,
-                delivery,
-                duration_s=time.perf_counter() - started_at,
-                event_meta=event_meta,
-            )
-        except asyncio.CancelledError:
-            failure = FailureInfo.from_exception(asyncio.CancelledError(), kind=FailureKind.CANCELLED)
-            ctx.logger.warning("task cancelled", extra={"failure_kind": failure.kind.value})
-            duration_s = time.perf_counter() - started_at
-            await self._emit_event(
-                TaskEventKind.CANCELLED,
-                delivery,
-                failure=failure,
-                duration_s=duration_s,
-            )
-            await delivery.retry()
-            await self._emit_event(
-                TaskEventKind.RETRIED,
-                delivery,
-                failure=failure,
-                duration_s=duration_s,
-            )
-            raise
-        except asyncio.TimeoutError as exc:
-            await self._handle_failure(
-                ctx,
-                delivery,
-                exc,
-                FailureKind.TIMEOUT,
-                duration_s=time.perf_counter() - started_at,
-            )
-        except Exception as exc:
-            await self._handle_failure(
-                ctx,
-                delivery,
-                exc,
-                FailureKind.ERROR,
-                duration_s=time.perf_counter() - started_at,
-            )
+        await self._executor.execute(delivery)
 
     async def _invoke_handler(self, ctx: TaskContext, delivery: "Delivery"):
         result = self.task.handler(ctx, delivery.payload)

--- a/tests/assets/diagnostic_app.py
+++ b/tests/assets/diagnostic_app.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+from onestep import OneStepApp
+from onestep.connectors.base import Sink
+from onestep.envelope import Envelope
+from onestep.task import TaskHooks
+
+
+async def yaml_handler(ctx, payload):
+    return {"value": payload["value"] + 1}
+
+
+app = OneStepApp("diagnostic-success")
+
+
+@app.task()
+async def success(ctx, payload):
+    return {"value": payload["value"] + 1}
+
+
+blocking_app = OneStepApp("diagnostic-blocking")
+
+
+@blocking_app.task()
+def block(ctx, payload):
+    while True:
+        time.sleep(1)
+
+
+hook_blocking_app = OneStepApp("diagnostic-hook-blocking")
+
+
+def blocking_before(ctx, payload):
+    while True:
+        time.sleep(1)
+
+
+@hook_blocking_app.task(hooks=TaskHooks(before=(blocking_before,)))
+async def blocked_by_hook(ctx, payload):
+    return payload
+
+
+async_cancel_app = OneStepApp("diagnostic-async-cancel")
+
+
+@async_cancel_app.task()
+async def wait_forever(ctx, payload):
+    await asyncio.Event().wait()
+
+
+output_app = OneStepApp("diagnostic-output")
+
+
+@output_app.task()
+async def write_output(ctx, payload):
+    print("child stdout marker")
+    print("child stderr marker", file=sys.stderr)
+    return None
+
+
+class BlockingSink(Sink):
+    async def send(self, envelope: Envelope) -> None:
+        marker = os.environ.get("ONESTEP_DIAGNOSTIC_SEND_MARKER")
+        if marker:
+            Path(marker).write_text("entered", encoding="utf-8")
+        while True:
+            time.sleep(1)
+
+
+send_blocking_app = OneStepApp("diagnostic-send-blocking")
+
+
+@send_blocking_app.task(emit=BlockingSink("blocking"))
+async def block_during_send(ctx, payload):
+    return {"sent": True}
+
+
+exit_app = OneStepApp("diagnostic-exit")
+
+
+@exit_app.task()
+async def exit_without_final(ctx, payload):
+    os._exit(17)

--- a/tests/assets/diagnostic_replay_import.py
+++ b/tests/assets/diagnostic_replay_import.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from onestep import OneStepApp
+
+marker = os.environ.get("ONESTEP_REPLAY_IMPORT_MARKER")
+if marker:
+    with Path(marker).open("a", encoding="utf-8") as handle:
+        handle.write("imported\n")
+
+delay_s = float(os.environ.get("ONESTEP_REPLAY_IMPORT_DELAY_S", "0"))
+if delay_s:
+    time.sleep(delay_s)
+
+app = OneStepApp("diagnostic-replay-import")
+
+
+@app.task()
+async def replay(ctx, payload):
+    return payload

--- a/tests/contract/test_runtime_contract.py
+++ b/tests/contract/test_runtime_contract.py
@@ -27,7 +27,8 @@ from onestep import (
 )
 from onestep.connectors.base import Delivery, Sink, Source
 from onestep.envelope import Envelope
-from onestep.task import EmitRoute
+from onestep.runtime import TaskRunner
+from onestep.task import EmitRoute, TaskHooks
 
 
 class _StubDelivery(Delivery):
@@ -43,6 +44,110 @@ class _StubDelivery(Delivery):
 
     async def fail(self, exc: Exception | None = None) -> None:
         return None
+
+
+def test_single_delivery_success_order_is_stable_contract() -> None:
+    class RecordingDelivery(Delivery):
+        def __init__(self, steps: list[str]) -> None:
+            super().__init__(Envelope(body={"value": 2}, meta={"trace": "t-1"}))
+            self.steps = steps
+
+        async def start_processing(self) -> None:
+            self.steps.append("start_processing")
+
+        async def ack(self) -> None:
+            self.steps.append("ack")
+
+        async def retry(self, *, delay_s: float | None = None) -> None:
+            self.steps.append("retry")
+
+        async def fail(self, exc: Exception | None = None) -> None:
+            self.steps.append("fail")
+
+    class RecordingSink(Sink):
+        def __init__(self, steps: list[str]) -> None:
+            super().__init__("recording")
+            self.steps = steps
+
+        async def send(self, envelope: Envelope) -> None:
+            assert envelope.body == {"value": 4}
+            self.steps.append("sink")
+
+    async def scenario() -> None:
+        steps: list[str] = []
+        app = OneStepApp("execution-order")
+        sink = RecordingSink(steps)
+
+        @app.on_event
+        def event(event):
+            steps.append(f"event:{event.kind.value}")
+
+        async def before(ctx, payload):
+            steps.append("before")
+
+        async def after(ctx, payload, result):
+            steps.append("after_success")
+
+        @app.task(emit=sink, hooks=TaskHooks(before=(before,), after_success=(after,)))
+        async def consume(ctx, payload):
+            steps.append("handler")
+            return {"value": payload["value"] * 2}
+
+        await TaskRunner(app, app.tasks[0])._handle_delivery(RecordingDelivery(steps))
+
+        assert steps == [
+            "start_processing",
+            "event:started",
+            "before",
+            "handler",
+            "after_success",
+            "sink",
+            "ack",
+            "event:succeeded",
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_fail_action_fallback_order_is_stable_contract() -> None:
+    class FallbackDelivery(Delivery):
+        def __init__(self, actions: list[str]) -> None:
+            super().__init__(Envelope(body={"value": 1}))
+            self.actions = actions
+
+        async def ack(self) -> None:
+            raise AssertionError("ack must not be called")
+
+        async def retry(self, *, delay_s: float | None = None) -> None:
+            self.actions.append("retry")
+
+        async def fail(self, exc: Exception | None = None) -> None:
+            self.actions.append("fail")
+            raise RuntimeError("source fail unavailable")
+
+    class RecordingDeadLetterSink(Sink):
+        def __init__(self) -> None:
+            super().__init__("dead")
+
+        async def send(self, envelope: Envelope) -> None:
+            return None
+
+    async def scenario() -> None:
+        actions: list[str] = []
+        events: list[str] = []
+        app = OneStepApp("fallback-order")
+        app.on_event(lambda event: events.append(event.kind.value))
+
+        @app.task(retry=NoRetry(), dead_letter=RecordingDeadLetterSink())
+        async def consume(ctx, payload):
+            raise ValueError("invalid")
+
+        await TaskRunner(app, app.tasks[0])._handle_delivery(FallbackDelivery(actions))
+
+        assert actions == ["fail", "retry"]
+        assert events == ["started", "dead_lettered", "failed"]
+
+    asyncio.run(scenario())
 
 
 class _FlakySource(Source):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import sys
+import time
 import types
 from contextlib import contextmanager
 from typing import Optional
@@ -11,7 +12,14 @@ import pytest
 
 import onestep.cli as cli_module
 import onestep.config as config_module
-from onestep import MemoryQueue, OneStepApp, StructuredEventLogger, load_app_config
+from onestep import (
+    FailureCaptureConfig,
+    MemoryQueue,
+    OneStepApp,
+    StructuredEventLogger,
+    load_app_config,
+)
+from onestep.capture.writer import FailureCaptureWriter
 from onestep.cli import (
     _connectivity_exit_code,
     _diagnostic_exit_code,
@@ -23,6 +31,8 @@ from onestep.diagnostics.models import (
     ConnectivityResourceResult,
     DiagnosticReport,
 )
+from onestep.envelope import Envelope
+from onestep.retry import FailureInfo, FailureKind
 
 
 @contextmanager
@@ -337,25 +347,37 @@ def test_task_run_accepts_any_single_json_value(
     assert "handler and task hooks" in captured.err
 
 
-def test_task_replay_validates_identity_and_passes_capture_path(
+def test_task_replay_defers_validation_and_passes_capture_path(
     tmp_path,
     monkeypatch,
     capsys,
 ) -> None:
     capture_path = tmp_path / "capture.json"
     capture_path.write_text("{}", encoding="utf-8")
-    app = OneStepApp("cli-diagnostic")
     observed = {}
-    monkeypatch.setattr(cli_module, "load_diagnostic_target", lambda target: app)
 
-    def validate_capture(path, *, expected_app, expected_task):
-        observed["identity"] = (path, expected_app, expected_task)
+    def reject_parent_target_load(target):
+        raise AssertionError("replay target must load only in the supervised child")
+
+    def reject_parent_capture_load(*args, **kwargs):
+        raise AssertionError("replay capture must load only in the supervised child")
 
     def supervise(request, *, timeout_s):
         observed["request"] = request
         return make_diagnostic_report()
 
-    monkeypatch.setattr(cli_module, "load_capture", validate_capture)
+    monkeypatch.setattr(
+        cli_module,
+        "load_diagnostic_target",
+        reject_parent_target_load,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "load_capture",
+        reject_parent_capture_load,
+        raising=False,
+    )
     monkeypatch.setattr(cli_module, "supervise_diagnostic", supervise)
     assert (
         main(
@@ -372,17 +394,12 @@ def test_task_replay_validates_identity_and_passes_capture_path(
         == 0
     )
     captured = capsys.readouterr()
-    assert observed["identity"] == (
-        str(capture_path),
-        "cli-diagnostic",
-        "sync",
-    )
     assert observed["request"].capture_path == str(capture_path)
     assert "Completion: succeeded" in captured.out
     assert "Warning:" in captured.out
 
 
-def test_task_replay_json_keeps_parent_target_output_off_stdout(
+def test_task_replay_json_does_not_load_target_in_parent(
     tmp_path,
     monkeypatch,
     capsys,
@@ -391,11 +408,14 @@ def test_task_replay_json_keeps_parent_target_output_off_stdout(
     capture_path.write_text("{}", encoding="utf-8")
 
     def load_target(target):
-        print("target import output")
-        return OneStepApp("cli-diagnostic")
+        raise AssertionError("target must load only in the supervised child")
 
-    monkeypatch.setattr(cli_module, "load_diagnostic_target", load_target)
-    monkeypatch.setattr(cli_module, "load_capture", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        cli_module,
+        "load_diagnostic_target",
+        load_target,
+        raising=False,
+    )
     monkeypatch.setattr(
         cli_module,
         "supervise_diagnostic",
@@ -418,7 +438,98 @@ def test_task_replay_json_keeps_parent_target_output_off_stdout(
     )
     captured = capsys.readouterr()
     assert json.loads(captured.out)["completion"] == "succeeded"
-    assert "target import output" in captured.err
+    assert "target import output" not in captured.err
+
+
+def test_task_replay_imports_target_once_and_bounds_parent_wall_time(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    capture_path = asyncio.run(
+        FailureCaptureWriter(
+            FailureCaptureConfig(directory=tmp_path / "captures")
+        ).write(
+            app="diagnostic-replay-import",
+            task="replay",
+            stage="handler",
+            terminal=True,
+            failure=FailureInfo(
+                kind=FailureKind.ERROR,
+                exception_type="ValueError",
+                message="expected",
+            ),
+            envelope=Envelope(body={"value": 1}),
+        )
+    )
+    marker = tmp_path / "imports.log"
+    monkeypatch.setenv("ONESTEP_REPLAY_IMPORT_MARKER", str(marker))
+    monkeypatch.setenv("ONESTEP_REPLAY_IMPORT_DELAY_S", "0.4")
+
+    started = time.monotonic()
+    exit_code = main(
+        [
+            "task",
+            "replay",
+            "tests.assets.diagnostic_replay_import:app",
+            "--task",
+            "replay",
+            "--envelope",
+            str(capture_path),
+            "--timeout",
+            "0.05",
+            "--json",
+        ]
+    )
+    elapsed = time.monotonic() - started
+
+    document = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert document["completion"] == "timed_out"
+    assert elapsed < 0.7
+    assert marker.read_text(encoding="utf-8").splitlines() == ["imported"]
+
+
+def test_task_replay_validation_failure_is_reported_from_child(
+    tmp_path,
+    capsys,
+) -> None:
+    capture_path = asyncio.run(
+        FailureCaptureWriter(
+            FailureCaptureConfig(directory=tmp_path / "captures")
+        ).write(
+            app="wrong-app",
+            task="success",
+            stage="handler",
+            terminal=True,
+            failure=FailureInfo(
+                kind=FailureKind.ERROR,
+                exception_type="ValueError",
+                message="expected",
+            ),
+            envelope=Envelope(body={"value": 1}),
+        )
+    )
+
+    exit_code = main(
+        [
+            "task",
+            "replay",
+            "tests.assets.diagnostic_app:app",
+            "--task",
+            "success",
+            "--envelope",
+            str(capture_path),
+            "--timeout",
+            "2",
+            "--json",
+        ]
+    )
+
+    document = json.loads(capsys.readouterr().out)
+    assert exit_code == 2
+    assert document["completion"] == "validation_failed"
+    assert document["failure_stage"] == "child_start"
 
 
 @pytest.mark.parametrize(
@@ -428,6 +539,7 @@ def test_task_replay_json_keeps_parent_target_output_off_stdout(
         ("failed", 1),
         ("timed_out", 1),
         ("child_failed", 1),
+        ("validation_failed", 2),
     ],
 )
 def test_task_exit_codes(completion: str, expected: int) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -382,6 +382,45 @@ def test_task_replay_validates_identity_and_passes_capture_path(
     assert "Warning:" in captured.out
 
 
+def test_task_replay_json_keeps_parent_target_output_off_stdout(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    capture_path = tmp_path / "capture.json"
+    capture_path.write_text("{}", encoding="utf-8")
+
+    def load_target(target):
+        print("target import output")
+        return OneStepApp("cli-diagnostic")
+
+    monkeypatch.setattr(cli_module, "load_diagnostic_target", load_target)
+    monkeypatch.setattr(cli_module, "load_capture", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        cli_module,
+        "supervise_diagnostic",
+        lambda request, *, timeout_s: make_diagnostic_report(),
+    )
+    assert (
+        main(
+            [
+                "task",
+                "replay",
+                "pkg.jobs:app",
+                "--task",
+                "sync",
+                "--envelope",
+                str(capture_path),
+                "--json",
+            ]
+        )
+        == 0
+    )
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["completion"] == "succeeded"
+    assert "target import output" in captured.err
+
+
 @pytest.mark.parametrize(
     "completion,expected",
     [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,9 +9,20 @@ from typing import Optional
 
 import pytest
 
+import onestep.cli as cli_module
 import onestep.config as config_module
 from onestep import MemoryQueue, OneStepApp, StructuredEventLogger, load_app_config
-from onestep.cli import main, parse_args
+from onestep.cli import (
+    _connectivity_exit_code,
+    _diagnostic_exit_code,
+    main,
+    parse_args,
+)
+from onestep.diagnostics.models import (
+    ConnectivityReport,
+    ConnectivityResourceResult,
+    DiagnosticReport,
+)
 
 
 @contextmanager
@@ -60,6 +71,28 @@ def isolated_logging():
 def clear_modules(monkeypatch, *names: str) -> None:
     for name in names:
         monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def make_diagnostic_report(*, completion: str = "succeeded") -> DiagnosticReport:
+    return DiagnosticReport(
+        operation="run",
+        app="cli-diagnostic",
+        task="sync",
+        mode="dry-run",
+        completion=completion,
+        attempts=0,
+        selected_sinks=("result",),
+        delivery_action="would_ack",
+        delivery_action_basis="predicted",
+        dead_letter={"attempted": False, "published": None},
+        events=(),
+        duration_s=0.01,
+        last_checkpoint={
+            "phase": "ack",
+            "transition": "completed",
+            "elapsed_s": 0.01,
+        },
+    )
 
 
 def install_fake_control_plane_reporter(monkeypatch, created: list[object]) -> None:
@@ -201,6 +234,258 @@ def test_cli_run_enables_task_events_by_default() -> None:
 
     assert args.log_level is None
     assert args.task_events is True
+
+
+def test_task_command_bypasses_legacy_run_shorthand() -> None:
+    args = parse_args(
+        [
+            "task",
+            "run",
+            "pkg.jobs:app",
+            "--task",
+            "sync",
+            "--input",
+            "input.json",
+        ]
+    )
+    assert (args.command, args.task_command, args.target) == (
+        "task",
+        "run",
+        "pkg.jobs:app",
+    )
+    assert args.timeout == 60.0
+    assert args.send is False
+
+
+def test_task_replay_parser_defaults_and_legacy_shorthand() -> None:
+    args = parse_args(
+        [
+            "task",
+            "replay",
+            "pkg.jobs:app",
+            "--task",
+            "sync",
+            "--envelope",
+            "capture.json",
+        ]
+    )
+    assert args.timeout == 60.0
+    assert args.send is False
+    assert parse_args(["run", "task"]).target == "task"
+    shorthand = parse_args(["pkg.jobs:app"])
+    assert (shorthand.command, shorthand.target) == ("run", "pkg.jobs:app")
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "nan", "inf"])
+def test_task_parser_rejects_non_positive_or_non_finite_timeout(value: str) -> None:
+    with pytest.raises(SystemExit) as raised:
+        parse_args(
+            [
+                "task",
+                "run",
+                "pkg.jobs:app",
+                "--task",
+                "sync",
+                "--input",
+                "input.json",
+                "--timeout",
+                value,
+            ]
+        )
+    assert raised.value.code == 2
+
+
+def test_check_connect_parser_defaults() -> None:
+    args = parse_args(["check", "pkg.jobs:app", "--connect"])
+    assert args.connect is True
+    assert args.connect_timeout == 10.0
+
+
+def test_task_run_accepts_any_single_json_value(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    input_path = tmp_path / "input.json"
+    input_path.write_text("42", encoding="utf-8")
+    observed = {}
+
+    def supervise(request, *, timeout_s):
+        observed["request"] = request
+        observed["timeout_s"] = timeout_s
+        return make_diagnostic_report()
+
+    monkeypatch.setattr(cli_module, "supervise_diagnostic", supervise)
+    exit_code = main(
+        [
+            "task",
+            "run",
+            "pkg.jobs:app",
+            "--task",
+            "sync",
+            "--input",
+            str(input_path),
+            "--json",
+        ]
+    )
+    captured = capsys.readouterr()
+    document = json.loads(captured.out)
+    assert exit_code == 0
+    assert document["schema"] == "onestep/diagnostic-result"
+    assert observed["request"].envelope.body == 42
+    assert observed["timeout_s"] == 60.0
+    assert "handler and task hooks" in captured.err
+
+
+def test_task_replay_validates_identity_and_passes_capture_path(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    capture_path = tmp_path / "capture.json"
+    capture_path.write_text("{}", encoding="utf-8")
+    app = OneStepApp("cli-diagnostic")
+    observed = {}
+    monkeypatch.setattr(cli_module, "load_diagnostic_target", lambda target: app)
+
+    def validate_capture(path, *, expected_app, expected_task):
+        observed["identity"] = (path, expected_app, expected_task)
+
+    def supervise(request, *, timeout_s):
+        observed["request"] = request
+        return make_diagnostic_report()
+
+    monkeypatch.setattr(cli_module, "load_capture", validate_capture)
+    monkeypatch.setattr(cli_module, "supervise_diagnostic", supervise)
+    assert (
+        main(
+            [
+                "task",
+                "replay",
+                "pkg.jobs:app",
+                "--task",
+                "sync",
+                "--envelope",
+                str(capture_path),
+            ]
+        )
+        == 0
+    )
+    captured = capsys.readouterr()
+    assert observed["identity"] == (
+        str(capture_path),
+        "cli-diagnostic",
+        "sync",
+    )
+    assert observed["request"].capture_path == str(capture_path)
+    assert "Completion: succeeded" in captured.out
+    assert "Warning:" in captured.out
+
+
+@pytest.mark.parametrize(
+    "completion,expected",
+    [
+        ("succeeded", 0),
+        ("failed", 1),
+        ("timed_out", 1),
+        ("child_failed", 1),
+    ],
+)
+def test_task_exit_codes(completion: str, expected: int) -> None:
+    assert _diagnostic_exit_code(
+        make_diagnostic_report(completion=completion)
+    ) == expected
+
+
+@pytest.mark.parametrize("contents", ["{", ""])
+def test_task_run_invalid_json_returns_validation_error(
+    contents,
+    tmp_path,
+    capsys,
+) -> None:
+    input_path = tmp_path / "input.json"
+    input_path.write_text(contents, encoding="utf-8")
+    assert (
+        main(
+            [
+                "task",
+                "run",
+                "pkg.jobs:app",
+                "--task",
+                "sync",
+                "--input",
+                str(input_path),
+            ]
+        )
+        == 2
+    )
+    assert "task diagnostic failed" in capsys.readouterr().err
+
+
+def test_task_run_unreadable_input_returns_validation_error(tmp_path, capsys) -> None:
+    missing = tmp_path / "missing.json"
+    assert (
+        main(
+            [
+                "task",
+                "run",
+                "pkg.jobs:app",
+                "--task",
+                "sync",
+                "--input",
+                str(missing),
+            ]
+        )
+        == 2
+    )
+    assert "task diagnostic failed" in capsys.readouterr().err
+
+
+def test_check_connect_renders_all_resources_and_exit_code(
+    monkeypatch,
+    capsys,
+) -> None:
+    app = OneStepApp("connect-cli")
+    report = ConnectivityReport(
+        app="connect-cli",
+        resources=(
+            ConnectivityResourceResult(
+                aliases=("queue",),
+                roles=("source",),
+                type_name="example.Queue",
+                probe_kind="lifecycle",
+                status="failed",
+                open={"status": "connected"},
+                close={"status": "failed", "exception_type": "RuntimeError"},
+            ),
+        ),
+        ok=False,
+    )
+
+    async def check(app_value, *, timeout_s):
+        assert app_value is app
+        assert timeout_s == 2.0
+        return report
+
+    monkeypatch.setattr(cli_module, "check_connectivity", check)
+    with registered_module("testsupport_connect_cli", app=app):
+        exit_code = main(
+            [
+                "check",
+                "testsupport_connect_cli:app",
+                "--connect",
+                "--connect-timeout",
+                "2",
+            ]
+        )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "queue roles=source" in captured.out
+    assert "open: status=connected" in captured.out
+    assert "close: status=failed exception_type=RuntimeError" in captured.out
+    assert _connectivity_exit_code(
+        ConnectivityReport(app="ok", resources=(), ok=True)
+    ) == 0
 
 
 def test_cli_run_configures_info_stdout_logging_and_task_events(capsys) -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from onestep import MaxAttempts, NoRetry, OneStepApp
+from onestep.connectors.base import Delivery, Sink, Source
+from onestep.diagnostics.connectivity import check_connectivity
+from onestep.diagnostics.models import DiagnosticReport
+from onestep.diagnostics.runner import DiagnosticRunner
+from onestep.envelope import Envelope
+from onestep.events import TaskEventKind
+from onestep.task import EmitRoute, TaskHooks
+
+
+class RecordingSink(Sink):
+    def __init__(
+        self,
+        name: str,
+        calls: list[str],
+        *,
+        broken: bool = False,
+    ) -> None:
+        super().__init__(name)
+        self.calls = calls
+        self.broken = broken
+
+    async def open(self) -> None:
+        self.calls.append(f"{self.name}:open")
+
+    async def send(self, envelope: Envelope) -> None:
+        self.calls.append(f"{self.name}:send")
+        if self.broken:
+            raise RuntimeError("secret sink details")
+
+    async def close(self) -> None:
+        self.calls.append(f"{self.name}:close")
+
+
+def test_diagnostic_dry_run_executes_handler_hooks_and_routes_without_sink_io() -> None:
+    async def scenario() -> None:
+        calls: list[str] = []
+        app = OneStepApp("diagnostic")
+        sink = RecordingSink("selected", calls)
+
+        async def before(ctx, payload):
+            calls.append("before")
+
+        async def after(ctx, payload, result):
+            calls.append("after")
+
+        async def predicate(ctx, payload, result):
+            calls.append("route")
+            return True
+
+        @app.task(
+            emit=EmitRoute(predicate=predicate, then_sinks=(sink,)),
+            hooks=TaskHooks(before=(before,), after_success=(after,)),
+        )
+        async def consume(ctx, payload):
+            calls.append("handler")
+            return {"output": payload["input"]}
+
+        report = await DiagnosticRunner(app).run(
+            task_name="consume",
+            envelope=Envelope(body={"input": 1}),
+            send=False,
+        )
+
+        assert calls == ["before", "handler", "after", "route"]
+        assert report.completion == "succeeded"
+        assert report.mode == "dry-run"
+        assert report.selected_sinks == ("selected",)
+        assert report.delivery_action == "would_ack"
+        assert report.delivery_action_basis == "predicted"
+        assert report.side_effect_outcome == "not_attempted"
+        assert report.outputs[0]["envelope"]["body"] == {"output": 1}
+        assert [event.kind for event in report.events] == [
+            TaskEventKind.STARTED,
+            TaskEventKind.SUCCEEDED,
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_diagnostic_events_do_not_reach_app_event_handlers() -> None:
+    async def scenario() -> None:
+        app = OneStepApp("local-events")
+        external_events = []
+        app.on_event(external_events.append)
+
+        @app.task()
+        async def consume(ctx, payload):
+            return None
+
+        report = await DiagnosticRunner(app).run(
+            task_name="consume",
+            envelope=Envelope(body={"id": 1}),
+            send=False,
+        )
+        assert external_events == []
+        assert [event.kind for event in report.events] == [
+            TaskEventKind.STARTED,
+            TaskEventKind.SUCCEEDED,
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_diagnostic_send_opens_and_reverse_closes_selected_sinks() -> None:
+    async def scenario() -> None:
+        calls: list[str] = []
+        first = RecordingSink("first", calls)
+        second = RecordingSink("second", calls)
+        app = OneStepApp("send")
+
+        @app.task(emit=(first, second))
+        async def consume(ctx, payload):
+            return {"ok": True}
+
+        report = await DiagnosticRunner(app).run(
+            task_name="consume",
+            envelope=Envelope(body={"id": 1}),
+            send=True,
+        )
+        assert calls == [
+            "first:open",
+            "first:send",
+            "second:open",
+            "second:send",
+            "second:close",
+            "first:close",
+        ]
+        assert report.side_effect_outcome == "completed"
+        assert report.cleanup == "complete"
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "retry,dead_letter,expected",
+    [
+        (MaxAttempts(max_attempts=3, delay_s=30), None, "would_retry"),
+        (NoRetry(), "dead", "would_dead_letter"),
+        (NoRetry(), None, "would_fail"),
+    ],
+)
+def test_diagnostic_runs_exactly_one_failed_attempt(retry, dead_letter, expected) -> None:
+    async def scenario() -> None:
+        calls = 0
+        sink_calls: list[str] = []
+        app = OneStepApp("failed-diagnostic")
+        sink = RecordingSink("dead", sink_calls) if dead_letter else None
+
+        @app.task(retry=retry, dead_letter=sink)
+        async def consume(ctx, payload):
+            nonlocal calls
+            calls += 1
+            raise ValueError("boom")
+
+        report = await DiagnosticRunner(app).run(
+            task_name="consume",
+            envelope=Envelope(body={"id": 1}, attempts=0),
+            send=False,
+        )
+        assert calls == 1
+        assert sink_calls == []
+        assert report.delivery_action == expected
+        assert report.delivery_action_basis == "predicted"
+        assert report.failure == {
+            "failure_kind": "error",
+            "exception_type": "ValueError",
+        }
+        assert "boom" not in str(report.to_dict())
+        if expected == "would_dead_letter":
+            assert report.dead_letter == {"attempted": False, "published": None}
+
+    asyncio.run(scenario())
+
+
+def test_diagnostic_send_dead_letter_observes_success_and_failure() -> None:
+    async def run_case(*, broken: bool):
+        calls: list[str] = []
+        app = OneStepApp("dead-send")
+
+        @app.task(retry=NoRetry(), dead_letter=RecordingSink("dead", calls, broken=broken))
+        async def consume(ctx, payload):
+            raise ValueError("boom")
+
+        report = await DiagnosticRunner(app).run(
+            task_name="consume",
+            envelope=Envelope(body={"id": 1}),
+            send=True,
+        )
+        return calls, report
+
+    calls, success = asyncio.run(run_case(broken=False))
+    assert calls == ["dead:open", "dead:send", "dead:close"]
+    assert success.delivery_action == "would_dead_letter"
+    assert success.dead_letter == {"attempted": True, "published": True}
+
+    calls, failure = asyncio.run(run_case(broken=True))
+    assert calls == ["dead:open", "dead:send", "dead:close"]
+    assert failure.delivery_action == "would_retry"
+    assert failure.dead_letter == {"attempted": True, "published": False}
+
+
+def test_diagnostic_report_json_round_trip_hides_failure_message() -> None:
+    async def scenario() -> None:
+        app = OneStepApp("roundtrip")
+
+        @app.task()
+        async def consume(ctx, payload):
+            raise RuntimeError("password=secret")
+
+        report = await DiagnosticRunner(app).run(
+            task_name="consume",
+            envelope=Envelope(body={"id": 1}),
+            send=False,
+        )
+        encoded = report.to_dict()
+        assert "password=secret" not in str(encoded)
+        assert DiagnosticReport.from_dict(encoded).to_dict() == encoded
+
+    asyncio.run(scenario())
+
+
+class _SharedResource(Source, Sink):
+    def __init__(self, calls: list[str]) -> None:
+        Source.__init__(self, "shared")
+        Sink.__init__(self, "shared")
+        self.calls = calls
+
+    async def open(self) -> None:
+        self.calls.append("open")
+
+    async def close(self) -> None:
+        self.calls.append("close")
+
+    async def fetch(self, limit: int) -> list[Delivery]:
+        raise AssertionError("fetch must not run")
+
+    async def send(self, envelope: Envelope) -> None:
+        raise AssertionError("send must not run")
+
+
+class _NoProbeStore:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def load(self, key: str):
+        self.calls.append("load")
+        raise AssertionError("load must not run")
+
+    async def save(self, key: str, value) -> None:
+        self.calls.append("save")
+        raise AssertionError("save must not run")
+
+    async def delete(self, key: str) -> None:
+        self.calls.append("delete")
+        raise AssertionError("delete must not run")
+
+
+def test_connectivity_deduplicates_aliases_and_never_probes_store_methods() -> None:
+    async def scenario() -> None:
+        calls: list[str] = []
+        shared = _SharedResource(calls)
+        store = _NoProbeStore()
+        app = OneStepApp("connectivity", state=store)
+        app.register_resource("queue", shared)
+
+        @app.task(source=shared, emit=shared)
+        async def consume(ctx, payload):
+            return payload
+
+        report = await check_connectivity(app, timeout_s=0.1)
+        shared_result = next(item for item in report.resources if "queue" in item.aliases)
+        store_result = next(item for item in report.resources if "app.state" in item.aliases)
+        assert shared_result.aliases == (
+            "queue",
+            "consume.source",
+            "consume.emit[0]",
+        )
+        assert shared_result.roles == ("named", "source", "sink")
+        assert shared_result.status == "connected"
+        assert store_result.probe_kind == "none"
+        assert store_result.status == "not_probeable"
+        assert store.calls == []
+        assert calls == ["open", "close"]
+        assert report.ok is True
+
+    asyncio.run(scenario())
+
+
+class _LifecycleResource:
+    def __init__(
+        self,
+        name: str,
+        calls: list[str],
+        *,
+        open_mode: str = "ok",
+        close_broken: bool = False,
+    ) -> None:
+        self.name = name
+        self.calls = calls
+        self.open_mode = open_mode
+        self.close_broken = close_broken
+
+    async def open(self) -> None:
+        self.calls.append(f"{self.name}:open")
+        if self.open_mode == "broken":
+            raise RuntimeError("dsn=secret")
+        if self.open_mode == "slow":
+            await asyncio.sleep(1)
+
+    async def close(self) -> None:
+        self.calls.append(f"{self.name}:close")
+        if self.close_broken:
+            raise RuntimeError("close secret")
+
+
+def test_connectivity_continues_after_failures_and_attempts_cleanup() -> None:
+    async def scenario() -> None:
+        calls: list[str] = []
+        app = OneStepApp("partial")
+        app.register_resource("good", _LifecycleResource("good", calls))
+        app.register_resource(
+            "broken",
+            _LifecycleResource("broken", calls, open_mode="broken"),
+        )
+        app.register_resource(
+            "slow",
+            _LifecycleResource("slow", calls, open_mode="slow"),
+        )
+        report = await check_connectivity(app, timeout_s=0.01)
+        lifecycle = [item for item in report.resources if item.probe_kind == "lifecycle"]
+        assert calls == [
+            "good:open",
+            "good:close",
+            "broken:open",
+            "broken:close",
+            "slow:open",
+            "slow:close",
+        ]
+        assert [item.status for item in lifecycle] == [
+            "connected",
+            "failed",
+            "failed",
+        ]
+        assert lifecycle[1].open == {
+            "status": "failed",
+            "exception_type": "RuntimeError",
+        }
+        assert "secret" not in str(report.to_dict())
+        assert report.ok is False
+
+    asyncio.run(scenario())
+
+
+def test_connectivity_only_not_probeable_is_success_with_warning() -> None:
+    app = OneStepApp("stores-only", state=_NoProbeStore())
+    report = asyncio.run(check_connectivity(app, timeout_s=0.1))
+    assert report.ok is True
+    assert "no connection was verified" in report.warnings[0]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
 import asyncio
+import time
+from copy import deepcopy
+from pathlib import Path
 
 import pytest
 
 from onestep import MaxAttempts, NoRetry, OneStepApp
 from onestep.connectors.base import Delivery, Sink, Source
 from onestep.diagnostics.connectivity import check_connectivity
-from onestep.diagnostics.models import DiagnosticReport
+from onestep.diagnostics.ipc import (
+    FrameValidator,
+    IPCProtocolError,
+    decode_frame,
+    encode_frame,
+)
+from onestep.diagnostics.models import DiagnosticReport, DiagnosticRequest
 from onestep.diagnostics.runner import DiagnosticRunner
+from onestep.diagnostics.supervisor import supervise_diagnostic
 from onestep.envelope import Envelope
 from onestep.events import TaskEventKind
 from onestep.task import EmitRoute, TaskHooks
@@ -363,3 +373,229 @@ def test_connectivity_only_not_probeable_is_success_with_warning() -> None:
     report = asyncio.run(check_connectivity(app, timeout_s=0.1))
     assert report.ok is True
     assert "no connection was verified" in report.warnings[0]
+
+
+def test_ipc_rejects_non_monotonic_and_unknown_frames() -> None:
+    validator = FrameValidator(direction="status")
+    validator.accept(
+        decode_frame(
+            encode_frame(
+                "checkpoint",
+                sequence=1,
+                payload={
+                    "phase": "child_start",
+                    "transition": "entered",
+                    "elapsed_s": 0.0,
+                },
+            )
+        )
+    )
+    with pytest.raises(IPCProtocolError, match="sequence"):
+        validator.accept(
+            decode_frame(
+                encode_frame(
+                    "checkpoint",
+                    sequence=1,
+                    payload={
+                        "phase": "handler",
+                        "transition": "entered",
+                        "elapsed_s": 0.1,
+                    },
+                )
+            )
+        )
+    with pytest.raises(IPCProtocolError, match="kind"):
+        decode_frame(
+            b'{"schema":"onestep/diagnostic-ipc","version":1,'
+            b'"kind":"other","sequence":2,"payload":{}}'
+        )
+
+
+@pytest.mark.parametrize(
+    "data,match",
+    [
+        (b"\xff", "malformed"),
+        (b"{", "malformed"),
+        (
+            b'{"schema":"wrong","version":1,"kind":"cancel",'
+            b'"sequence":1,"payload":{}}',
+            "schema",
+        ),
+    ],
+)
+def test_ipc_rejects_malformed_frames(data: bytes, match: str) -> None:
+    with pytest.raises(IPCProtocolError, match=match):
+        decode_frame(data)
+
+
+def test_ipc_rejects_invalid_checkpoint_and_final_payloads() -> None:
+    checkpoint_validator = FrameValidator(direction="status")
+    with pytest.raises(IPCProtocolError, match="fields"):
+        checkpoint_validator.accept(
+            decode_frame(
+                encode_frame(
+                    "checkpoint",
+                    sequence=1,
+                    payload={
+                        "phase": "handler",
+                        "transition": "entered",
+                        "elapsed_s": 0.0,
+                        "secret": "must not cross IPC",
+                    },
+                )
+            )
+        )
+    with pytest.raises(IPCProtocolError, match="diagnostic result"):
+        checkpoint_validator.accept(
+            decode_frame(encode_frame("final", sequence=1, payload={}))
+        )
+    frame = decode_frame(
+        encode_frame(
+            "checkpoint",
+            sequence=True,
+            payload={
+                "phase": "handler",
+                "transition": "entered",
+                "elapsed_s": 0.0,
+            },
+        )
+    )
+    with pytest.raises(IPCProtocolError, match="sequence"):
+        checkpoint_validator.accept(frame)
+
+
+def _run_request(target: str, task: str, *, send: bool = False) -> DiagnosticRequest:
+    return DiagnosticRequest(
+        operation="run",
+        target=target,
+        task=task,
+        envelope=Envelope(body={"value": 1}),
+        send=send,
+    )
+
+
+def test_spawned_python_and_yaml_targets_have_matching_results(
+    tmp_path: Path,
+) -> None:
+    yaml_target = tmp_path / "worker.yaml"
+    yaml_target.write_text(
+        """apiVersion: onestep/v1alpha1
+kind: App
+app:
+  name: diagnostic-yaml
+tasks:
+  - name: success
+    handler:
+      ref: tests.assets.diagnostic_app:yaml_handler
+""",
+        encoding="utf-8",
+    )
+    python_report = supervise_diagnostic(
+        _run_request("tests.assets.diagnostic_app:app", "success"),
+        timeout_s=3,
+        grace_s=0.2,
+    )
+    yaml_report = supervise_diagnostic(
+        _run_request(str(yaml_target), "success"),
+        timeout_s=3,
+        grace_s=0.2,
+    )
+    assert python_report.completion == yaml_report.completion == "succeeded"
+    assert python_report.selected_sinks == yaml_report.selected_sinks == ()
+    assert python_report.delivery_action == yaml_report.delivery_action == "would_ack"
+
+
+@pytest.mark.parametrize(
+    "target,phase",
+    [
+        ("tests.assets.diagnostic_app:blocking_app", "handler"),
+        ("tests.assets.diagnostic_app:hook_blocking_app", "before_hook"),
+        ("tests.assets.diagnostic_app:async_cancel_app", "handler"),
+    ],
+)
+def test_supervisor_bounds_blocking_diagnostics(target: str, phase: str) -> None:
+    task = {
+        "tests.assets.diagnostic_app:blocking_app": "block",
+        "tests.assets.diagnostic_app:hook_blocking_app": "blocked_by_hook",
+        "tests.assets.diagnostic_app:async_cancel_app": "wait_forever",
+    }[target]
+    started = time.monotonic()
+    report = supervise_diagnostic(
+        _run_request(target, task),
+        timeout_s=0.3,
+        grace_s=0.2,
+    )
+    assert time.monotonic() - started < 2
+    assert report.completion == "timed_out"
+    assert report.cleanup in {"complete", "incomplete"}
+    assert report.last_checkpoint is not None
+    assert report.last_checkpoint["phase"] == phase
+
+
+def test_spawned_child_output_is_forwarded_only_to_stderr(capsys) -> None:
+    report = supervise_diagnostic(
+        _run_request("tests.assets.diagnostic_app:output_app", "write_output"),
+        timeout_s=3,
+        grace_s=0.2,
+    )
+    captured = capsys.readouterr()
+    assert report.completion == "succeeded"
+    assert captured.out == ""
+    assert "child stdout marker" in captured.err
+    assert "child stderr marker" in captured.err
+
+
+def test_supervisor_marks_forced_send_outcome_unknown(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    marker = tmp_path / "send-entered"
+    monkeypatch.setenv("ONESTEP_DIAGNOSTIC_SEND_MARKER", str(marker))
+    report = supervise_diagnostic(
+        _run_request(
+            "tests.assets.diagnostic_app:send_blocking_app",
+            "block_during_send",
+            send=True,
+        ),
+        timeout_s=0.4,
+        grace_s=0.2,
+    )
+    assert marker.read_text(encoding="utf-8") == "entered"
+    assert report.completion == "timed_out"
+    assert report.side_effect_outcome == "unknown"
+    assert "partial" in report.warning
+    assert "duplicate" in report.warning
+
+
+def test_supervisor_synthesizes_child_failure_without_final() -> None:
+    report = supervise_diagnostic(
+        _run_request("tests.assets.diagnostic_app:exit_app", "exit_without_final"),
+        timeout_s=3,
+        grace_s=0.2,
+    )
+    assert report.completion == "child_failed"
+    assert report.last_checkpoint is not None
+    assert report.last_checkpoint["phase"] in {"child_start", "handler"}
+
+
+def test_final_frame_requires_strict_nested_report_types() -> None:
+    app = OneStepApp("strict-final")
+
+    @app.task()
+    async def task(ctx, payload):
+        return None
+
+    report = asyncio.run(
+        DiagnosticRunner(app).run(
+            task_name="task",
+            envelope=Envelope(body={}),
+            send=False,
+        )
+    ).to_dict()
+    invalid = deepcopy(report)
+    invalid["events"][0]["attempts"] = True
+    validator = FrameValidator(direction="status")
+    with pytest.raises(IPCProtocolError, match="diagnostic result"):
+        validator.accept(
+            decode_frame(encode_frame("final", sequence=1, payload=invalid))
+        )

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from copy import deepcopy
 from pathlib import Path
@@ -366,6 +367,43 @@ def test_connectivity_continues_after_failures_and_attempts_cleanup() -> None:
         assert report.ok is False
 
     asyncio.run(scenario())
+
+
+def test_connectivity_timeout_bounds_synchronously_blocking_lifecycle() -> None:
+    class BlockingLifecycle:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+            self.connected = False
+            self.cleaned_up = threading.Event()
+
+        def open(self) -> None:
+            self.calls.append("open")
+            time.sleep(0.1)
+            self.connected = True
+
+        def close(self) -> None:
+            self.calls.append("close")
+            self.connected = False
+            self.cleaned_up.set()
+
+    resource = BlockingLifecycle()
+    app = OneStepApp("sync-blocking-connectivity")
+    app.register_resource("blocking", resource)
+
+    started = time.monotonic()
+    report = asyncio.run(check_connectivity(app, timeout_s=0.02))
+    elapsed = time.monotonic() - started
+
+    result = report.resources[0]
+    assert elapsed < 0.15
+    assert result.open == {"status": "timed_out"}
+    assert result.close == {"status": "timed_out"}
+    assert resource.calls == ["open"]
+    assert report.ok is False
+
+    assert resource.cleaned_up.wait(timeout=0.5)
+    assert resource.calls == ["open", "close"]
+    assert resource.connected is False
 
 
 def test_connectivity_only_not_probeable_is_success_with_warning() -> None:

--- a/tests/test_failure_capture.py
+++ b/tests/test_failure_capture.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections import namedtuple
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import Enum
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from onestep import FailureCaptureConfig
+from onestep.capture.codec import CaptureEncodingError, decode_value, encode_value
+from onestep.capture.writer import FailureCaptureWriter, load_capture, redact_envelope
+from onestep.config import load_app_config
+from onestep.envelope import Envelope
+from onestep.retry import FailureInfo, FailureKind
+
+
+class CaptureStatus(Enum):
+    READY = ("ready", 1)
+
+
+CapturePoint = namedtuple("CapturePoint", "x y")
+
+
+def test_failure_capture_config_normalizes_values(tmp_path: Path) -> None:
+    config = FailureCaptureConfig(
+        directory=tmp_path / "captures",
+        mode="all",
+        max_bytes=2048,
+        redact_paths=("/body/password",),
+    )
+    assert config.directory == tmp_path / "captures"
+    assert config.mode == "all"
+    assert config.max_bytes == 2048
+    assert config.redact_paths == ("/body/password",)
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"mode": "sometimes"}, "mode must be 'terminal' or 'all'"),
+        ({"max_bytes": 0}, "max_bytes must be >= 1"),
+        ({"max_bytes": True}, "must be an integer"),
+        ({"redact_paths": ("body/password",)}, "JSON Pointer"),
+        ({"redact_paths": ("",)}, "JSON Pointer"),
+    ],
+)
+def test_failure_capture_config_rejects_invalid_values(kwargs, match) -> None:
+    with pytest.raises((TypeError, ValueError), match=match):
+        FailureCaptureConfig(directory="captures", **kwargs)
+
+
+def test_yaml_app_builds_failure_capture_config(tmp_path: Path) -> None:
+    app = load_app_config(
+        {
+            "app": {
+                "name": "capture-yaml",
+                "failure_capture": {
+                    "directory": str(tmp_path / "captures"),
+                    "mode": "terminal",
+                    "max_bytes": 4096,
+                    "redact_paths": ["/body/token"],
+                },
+            },
+            "tasks": [],
+        },
+        strict=True,
+    )
+    assert app.failure_capture == FailureCaptureConfig(
+        directory=tmp_path / "captures",
+        mode="terminal",
+        max_bytes=4096,
+        redact_paths=("/body/token",),
+    )
+
+
+@pytest.mark.parametrize(
+    "capture,match",
+    [
+        ({"directory": "captures", "unknown": True}, "unsupported fields"),
+        ({"mode": "terminal"}, "directory is required"),
+        ({"directory": 1}, "path string"),
+        ({"directory": "captures", "redact_paths": "password"}, "must be a list"),
+    ],
+)
+def test_yaml_failure_capture_rejects_invalid_schema(capture, match) -> None:
+    with pytest.raises((TypeError, ValueError), match=match):
+        load_app_config(
+            {"app": {"name": "invalid", "failure_capture": capture}, "tasks": []},
+            strict=True,
+        )
+
+
+def test_capture_codec_round_trips_supported_values() -> None:
+    value = {
+        "at": datetime(2026, 7, 30, 9, 15, tzinfo=timezone.utc),
+        "id": UUID("d78e3d0d-13e1-44ef-96a5-10bd28fc882d"),
+        "raw": b"\x00\xff",
+        "amount": Decimal("-0.0100"),
+        "decimal_nan": Decimal("NaN"),
+        "tuple": (1, "x"),
+        "enum": CaptureStatus.READY,
+        "point": CapturePoint(2, 3),
+        "set": {"b", "a"},
+        "frozen": frozenset({2, 1}),
+        "$onestep": {"type": "user-data"},
+    }
+    decoded = decode_value(encode_value(value))
+    assert decoded["decimal_nan"].is_nan()
+    decoded.pop("decimal_nan")
+    value.pop("decimal_nan")
+    assert decoded == value
+
+
+def test_capture_codec_orders_sets_deterministically() -> None:
+    assert encode_value({"b", "a", "c"}) == encode_value({"c", "b", "a"})
+
+
+def test_capture_codec_rejects_custom_values_without_repr() -> None:
+    class SecretObject:
+        def __repr__(self) -> str:
+            return "token=do-not-log"
+
+    with pytest.raises(CaptureEncodingError) as captured:
+        encode_value({"nested": [SecretObject()]})
+    assert captured.value.path == "/nested/0"
+    assert captured.value.type_name.endswith("SecretObject")
+    assert "do-not-log" not in str(captured.value)
+
+
+def test_capture_codec_rejects_invalid_values_and_tags() -> None:
+    with pytest.raises(CaptureEncodingError, match="mapping keys must be strings"):
+        encode_value({1: "value"})
+    with pytest.raises(CaptureEncodingError, match="non-finite float"):
+        encode_value(float("nan"))
+    with pytest.raises(ValueError, match="unknown extension type"):
+        decode_value({"$onestep": {"type": "unknown"}})
+
+    encoded = encode_value(CaptureStatus.READY)
+    encoded["$onestep"]["value"] = "changed"
+    with pytest.raises(ValueError, match="enum value changed"):
+        decode_value(encoded)
+
+
+def test_capture_codec_rejects_unloaded_or_local_types() -> None:
+    encoded = encode_value(CaptureStatus.READY)
+    encoded["$onestep"]["module"] = "not_loaded_capture_module"
+    with pytest.raises(ValueError, match="not loaded"):
+        decode_value(encoded)
+
+    LocalPoint = namedtuple("LocalPoint", "x")
+    encoded_local = encode_value(LocalPoint(1))
+    with pytest.raises(ValueError, match="unavailable"):
+        decode_value(encoded_local)
+
+
+def test_redact_envelope_handles_secret_keys_and_pointers() -> None:
+    envelope = Envelope(
+        body={
+            "Password": "secret",
+            "rows": [{"card": "4111"}, {"card": "4222"}],
+        },
+        meta={"API-Key": "token", "trace": "t-1"},
+        attempts=3,
+    )
+    redacted, paths = redact_envelope(
+        envelope,
+        ("/body/rows/1/card", "/body/not-there"),
+    )
+    assert redacted.body == {
+        "Password": "<redacted>",
+        "rows": [{"card": "4111"}, {"card": "<redacted>"}],
+    }
+    assert redacted.meta == {"API-Key": "<redacted>", "trace": "t-1"}
+    assert redacted.attempts == 3
+    assert paths == ("/body/Password", "/body/rows/1/card", "/meta/API-Key")
+    assert envelope.body["Password"] == "secret"
+
+
+def _write_capture(writer: FailureCaptureWriter, envelope: Envelope) -> Path:
+    return asyncio.run(
+        writer.write(
+            app="billing",
+            task="sync",
+            stage="handler",
+            terminal=True,
+            failure=FailureInfo(FailureKind.ERROR, "ValueError", "bad row"),
+            envelope=envelope,
+        )
+    )
+
+
+def test_capture_writer_redacts_and_round_trips(tmp_path: Path) -> None:
+    writer = FailureCaptureWriter(
+        FailureCaptureConfig(
+            directory=tmp_path / "captures",
+            redact_paths=("/body/customer/card",),
+        )
+    )
+    path = _write_capture(
+        writer,
+        Envelope(
+            body={
+                "password": "p",
+                "customer": {"card": "4111", "amount": Decimal("1.20")},
+            },
+            meta={"Authorization": "Bearer secret", "trace": "t-1"},
+            attempts=2,
+        ),
+    )
+    capture = load_capture(path, expected_app="billing", expected_task="sync")
+    assert capture.envelope.body == {
+        "password": "<redacted>",
+        "customer": {"card": "<redacted>", "amount": Decimal("1.20")},
+    }
+    assert capture.envelope.meta == {
+        "Authorization": "<redacted>",
+        "trace": "t-1",
+    }
+    assert set(capture.redacted_paths) == {
+        "/body/password",
+        "/body/customer/card",
+        "/meta/Authorization",
+    }
+    assert capture.envelope.attempts == 2
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert path.parent.stat().st_mode & 0o077 == 0
+    assert not list(path.parent.glob("*.tmp"))
+
+
+def test_capture_writer_rejects_oversized_values_without_file(tmp_path: Path) -> None:
+    directory = tmp_path / "captures"
+    writer = FailureCaptureWriter(
+        FailureCaptureConfig(directory=directory, max_bytes=32)
+    )
+    with pytest.raises(ValueError, match="max_bytes"):
+        _write_capture(writer, Envelope(body={"large": "x" * 100}))
+    assert list(directory.iterdir()) == []
+
+
+def test_capture_writer_rejects_symlink_directory(tmp_path: Path) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    linked = tmp_path / "linked"
+    try:
+        linked.symlink_to(real, target_is_directory=True)
+    except OSError:
+        pytest.skip("symbolic links unavailable")
+    writer = FailureCaptureWriter(FailureCaptureConfig(directory=linked))
+    with pytest.raises(ValueError, match="symbolic link"):
+        _write_capture(writer, Envelope(body={"id": 1}))
+
+
+def test_load_capture_rejects_version_and_identity_mismatch(tmp_path: Path) -> None:
+    path = _write_capture(
+        FailureCaptureWriter(FailureCaptureConfig(directory=tmp_path)),
+        Envelope(body={"id": 1}),
+    )
+    with pytest.raises(ValueError, match="expected 'other'.*received 'billing'"):
+        load_capture(path, expected_app="other")
+    with pytest.raises(ValueError, match="expected 'other'.*received 'sync'"):
+        load_capture(path, expected_task="other")
+
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["version"] = 999
+    path.write_text(json.dumps(document), encoding="utf-8")
+    with pytest.raises(ValueError, match="unsupported capture version 999"):
+        load_capture(path)
+
+
+def test_capture_file_contains_no_traceback(tmp_path: Path) -> None:
+    writer = FailureCaptureWriter(FailureCaptureConfig(directory=tmp_path))
+    path = asyncio.run(
+        writer.write(
+            app="billing",
+            task="sync",
+            stage="handler",
+            terminal=True,
+            failure=FailureInfo(
+                FailureKind.ERROR,
+                "ValueError",
+                "bad",
+                "secret traceback",
+            ),
+            envelope=Envelope(body={"id": 1}),
+        )
+    )
+    assert "secret traceback" not in path.read_text(encoding="utf-8")

--- a/tests/test_failure_capture.py
+++ b/tests/test_failure_capture.py
@@ -169,6 +169,28 @@ def test_capture_codec_rejects_custom_values_without_repr() -> None:
     assert "do-not-log" not in str(captured.value)
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        type("CustomInt", (int,), {})(1),
+        type("CustomFloat", (float,), {})(1.5),
+        type("CustomStr", (str,), {})("value"),
+        type("CustomBytes", (bytes,), {})(b"value"),
+        type("CustomList", (list,), {})([1]),
+        type("CustomDict", (dict,), {})(value=1),
+        type("CustomTuple", (tuple,), {})([1]),
+        type("CustomSet", (set,), {})({1}),
+        type("CustomFrozenSet", (frozenset,), {})({1}),
+        type("CustomDatetime", (datetime,), {})(2026, 7, 30),
+        type("CustomDecimal", (Decimal,), {})("1.25"),
+        type("CustomUUID", (UUID,), {})("d78e3d0d-13e1-44ef-96a5-10bd28fc882d"),
+    ],
+)
+def test_capture_codec_rejects_lossy_builtin_subclasses(value) -> None:
+    with pytest.raises(CaptureEncodingError, match="unsupported value type"):
+        encode_value(value)
+
+
 def test_capture_codec_rejects_invalid_values_and_tags() -> None:
     with pytest.raises(CaptureEncodingError, match="mapping keys must be strings"):
         encode_value({1: "value"})
@@ -190,9 +212,8 @@ def test_capture_codec_rejects_unloaded_or_local_types() -> None:
         decode_value(encoded)
 
     LocalPoint = namedtuple("LocalPoint", "x")
-    encoded_local = encode_value(LocalPoint(1))
-    with pytest.raises(ValueError, match="unavailable"):
-        decode_value(encoded_local)
+    with pytest.raises(CaptureEncodingError, match="not replayable"):
+        encode_value(LocalPoint(1))
 
 
 def test_redact_envelope_handles_secret_keys_and_pointers() -> None:
@@ -267,6 +288,27 @@ def test_capture_writer_redacts_and_round_trips(tmp_path: Path) -> None:
     assert path.stat().st_mode & 0o777 == 0o600
     assert path.parent.stat().st_mode & 0o077 == 0
     assert not list(path.parent.glob("*.tmp"))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        type("WriterCustomList", (list,), {})([1]),
+        type("WriterCustomDict", (dict,), {})(value=1),
+        type("WriterCustomSet", (set,), {})({1}),
+    ],
+)
+def test_capture_writer_rejects_lossy_container_subclasses(
+    tmp_path: Path,
+    value,
+) -> None:
+    directory = tmp_path / "captures"
+    writer = FailureCaptureWriter(FailureCaptureConfig(directory=directory))
+
+    with pytest.raises(CaptureEncodingError, match="unsupported value type"):
+        _write_capture(writer, Envelope(body=value))
+
+    assert list(directory.iterdir()) == []
 
 
 def test_capture_writer_rejects_oversized_values_without_file(tmp_path: Path) -> None:
@@ -434,3 +476,50 @@ def test_failure_capture_runtime_encoding_error_preserves_action_and_logs_safe_c
     assert capture_logs[0].failure_stage == "handler"
     assert capture_logs[0].capture_path == "/value"
     assert "secret-repr" not in capture_logs[0].getMessage()
+
+
+def test_disabled_failure_capture_does_not_copy_failed_envelope(tmp_path: Path) -> None:
+    class NonCopyable:
+        def __deepcopy__(self, memo):
+            raise TypeError("must not copy")
+
+    app = OneStepApp("capture-disabled")
+
+    @app.task(retry=NoRetry())
+    async def consume(ctx, payload):
+        raise ValueError("boom")
+
+    delivery = _CaptureDelivery({"value": NonCopyable()})
+    asyncio.run(TaskRunner(app, app.tasks[0])._handle_delivery(delivery))
+
+    assert delivery.failed is True
+    assert delivery.retried is False
+
+
+def test_capture_snapshot_failure_preserves_retry_action(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    class NonCopyable:
+        def __deepcopy__(self, memo):
+            raise TypeError("secret snapshot detail")
+
+    caplog.set_level("ERROR")
+    delivery = _run_failed_delivery(
+        tmp_path,
+        mode="all",
+        retry=MaxAttempts(max_attempts=3),
+        delivery=_CaptureDelivery({"value": NonCopyable()}),
+    )
+
+    assert delivery.retried is True
+    assert delivery.failed is False
+    assert list(tmp_path.glob("*.json")) == []
+    snapshot_logs = [
+        record
+        for record in caplog.records
+        if record.message == "failure capture snapshot failed"
+    ]
+    assert len(snapshot_logs) == 1
+    assert snapshot_logs[0].capture_type == "TypeError"
+    assert "secret snapshot detail" not in snapshot_logs[0].getMessage()

--- a/tests/test_failure_capture.py
+++ b/tests/test_failure_capture.py
@@ -11,12 +11,14 @@ from uuid import UUID
 
 import pytest
 
-from onestep import FailureCaptureConfig
+from onestep import FailureCaptureConfig, MaxAttempts, NoRetry, OneStepApp
 from onestep.capture.codec import CaptureEncodingError, decode_value, encode_value
 from onestep.capture.writer import FailureCaptureWriter, load_capture, redact_envelope
+from onestep.connectors.base import Delivery, Sink
 from onestep.config import load_app_config
 from onestep.envelope import Envelope
 from onestep.retry import FailureInfo, FailureKind
+from onestep.runtime import TaskRunner
 
 
 class CaptureStatus(Enum):
@@ -24,6 +26,41 @@ class CaptureStatus(Enum):
 
 
 CapturePoint = namedtuple("CapturePoint", "x y")
+
+
+class _CaptureDelivery(Delivery):
+    def __init__(self, body, *, fail_raises: bool = False) -> None:
+        super().__init__(Envelope(body=body))
+        self.fail_raises = fail_raises
+        self.acked = False
+        self.retried = False
+        self.failed = False
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        self.retried = True
+        self.envelope = Envelope(
+            body=self.envelope.body,
+            meta=dict(self.envelope.meta),
+            attempts=self.envelope.attempts + 1,
+        )
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        self.failed = True
+        if self.fail_raises:
+            raise RuntimeError("fail unavailable")
+
+
+class _CaptureSink(Sink):
+    def __init__(self, *, broken: bool = False) -> None:
+        super().__init__("capture-dead")
+        self.broken = broken
+
+    async def send(self, envelope: Envelope) -> None:
+        if self.broken:
+            raise RuntimeError("dead letter unavailable")
 
 
 def test_failure_capture_config_normalizes_values(tmp_path: Path) -> None:
@@ -290,3 +327,110 @@ def test_capture_file_contains_no_traceback(tmp_path: Path) -> None:
         )
     )
     assert "secret traceback" not in path.read_text(encoding="utf-8")
+
+
+def _run_failed_delivery(
+    tmp_path: Path,
+    *,
+    mode: str,
+    retry=None,
+    dead_letter: Sink | None = None,
+    delivery: _CaptureDelivery | None = None,
+) -> _CaptureDelivery:
+    app = OneStepApp(
+        "runtime-capture",
+        failure_capture=FailureCaptureConfig(directory=tmp_path, mode=mode),
+    )
+
+    @app.task(retry=retry or NoRetry(), dead_letter=dead_letter)
+    async def consume(ctx, payload):
+        raise ValueError("boom")
+
+    active_delivery = delivery or _CaptureDelivery({"id": 1})
+    asyncio.run(TaskRunner(app, app.tasks[0])._handle_delivery(active_delivery))
+    return active_delivery
+
+
+def test_failure_capture_runtime_terminal_writes_after_effective_fail(
+    tmp_path: Path,
+) -> None:
+    delivery = _run_failed_delivery(
+        tmp_path,
+        mode="terminal",
+        dead_letter=_CaptureSink(),
+    )
+    paths = list(tmp_path.glob("*.json"))
+    assert delivery.failed is True
+    assert delivery.retried is False
+    assert len(paths) == 1
+    capture = load_capture(paths[0])
+    assert capture.terminal is True
+    assert capture.stage == "handler"
+
+
+def test_failure_capture_runtime_terminal_skips_retrying_outcomes(
+    tmp_path: Path,
+) -> None:
+    retry_delivery = _run_failed_delivery(
+        tmp_path / "retry",
+        mode="terminal",
+        retry=MaxAttempts(max_attempts=3),
+    )
+    broken_dead_delivery = _run_failed_delivery(
+        tmp_path / "dead",
+        mode="terminal",
+        dead_letter=_CaptureSink(broken=True),
+    )
+    fail_fallback_delivery = _run_failed_delivery(
+        tmp_path / "fail",
+        mode="terminal",
+        delivery=_CaptureDelivery({"id": 1}, fail_raises=True),
+    )
+    assert retry_delivery.retried is True
+    assert broken_dead_delivery.retried is True
+    assert fail_fallback_delivery.retried is True
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+def test_failure_capture_runtime_all_writes_non_terminal_retry(
+    tmp_path: Path,
+) -> None:
+    delivery = _run_failed_delivery(
+        tmp_path,
+        mode="all",
+        retry=MaxAttempts(max_attempts=3),
+    )
+    paths = list(tmp_path.glob("*.json"))
+    assert delivery.retried is True
+    assert len(paths) == 1
+    capture = load_capture(paths[0])
+    assert capture.terminal is False
+    assert capture.envelope.attempts == 0
+
+
+def test_failure_capture_runtime_encoding_error_preserves_action_and_logs_safe_context(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    class Unsupported:
+        def __repr__(self) -> str:
+            return "secret-repr"
+
+    caplog.set_level("ERROR")
+    delivery = _run_failed_delivery(
+        tmp_path,
+        mode="all",
+        retry=MaxAttempts(max_attempts=3),
+        delivery=_CaptureDelivery({"value": Unsupported()}),
+    )
+    assert delivery.retried is True
+    assert list(tmp_path.glob("*.json")) == []
+    capture_logs = [
+        record for record in caplog.records if record.message == "failure capture encoding failed"
+    ]
+    assert len(capture_logs) == 1
+    assert capture_logs[0].app_name == "runtime-capture"
+    assert capture_logs[0].task_name == "consume"
+    assert capture_logs[0].failure_stage == "handler"
+    assert capture_logs[0].capture_path == "/value"
+    assert "secret-repr" not in capture_logs[0].getMessage()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -123,6 +123,7 @@ from onestep import (
     CronSource,
     Delivery,
     Envelope,
+    FailureCaptureConfig,
     HttpSink,
     InMemoryMetrics,
     IntervalSource,
@@ -158,6 +159,7 @@ assert callable(load_resource_plugins)
 assert callable(register_resource_type)
 assert Delivery is not None
 assert Envelope is not None
+assert FailureCaptureConfig is not None
 assert HttpSink is not None
 assert InMemoryMetrics is not None
 assert IntervalSource is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1261,7 +1261,7 @@ wheels = [
 
 [[package]]
 name = "onestep"
-version = "1.7.3"
+version = "1.8.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

### Local task diagnostics

- Add `onestep task run` and `onestep task replay` for one-attempt local execution of Python and YAML targets.
- Reuse production delivery semantics through an internal `DeliveryExecutor` while keeping task events, reporter payloads, remote controls, and Control Plane protocols unchanged.
- Suppress framework-managed sink I/O by default and make real sends explicit through `--send`.
- Enforce an overall timeout in a spawned child process with strict versioned JSON IPC, incremental checkpoints, cooperative cancellation, and forced termination fallback.
- Load replay targets and validate captures only in the supervised child, so imports occur once and remain inside the overall timeout. Validation failures return a structured `validation_failed` report and exit code 2.
- Keep JSON stdout isolated from child and target-import output.

### Failure capture and replay

- Add opt-in `FailureCaptureConfig` for terminal-only or all-attempt capture.
- Preserve datetime, UUID, bytes, Decimal, enum, tuple/namedtuple, set, and frozenset values losslessly.
- Reject custom built-in subclasses and enum/namedtuple types that cannot be replayed instead of silently degrading their type.
- Snapshot failed envelopes only when capture is enabled; snapshot/encoding failures no longer prevent retry or terminal delivery actions.
- Redact configured JSON Pointer paths and known secret keys.
- Persist captures privately and atomically, and validate schema, version, app, and task identity before replay.

### Connectivity and documentation

- Add capability-based `onestep check --connect` using callable `open()` and `close()` methods only.
- Report state/cursor stores without lifecycle methods as `not_probeable` without calling `load()`, `save()`, or `delete()`.
- Bound synchronously blocking lifecycle calls on daemon threads. When `open()` times out, defer `close()` until that same invocation returns so cleanup cannot race and leave the resource connected.
- Document dry-run prediction semantics, `--send` partial/duplicate write risk, timeout behavior, capture support, and YAML configuration in English and Chinese.
- Prepare core version `1.8.0` and mark roadmap milestone P2 complete.

## Compatibility

- Public task lifecycle events and reporter payloads are unchanged.
- WebSocket behavior, runtime identity, remote task control, and Control Plane storage/rendering contracts are unchanged.
- Existing `run`, `check`, `init`, `build`, `catalog`, and `run_task_once()` behavior is preserved.
- No plugin versions or Control Plane code were changed.
- The CLI additions are additive. Lossy capture values that the feature branch previously accepted are now rejected explicitly before this feature reaches `main`.

## Test Coverage

- 363 core non-integration tests passed.
- 493 plugin reliability tests passed across all ten plugin suites; 12 infrastructure-dependent cases were skipped or deselected.
- Focused CLI, diagnostics, and failure-capture suite: 141 passed.
- The seven new P1 regression cases pass, covering replay supervision, synchronous lifecycle cleanup, lossless codec boundaries, and non-copyable payload delivery actions.

## Pre-Landing Review

No blocking issues found. The review traced the new `validation_failed` completion through worker, model validation, CLI exit mapping, and tests; checked synchronization of timed-out lifecycle cleanup; and verified capture failures do not leak exception messages or change delivery actions.

No frontend files changed; design review was skipped.

## Plan Completion

P2 Local Handler Loop is implemented and marked complete after all planned feature, contract, non-integration, and plugin reliability gates passed. This follow-up closes the three P1 findings from the final review.

## Verification Results

- [x] `uv run pytest -q -m "not integration"` - 363 passed
- [x] `./scripts/run-reliability-checks.sh` - 856 total tests passed across core and all plugin suites
- [x] `uv run pytest -q tests/test_cli.py tests/test_diagnostics.py tests/test_failure_capture.py` - 141 passed
- [x] `uvx ruff==0.16.0 check --select F <changed Python files>`
- [x] `uv run python -m compileall -q src/onestep tests`
- [x] `uv lock --check`
- [x] `git diff --check`
- [x] `uv build` and `twine check` for the 1.8.0 wheel and sdist

## Known Quality Baseline

Ruff is not configured as a root project dependency or root CI gate. Ruff 0.16.0 passes functional `F` rules for every Python file changed in this follow-up. A default all-rule scan still reports existing style findings in the feature branch, so this PR does not include unrelated bulk lint or formatting changes.

## Test Plan

- [x] Run one dry-run diagnostic from JSON input.
- [x] Replay and validate a versioned capture entirely inside the supervised child.
- [x] Bound synchronous and asynchronous blocking handlers with the overall timeout.
- [x] Isolate child stdout/stderr from JSON stdout.
- [x] Report interrupted real sends as an unknown side-effect outcome.
- [x] Probe lifecycle resources while leaving stores non-probeable.
- [x] Serialize cleanup after a synchronously blocked `open()` times out.
- [x] Preserve retry/fail delivery actions when failure capture cannot snapshot or encode a payload.
