### PR TITLE
feat(mysql): add update control and JSON coercion to mysql_table_sink

### DIFF
--- a/docs/yaml-task-definition.md
+++ b/docs/yaml-task-definition.md
@@ -237,9 +237,11 @@ tasks:
 | `update_expr` | optional | For `upsert` only: mapping of column to a raw SQL expression rendered on conflict (for example `updated_at: NOW(6)`). |
 | `serialize_json` | `auto` | `auto`, `always`, or `never`. When `auto`, list/dict payload values are JSON-serialized unless the target column is a JSON type. |
 
-In `upsert` mode, only the fields selected by `update_columns` (or every
-non-key field when unset) are rewritten on conflict; `update_expr` entries are
-rendered as raw SQL expressions such as `updated_at=NOW(6)`. Payload values
+In `upsert` mode, only the fields selected by `update_columns` are rewritten on
+conflict; when `update_columns` is unset, every non-key field is rewritten.
+Setting `update_columns: []` disables payload updates entirely, leaving only
+`update_expr` entries (for example `updated_at=NOW(6)`) to run on conflict.
+`update_expr` values are rendered as raw SQL expressions. Payload values
 that are lists or dicts are serialized to JSON strings before binding unless
 the column type is JSON (`auto`) or serialization is forced off (`never`).
 

--- a/docs/yaml-task-definition.md
+++ b/docs/yaml-task-definition.md
@@ -224,6 +224,25 @@ tasks:
       delay_s: 10
 ```
 
+`mysql_table_sink` fields:
+
+| Field | Required/default | Meaning |
+| --- | --- | --- |
+| `type` | required: `mysql_table_sink` | Resource type. |
+| `connector` | required | Reference to a `mysql` connector. |
+| `table` | required | Non-empty existing table name. |
+| `mode` | `insert` | `insert` or `upsert`. |
+| `keys` | required for `upsert` | Unique key columns used to detect conflicts. |
+| `update_columns` | optional | For `upsert` only: whitelist of columns to update on conflict. Defaults to every payload column except `keys`. |
+| `update_expr` | optional | For `upsert` only: mapping of column to a raw SQL expression rendered on conflict (for example `updated_at: NOW(6)`). |
+| `serialize_json` | `auto` | `auto`, `always`, or `never`. When `auto`, list/dict payload values are JSON-serialized unless the target column is a JSON type. |
+
+In `upsert` mode, only the fields selected by `update_columns` (or every
+non-key field when unset) are rewritten on conflict; `update_expr` entries are
+rendered as raw SQL expressions such as `updated_at=NOW(6)`. Payload values
+that are lists or dicts are serialized to JSON strings before binding unless
+the column type is JSON (`auto`) or serialization is forced off (`never`).
+
 ### Conditional Sink Routing
 
 `emit` entries can mix unconditional sinks with conditional route mappings.

--- a/plugins/onestep-control-plane/src/onestep_control_plane/reporter.py
+++ b/plugins/onestep-control-plane/src/onestep_control_plane/reporter.py
@@ -838,11 +838,17 @@ class ControlPlaneReporter:
                 "state_key": resource.state_key,
             }
         if class_name == "TableSink":
-            return {
+            config = {
                 "table": resource.table_name,
                 "mode": resource.mode,
                 "keys": list(resource.keys),
             }
+            if resource.update_columns is not None:
+                config["update_columns"] = list(resource.update_columns)
+            if resource.update_expr:
+                config["update_expr"] = dict(resource.update_expr)
+            config["serialize_json"] = resource.serialize_json
+            return config
         return {}
 
     def _build_connector_descriptor(self, resource: Any) -> dict[str, Any]:

--- a/plugins/onestep-control-plane/tests/test_control_plane_reporter.py
+++ b/plugins/onestep-control-plane/tests/test_control_plane_reporter.py
@@ -12,9 +12,11 @@ from onestep import (
     MaxAttempts,
     MemoryQueue,
     OneStepApp,
+    Sink,
     TaskEvent,
     TaskEventKind,
 )
+from onestep.envelope import Envelope
 from onestep.task import EmitRoute
 from onestep_control_plane import ControlPlaneReporter, ControlPlaneReporterConfig
 
@@ -47,6 +49,29 @@ def _make_config() -> ControlPlaneReporterConfig:
         reconnect_base_delay_s=0.01,
         reconnect_max_delay_s=0.02,
     )
+
+
+class TableSink(Sink):
+    def __init__(
+        self,
+        *,
+        table: str,
+        mode: str,
+        keys: tuple[str, ...],
+        update_columns: tuple[str, ...] | None = None,
+        update_expr: dict[str, str] | None = None,
+        serialize_json: str = "auto",
+    ) -> None:
+        super().__init__(f"mysql.table_sink:{table}")
+        self.table_name = table
+        self.mode = mode
+        self.keys = keys
+        self.update_columns = update_columns
+        self.update_expr = update_expr or {}
+        self.serialize_json = serialize_json
+
+    async def send(self, envelope: Envelope) -> None:
+        return None
 
 
 def test_reporter_startup_sends_heartbeat() -> None:
@@ -89,6 +114,51 @@ def test_reporter_startup_sends_heartbeat() -> None:
     }
     assert sync_payload["sequence"] == 1
     assert sync_payload["app"]["topology_hash"].startswith("sha256:")
+
+
+def test_reporter_sync_payload_includes_mysql_table_sink_update_controls() -> None:
+    def render(update_columns: tuple[str, ...]) -> dict:
+        recorder = SenderRecorder()
+        app = OneStepApp("billing-sync")
+        sink = TableSink(
+            table="articles",
+            mode="upsert",
+            keys=("id",),
+            update_columns=update_columns,
+            update_expr={"updated_at": "NOW(6)"},
+            serialize_json="always",
+        )
+
+        @app.task(source=MemoryQueue("incoming"), emit=sink)
+        async def sync_articles(ctx, payload):
+            return payload
+
+        reporter = ControlPlaneReporter(_make_config(), sender=recorder)
+        reporter.attach(app)
+
+        async def scenario() -> None:
+            await reporter.send_sync_now()
+
+        asyncio.run(scenario())
+        return next(payload for channel, payload in recorder.calls if channel == "sync")
+
+    first_payload = render(("title",))
+    second_payload = render(("body",))
+    emit = first_payload["app"]["tasks"][0]["emit"][0]
+
+    assert emit == {
+        "kind": "mysql_table_sink",
+        "name": "mysql.table_sink:articles",
+        "config": {
+            "table": "articles",
+            "mode": "upsert",
+            "keys": ["id"],
+            "update_columns": ["title"],
+            "update_expr": {"updated_at": "NOW(6)"},
+            "serialize_json": "always",
+        },
+    }
+    assert first_payload["app"]["topology_hash"] != second_payload["app"]["topology_hash"]
 
 
 def test_reporter_sync_payload_includes_task_topology() -> None:

--- a/plugins/onestep-mysql/src/onestep_mysql/connector.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/connector.py
@@ -180,7 +180,7 @@ class MySQLConnector:
         table: str,
         mode: str = "insert",
         keys: Sequence[str] = (),
-        update_columns: Sequence[str] = (),
+        update_columns: Sequence[str] | None = None,
         update_expr: Mapping[str, str] | None = None,
         serialize_json: str = "auto",
     ) -> "TableSink":
@@ -189,7 +189,7 @@ class MySQLConnector:
             table=table,
             mode=mode,
             keys=tuple(keys),
-            update_columns=tuple(update_columns),
+            update_columns=tuple(update_columns) if update_columns is not None else None,
             update_expr=update_expr,
             serialize_json=serialize_json,
         )
@@ -745,22 +745,27 @@ class TableSink(Sink):
         table: str,
         mode: str = "insert",
         keys: tuple[str, ...] = (),
-        update_columns: tuple[str, ...] = (),
+        update_columns: tuple[str, ...] | None = None,
         update_expr: Mapping[str, str] | None = None,
         serialize_json: str = "auto",
     ) -> None:
         super().__init__(f"mysql.table_sink:{table}")
         if mode not in {"insert", "upsert"}:
             raise ValueError("mode must be either 'insert' or 'upsert'")
-        if update_columns and mode != "upsert":
+        if update_columns is not None and mode != "upsert":
             raise ValueError("update_columns only applies to upsert mode")
+        if update_expr:
+            if mode != "upsert":
+                raise ValueError("update_expr only applies to upsert mode")
+            if not all(isinstance(key, str) and isinstance(value, str) for key, value in update_expr.items()):
+                raise TypeError("update_expr keys and values must be strings")
         if serialize_json not in {"auto", "always", "never"}:
             raise ValueError("serialize_json must be 'auto', 'always' or 'never'")
         self.connector = connector
         self.table_name = table
         self.mode = mode
         self.keys = keys
-        self.update_columns = update_columns
+        self.update_columns = tuple(update_columns) if update_columns is not None else None
         self.update_expr = dict(update_expr or {})
         self.serialize_json = serialize_json
 
@@ -793,7 +798,7 @@ class TableSink(Sink):
             return sa.insert(table).values(**payload)
         if not self.keys:
             raise ValueError("upsert mode requires keys")
-        if self.update_columns:
+        if self.update_columns is not None:
             update_payload = {key: value for key, value in payload.items() if key in self.update_columns}
         else:
             update_payload = {key: value for key, value in payload.items() if key not in self.keys}

--- a/plugins/onestep-mysql/src/onestep_mysql/connector.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/connector.py
@@ -754,19 +754,23 @@ class TableSink(Sink):
             raise ValueError("mode must be either 'insert' or 'upsert'")
         if update_columns is not None and mode != "upsert":
             raise ValueError("update_columns only applies to upsert mode")
-        if update_expr:
+        update_columns_tuple = tuple(update_columns) if update_columns is not None else None
+        update_expr_dict = dict(update_expr or {})
+        if update_expr is not None:
             if mode != "upsert":
                 raise ValueError("update_expr only applies to upsert mode")
             if not all(isinstance(key, str) and isinstance(value, str) for key, value in update_expr.items()):
                 raise TypeError("update_expr keys and values must be strings")
+        if mode == "upsert" and update_columns_tuple == () and not update_expr_dict:
+            raise ValueError("upsert mode requires update_expr when update_columns is empty")
         if serialize_json not in {"auto", "always", "never"}:
             raise ValueError("serialize_json must be 'auto', 'always' or 'never'")
         self.connector = connector
         self.table_name = table
         self.mode = mode
         self.keys = keys
-        self.update_columns = tuple(update_columns) if update_columns is not None else None
-        self.update_expr = dict(update_expr or {})
+        self.update_columns = update_columns_tuple
+        self.update_expr = update_expr_dict
         self.serialize_json = serialize_json
 
     async def send(self, envelope: Envelope) -> None:
@@ -804,6 +808,8 @@ class TableSink(Sink):
             update_payload = {key: value for key, value in payload.items() if key not in self.keys}
         for column, expr in self.update_expr.items():
             update_payload[column] = sa.literal_column(expr)
+        if not update_payload:
+            raise ValueError("upsert mode requires at least one update column or update_expr")
         dialect = self.connector.engine.dialect.name
         if dialect == "mysql":
             from sqlalchemy.dialects.mysql import insert as mysql_insert

--- a/plugins/onestep-mysql/src/onestep_mysql/connector.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/connector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -179,8 +180,19 @@ class MySQLConnector:
         table: str,
         mode: str = "insert",
         keys: Sequence[str] = (),
+        update_columns: Sequence[str] = (),
+        update_expr: Mapping[str, str] | None = None,
+        serialize_json: str = "auto",
     ) -> "TableSink":
-        return TableSink(connector=self, table=table, mode=mode, keys=tuple(keys))
+        return TableSink(
+            connector=self,
+            table=table,
+            mode=mode,
+            keys=tuple(keys),
+            update_columns=tuple(update_columns),
+            update_expr=update_expr,
+            serialize_json=serialize_json,
+        )
 
     def _table(self, table_name: str):
         table = self._tables.get(table_name)
@@ -726,14 +738,31 @@ class IncrementalTableSource(Source):
 
 
 class TableSink(Sink):
-    def __init__(self, *, connector: MySQLConnector, table: str, mode: str, keys: tuple[str, ...]) -> None:
+    def __init__(
+        self,
+        *,
+        connector: MySQLConnector,
+        table: str,
+        mode: str = "insert",
+        keys: tuple[str, ...] = (),
+        update_columns: tuple[str, ...] = (),
+        update_expr: Mapping[str, str] | None = None,
+        serialize_json: str = "auto",
+    ) -> None:
         super().__init__(f"mysql.table_sink:{table}")
         if mode not in {"insert", "upsert"}:
             raise ValueError("mode must be either 'insert' or 'upsert'")
+        if update_columns and mode != "upsert":
+            raise ValueError("update_columns only applies to upsert mode")
+        if serialize_json not in {"auto", "always", "never"}:
+            raise ValueError("serialize_json must be 'auto', 'always' or 'never'")
         self.connector = connector
         self.table_name = table
         self.mode = mode
         self.keys = keys
+        self.update_columns = update_columns
+        self.update_expr = dict(update_expr or {})
+        self.serialize_json = serialize_json
 
     async def send(self, envelope: Envelope) -> None:
         if not isinstance(envelope.body, Mapping):
@@ -754,24 +783,46 @@ class TableSink(Sink):
 
     def _send_sync(self, payload: dict[str, Any]) -> None:
         table = self.connector._table(self.table_name)
-        dialect = self.connector.engine.dialect.name
+        stmt = self._build_statement(payload, table)
         with self.connector.engine.begin() as conn:
-            if self.mode == "insert":
-                conn.execute(sa.insert(table).values(**payload))
-                return
-            if not self.keys:
-                raise ValueError("upsert mode requires keys")
+            conn.execute(stmt)
+
+    def _build_statement(self, payload: dict[str, Any], table: sa.Table):
+        payload = self._coerce_json_values(payload, table)
+        if self.mode == "insert":
+            return sa.insert(table).values(**payload)
+        if not self.keys:
+            raise ValueError("upsert mode requires keys")
+        if self.update_columns:
+            update_payload = {key: value for key, value in payload.items() if key in self.update_columns}
+        else:
             update_payload = {key: value for key, value in payload.items() if key not in self.keys}
-            if dialect == "mysql":
-                from sqlalchemy.dialects.mysql import insert as mysql_insert
+        for column, expr in self.update_expr.items():
+            update_payload[column] = sa.literal_column(expr)
+        dialect = self.connector.engine.dialect.name
+        if dialect == "mysql":
+            from sqlalchemy.dialects.mysql import insert as mysql_insert
 
-                stmt = mysql_insert(table).values(**payload)
-                conn.execute(stmt.on_duplicate_key_update(**update_payload))
-                return
-            if dialect == "sqlite":
-                from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+            stmt = mysql_insert(table).values(**payload)
+            return stmt.on_duplicate_key_update(**update_payload)
+        if dialect == "sqlite":
+            from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
-                stmt = sqlite_insert(table).values(**payload)
-                conn.execute(stmt.on_conflict_do_update(index_elements=list(self.keys), set_=update_payload))
-                return
-            conn.execute(sa.insert(table).values(**payload))
+            stmt = sqlite_insert(table).values(**payload)
+            return stmt.on_conflict_do_update(index_elements=list(self.keys), set_=update_payload)
+        return sa.insert(table).values(**payload)
+
+    def _coerce_json_values(self, payload: dict[str, Any], table: sa.Table) -> dict[str, Any]:
+        if self.serialize_json == "never":
+            return payload
+        coerced = dict(payload)
+        for column_name, value in list(payload.items()):
+            if not isinstance(value, (list, dict)):
+                continue
+            column = table.columns.get(column_name)
+            if column is None:
+                continue
+            is_json_column = isinstance(column.type, sa.JSON)
+            if self.serialize_json == "always" or not is_json_column:
+                coerced[column_name] = json.dumps(value, ensure_ascii=False)
+        return coerced

--- a/plugins/onestep-mysql/src/onestep_mysql/resources.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/resources.py
@@ -41,7 +41,9 @@ _MYSQL_BINLOG_FIELDS = frozenset(
         "blocking",
     }
 )
-_MYSQL_TABLE_SINK_FIELDS = frozenset({"type", "connector", "table", "mode", "keys"})
+_MYSQL_TABLE_SINK_FIELDS = frozenset(
+    {"type", "connector", "table", "mode", "keys", "update_columns", "update_expr", "serialize_json"}
+)
 _MYSQL_CATALOG = ResourceCatalogEntry(
     type="mysql",
     roles=("connector",),
@@ -151,8 +153,11 @@ _MYSQL_TABLE_SINK_CATALOG = ResourceCatalogEntry(
         ResourceCatalogField("table", "string", required=True),
         ResourceCatalogField("mode", "string", default="insert", options=("insert", "upsert")),
         ResourceCatalogField("keys", "string_list"),
+        ResourceCatalogField("update_columns", "string_list"),
+        ResourceCatalogField("update_expr", "mapping"),
+        ResourceCatalogField("serialize_json", "string", default="auto", options=("auto", "always", "never")),
     ),
-    topology_fields=("table", "mode", "keys"),
+    topology_fields=("table", "mode", "keys", "update_columns", "update_expr"),
 )
 
 
@@ -322,8 +327,17 @@ def _build_mysql_table_sink(ctx: ResourceBuildContext, spec: Mapping[str, Any]) 
     if not hasattr(connector, "table_sink"):
         raise TypeError(f"resource {spec['connector']!r} cannot build mysql_table_sink")
     keys = spec.get("keys")
+    update_columns = spec.get("update_columns")
+    update_expr = spec.get("update_expr")
     return connector.table_sink(
         table=ctx.require_string(spec, "table"),
         mode=spec.get("mode", "insert"),
         keys=tuple(ctx.string_list(keys, field=f"{ctx.field}.keys")) if keys is not None else (),
+        update_columns=tuple(ctx.string_list(update_columns, field=f"{ctx.field}.update_columns"))
+        if update_columns is not None
+        else (),
+        update_expr=ctx.mapping_value(update_expr, field=f"{ctx.field}.update_expr")
+        if update_expr is not None
+        else None,
+        serialize_json=spec.get("serialize_json", "auto"),
     )

--- a/plugins/onestep-mysql/src/onestep_mysql/resources.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/resources.py
@@ -335,7 +335,7 @@ def _build_mysql_table_sink(ctx: ResourceBuildContext, spec: Mapping[str, Any]) 
         keys=tuple(ctx.string_list(keys, field=f"{ctx.field}.keys")) if keys is not None else (),
         update_columns=tuple(ctx.string_list(update_columns, field=f"{ctx.field}.update_columns"))
         if update_columns is not None
-        else (),
+        else None,
         update_expr=ctx.mapping_value(update_expr, field=f"{ctx.field}.update_expr")
         if update_expr is not None
         else None,

--- a/plugins/onestep-mysql/src/onestep_mysql/resources.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/resources.py
@@ -157,7 +157,7 @@ _MYSQL_TABLE_SINK_CATALOG = ResourceCatalogEntry(
         ResourceCatalogField("update_expr", "mapping"),
         ResourceCatalogField("serialize_json", "string", default="auto", options=("auto", "always", "never")),
     ),
-    topology_fields=("table", "mode", "keys", "update_columns", "update_expr"),
+    topology_fields=("table", "mode", "keys", "update_columns", "update_expr", "serialize_json"),
 )
 
 

--- a/plugins/onestep-mysql/tests/test_mysql_plugin.py
+++ b/plugins/onestep-mysql/tests/test_mysql_plugin.py
@@ -196,6 +196,88 @@ def test_yaml_builds_table_sink_with_update_control(tmp_path) -> None:
     assert sink.serialize_json == "auto"
 
 
+def test_yaml_empty_update_columns_is_distinct_from_unset(tmp_path) -> None:
+    dsn = f"sqlite:///{tmp_path / 'mysql-plugin.db'}"
+
+    app = load_app_config(
+        {
+            "apiVersion": "onestep/v1alpha1",
+            "kind": "App",
+            "app": {"name": "mysql-plugin"},
+            "resources": {
+                "db": {"type": "mysql", "dsn": dsn},
+                "processed": {
+                    "type": "mysql_table_sink",
+                    "connector": "db",
+                    "table": "processed_users",
+                    "mode": "upsert",
+                    "keys": ["id"],
+                    "update_columns": [],
+                    "update_expr": {"updated_at": "NOW(6)"},
+                },
+            },
+            "tasks": [],
+        },
+        strict=True,
+    )
+
+    sink = app.resources["processed"]
+    assert isinstance(sink, TableSink)
+    assert sink.update_columns == ()
+    assert sink.update_expr == {"updated_at": "NOW(6)"}
+
+
+def test_yaml_rejects_update_expr_in_insert_mode(tmp_path) -> None:
+    dsn = f"sqlite:///{tmp_path / 'mysql-plugin.db'}"
+
+    with pytest.raises(ValueError, match="update_expr"):
+        load_app_config(
+            {
+                "apiVersion": "onestep/v1alpha1",
+                "kind": "App",
+                "app": {"name": "mysql-plugin"},
+                "resources": {
+                    "db": {"type": "mysql", "dsn": dsn},
+                    "processed": {
+                        "type": "mysql_table_sink",
+                        "connector": "db",
+                        "table": "processed_users",
+                        "mode": "insert",
+                        "update_expr": {"updated_at": "NOW(6)"},
+                    },
+                },
+                "tasks": [],
+            },
+            strict=True,
+        )
+
+
+def test_yaml_rejects_non_string_update_expr_values(tmp_path) -> None:
+    dsn = f"sqlite:///{tmp_path / 'mysql-plugin.db'}"
+
+    with pytest.raises(TypeError, match="update_expr"):
+        load_app_config(
+            {
+                "apiVersion": "onestep/v1alpha1",
+                "kind": "App",
+                "app": {"name": "mysql-plugin"},
+                "resources": {
+                    "db": {"type": "mysql", "dsn": dsn},
+                    "processed": {
+                        "type": "mysql_table_sink",
+                        "connector": "db",
+                        "table": "processed_users",
+                        "mode": "upsert",
+                        "keys": ["id"],
+                        "update_expr": {"updated_at": 123},
+                    },
+                },
+                "tasks": [],
+            },
+            strict=True,
+        )
+
+
 def _entry_points_for_group(group: str) -> tuple[Any, ...]:
     entry_points = importlib_metadata.entry_points()
     if hasattr(entry_points, "select"):

--- a/plugins/onestep-mysql/tests/test_mysql_plugin.py
+++ b/plugins/onestep-mysql/tests/test_mysql_plugin.py
@@ -227,6 +227,32 @@ def test_yaml_empty_update_columns_is_distinct_from_unset(tmp_path) -> None:
     assert sink.update_expr == {"updated_at": "NOW(6)"}
 
 
+def test_yaml_rejects_empty_update_columns_without_update_expr(tmp_path) -> None:
+    dsn = f"sqlite:///{tmp_path / 'mysql-plugin.db'}"
+
+    with pytest.raises(ValueError, match="update_expr"):
+        load_app_config(
+            {
+                "apiVersion": "onestep/v1alpha1",
+                "kind": "App",
+                "app": {"name": "mysql-plugin"},
+                "resources": {
+                    "db": {"type": "mysql", "dsn": dsn},
+                    "processed": {
+                        "type": "mysql_table_sink",
+                        "connector": "db",
+                        "table": "processed_users",
+                        "mode": "upsert",
+                        "keys": ["id"],
+                        "update_columns": [],
+                    },
+                },
+                "tasks": [],
+            },
+            strict=True,
+        )
+
+
 def test_yaml_rejects_update_expr_in_insert_mode(tmp_path) -> None:
     dsn = f"sqlite:///{tmp_path / 'mysql-plugin.db'}"
 

--- a/plugins/onestep-mysql/tests/test_mysql_plugin.py
+++ b/plugins/onestep-mysql/tests/test_mysql_plugin.py
@@ -154,6 +154,48 @@ def test_yaml_builds_mysql_resources_via_plugin_entry_point(tmp_path) -> None:
     assert app.state is app.resources["app_state"]
 
 
+def test_yaml_builds_table_sink_with_update_control(tmp_path) -> None:
+    dsn = f"sqlite:///{tmp_path / 'mysql-plugin.db'}"
+
+    app = load_app_config(
+        {
+            "apiVersion": "onestep/v1alpha1",
+            "kind": "App",
+            "app": {
+                "name": "mysql-plugin",
+            },
+            "resources": {
+                "db": {
+                    "type": "mysql",
+                    "dsn": dsn,
+                },
+                "processed": {
+                    "type": "mysql_table_sink",
+                    "connector": "db",
+                    "table": "processed_users",
+                    "mode": "upsert",
+                    "keys": ["id"],
+                    "update_columns": ["name", "email"],
+                    "update_expr": {
+                        "updated_at": "NOW(6)",
+                    },
+                    "serialize_json": "auto",
+                },
+            },
+            "tasks": [],
+        },
+        strict=True,
+    )
+
+    sink = app.resources["processed"]
+    assert isinstance(sink, TableSink)
+    assert sink.mode == "upsert"
+    assert sink.keys == ("id",)
+    assert sink.update_columns == ("name", "email")
+    assert sink.update_expr == {"updated_at": "NOW(6)"}
+    assert sink.serialize_json == "auto"
+
+
 def _entry_points_for_group(group: str) -> tuple[Any, ...]:
     entry_points = importlib_metadata.entry_points()
     if hasattr(entry_points, "select"):

--- a/plugins/onestep-mysql/tests/test_mysql_table_sink.py
+++ b/plugins/onestep-mysql/tests/test_mysql_table_sink.py
@@ -225,6 +225,31 @@ def test_empty_update_columns_limits_updates_to_update_expr() -> None:
 
 
 @pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_empty_update_columns_requires_update_expr() -> None:
+    with pytest.raises(ValueError, match="update_expr"):
+        TableSink(
+            connector=_FakeConnector(),  # type: ignore[arg-type]
+            table="t",
+            mode="upsert",
+            keys=("id",),
+            update_columns=(),
+        )
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_upsert_rejects_empty_update_payload() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="upsert",
+        keys=("article_identity",),
+    )
+
+    with pytest.raises(ValueError, match="at least one update column"):
+        sink._build_statement({"article_identity": "article-1"}, _candidate_table())
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
 def test_update_expr_only_valid_in_upsert_mode() -> None:
     with pytest.raises(ValueError, match="update_expr"):
         TableSink(

--- a/plugins/onestep-mysql/tests/test_mysql_table_sink.py
+++ b/plugins/onestep-mysql/tests/test_mysql_table_sink.py
@@ -207,6 +207,47 @@ def test_update_columns_only_valid_in_upsert_mode() -> None:
 
 
 @pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_empty_update_columns_limits_updates_to_update_expr() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="upsert",
+        keys=("article_identity",),
+        update_columns=(),
+        update_expr={"updated_at": "NOW(6)"},
+    )
+
+    update = _update_clause(_compile(sink._build_statement(_payload(), _candidate_table())))
+
+    assert "updated_at = NOW(6)" in update
+    assert "title = " not in update
+    assert "trace_id = " not in update
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_expr_only_valid_in_upsert_mode() -> None:
+    with pytest.raises(ValueError, match="update_expr"):
+        TableSink(
+            connector=_FakeConnector(),  # type: ignore[arg-type]
+            table="t",
+            mode="insert",
+            update_expr={"updated_at": "NOW(6)"},
+        )
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_expr_rejects_non_string_values() -> None:
+    with pytest.raises(TypeError, match="update_expr"):
+        TableSink(
+            connector=_FakeConnector(),  # type: ignore[arg-type]
+            table="t",
+            mode="upsert",
+            keys=("id",),
+            update_expr={"updated_at": 123},
+        )
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
 def test_invalid_serialize_json_value_rejected() -> None:
     with pytest.raises(ValueError, match="serialize_json"):
         TableSink(

--- a/plugins/onestep-mysql/tests/test_mysql_table_sink.py
+++ b/plugins/onestep-mysql/tests/test_mysql_table_sink.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from onestep_mysql.connector import TableSink
+
+try:
+    import sqlalchemy as sa
+    from sqlalchemy.dialects import mysql as mysql_dialect
+except ImportError:  # pragma: no cover - optional deps
+    sa = None
+    mysql_dialect = None
+
+
+class _FakeEngine:
+    class _Dialect:
+        name = "mysql"
+
+    dialect = _Dialect()
+
+
+class _FakeConnector:
+    engine = _FakeEngine()
+
+
+def _candidate_table() -> sa.Table:
+    metadata = sa.MetaData()
+    return sa.Table(
+        "v2_clean_article_candidate",
+        metadata,
+        sa.Column("trace_id", sa.String(64)),
+        sa.Column("article_identity", sa.String(64), primary_key=True),
+        sa.Column("channel_id", sa.BigInteger),
+        sa.Column("config_id", sa.BigInteger),
+        sa.Column("source_url", sa.Text),
+        sa.Column("source_url_hash", sa.String(64)),
+        sa.Column("title", sa.String(255)),
+        sa.Column("content", sa.Text),
+        sa.Column("content_hash", sa.String(64)),
+        sa.Column("publish_at", sa.DateTime),
+        sa.Column("attachments", sa.Text),
+        sa.Column("tags", sa.Text),
+        sa.Column("cleaning_version", sa.Integer),
+        sa.Column("quality_flags", sa.Text),
+        sa.Column("status", sa.String(32)),
+        sa.Column("updated_at", sa.DateTime),
+    )
+
+
+def _payload() -> dict[str, Any]:
+    return {
+        "trace_id": "trace-1",
+        "article_identity": "article-1",
+        "channel_id": 42,
+        "config_id": 7,
+        "source_url": "https://example.com/a",
+        "source_url_hash": "abc123",
+        "title": "title",
+        "content": "content",
+        "content_hash": "def456",
+        "publish_at": None,
+        "attachments": ["https://example.com/1.jpg"],
+        "tags": ["tech"],
+        "cleaning_version": 2,
+        "quality_flags": ["content_short"],
+        "status": "cleaned",
+    }
+
+
+def _compile(stmt) -> str:
+    return str(stmt.compile(dialect=mysql_dialect.dialect()))
+
+
+def _update_clause(sql: str) -> str:
+    return sql.split("ON DUPLICATE KEY UPDATE", 1)[1]
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_upsert_updates_only_whitelisted_columns() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="upsert",
+        keys=("article_identity",),
+        update_columns=("title", "content", "content_hash", "status", "quality_flags"),
+    )
+
+    update = _update_clause(_compile(sink._build_statement(_payload(), _candidate_table())))
+
+    assert "title = " in update
+    assert "content = " in update
+    assert "content_hash = " in update
+    assert "status = " in update
+    assert "quality_flags = " in update
+    assert "trace_id = " not in update
+    assert "channel_id = " not in update
+    assert "source_url = " not in update
+    assert "publish_at = " not in update
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_upsert_renders_update_expr_as_literal_sql() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="upsert",
+        keys=("article_identity",),
+        update_columns=("title", "content", "content_hash", "status", "quality_flags"),
+        update_expr={"updated_at": "NOW(6)"},
+    )
+
+    update = _update_clause(_compile(sink._build_statement(_payload(), _candidate_table())))
+
+    assert "updated_at = NOW(6)" in update
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_upsert_default_updates_all_non_key_columns() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="upsert",
+        keys=("article_identity",),
+    )
+
+    update = _update_clause(_compile(sink._build_statement(_payload(), _candidate_table())))
+
+    assert "trace_id = " in update
+    assert "channel_id = " in update
+    assert "updated_at = " not in update
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_auto_serializes_list_values_for_text_columns() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="upsert",
+        keys=("article_identity",),
+    )
+    table = _candidate_table()
+    payload = _payload()
+
+    coerced = sink._coerce_json_values(payload, table)
+
+    assert coerced["attachments"] == '["https://example.com/1.jpg"]'
+    assert coerced["tags"] == '["tech"]'
+    assert coerced["quality_flags"] == '["content_short"]'
+    assert coerced["title"] == "title"
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_auto_keeps_list_values_for_json_columns() -> None:
+    metadata = sa.MetaData()
+    table = sa.Table("t", metadata, sa.Column("meta", sa.JSON))
+
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="t",
+        mode="insert",
+    )
+
+    coerced = sink._coerce_json_values({"meta": {"k": [1, 2]}}, table)
+
+    assert coerced["meta"] == {"k": [1, 2]}
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_serialize_json_never_skips_coercion() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="upsert",
+        keys=("article_identity",),
+        serialize_json="never",
+    )
+    payload = _payload()
+
+    coerced = sink._coerce_json_values(payload, _candidate_table())
+
+    assert coerced["attachments"] == payload["attachments"]
+    assert isinstance(coerced["attachments"], list)
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_upsert_requires_keys() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="t",
+        mode="upsert",
+    )
+
+    with pytest.raises(ValueError, match="requires keys"):
+        sink._build_statement({"a": 1}, _candidate_table())
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_columns_only_valid_in_upsert_mode() -> None:
+    with pytest.raises(ValueError, match="update_columns"):
+        TableSink(
+            connector=_FakeConnector(),  # type: ignore[arg-type]
+            table="t",
+            mode="insert",
+            update_columns=("a",),
+        )
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_invalid_serialize_json_value_rejected() -> None:
+    with pytest.raises(ValueError, match="serialize_json"):
+        TableSink(
+            connector=_FakeConnector(),  # type: ignore[arg-type]
+            table="t",
+            serialize_json="sometimes",
+        )
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_sqlite_upsert_uses_on_conflict() -> None:
+    class _SqliteEngine(_FakeEngine):
+        class _Dialect:
+            name = "sqlite"
+
+        dialect = _Dialect()
+
+    class _SqliteConnector(_FakeConnector):
+        engine = _SqliteEngine()
+
+    sink = TableSink(
+        connector=_SqliteConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="upsert",
+        keys=("article_identity",),
+        update_columns=("title", "status"),
+    )
+
+    stmt = sink._build_statement(_payload(), _candidate_table())
+
+    from sqlalchemy.dialects import sqlite as sqlite_dialect
+
+    sql = str(stmt.compile(dialect=sqlite_dialect.dialect()))
+    assert "ON CONFLICT" in sql


### PR DESCRIPTION
## Summary

Enhances `mysql_table_sink` so pipeline handlers can return native Python values and the sink handles upsert semantics precisely, closing the gap that forced direct pymysql writes in downstream projects.

### New config options

| Option | Default | Meaning |
| --- | --- | --- |
| `update_columns` | all non-key cols | For `upsert`: whitelist of columns rewritten on conflict (immutable fields stay untouched) |
| `update_expr` | none | For `upsert`: mapping of column → raw SQL expression rendered on conflict, e.g. `updated_at: NOW(6)` |
| `serialize_json` | `auto` | `auto`/`always`/`never`: JSON-serialize list/dict payload values; `auto` skips columns with JSON type |

### Motivation

A downstream pipeline initially used the handler-return → sink flow, then replaced it with direct pymysql writes (see `uu-recruit-pipeline` commit `65dd700`) because the sink:
1. rewrote **all** non-key columns on upsert conflict, with no way to whitelist mutable fields
2. could not emit computed values like `updated_at=NOW(6)`
3. required manual `json.dumps` of list/dict payload fields

This change makes the sink capable of all three, so the pipeline can return to the framework-managed return → emit flow (with built-in retry, pooling, and error normalization).

## Changes

- `connector.py`: `TableSink` gained `update_columns` / `update_expr` / `serialize_json`; statement building refactored into `_build_statement` + `_coerce_json_values` for testability
- `resources.py`: new catalog fields, allowed fields, and YAML parsing
- `docs/yaml-task-definition.md`: `mysql_table_sink` field reference
- tests: SQL-compile tests (no live DB) for whitelist filtering, `update_expr` rendering, JSON coercion, default behavior, SQLite path; YAML build test

## Backward compatibility

All new options default to the previous behavior. No config migration needed.

## Testing

- `pytest plugins/onestep-mysql/tests/` — 32 passed, 1 skipped
- full unit suite: 395 passed