### PR TITLE
feat: env var expansion with JSON type coercion

### DIFF
--- a/src/onestep/config.py
+++ b/src/onestep/config.py
@@ -4,6 +4,7 @@ import copy
 import functools
 import importlib
 import inspect
+import json
 import logging
 import os
 import re
@@ -146,11 +147,10 @@ def _expand_env_vars(value: Any) -> Any:
     """Recursively expand environment variables in a configuration value.
     
     Supports ${VAR}, ${VAR:-default}, ${VAR:default} syntax in strings.
-    
+
     When a string value is entirely a single env var reference like ${VAR},
-    the expanded value is parsed through YAML to preserve the original type
-    (int, bool, dict, list, etc.). Mixed strings like "prefix-${VAR}-suffix"
-    remain as plain strings.
+    JSON literals are decoded to preserve typed values (int, bool, dict, list,
+    etc.). Mixed strings like "prefix-${VAR}-suffix" remain as plain strings.
     """
     if isinstance(value, str):
         expanded = _expand_env_vars_in_string(value)
@@ -166,22 +166,25 @@ def _expand_env_vars(value: Any) -> Any:
 
 def _is_pure_env_reference(value: str) -> bool:
     """Check if a string is entirely a single ${...} env var reference."""
-    stripped = value.strip()
-    return stripped.startswith("${") and stripped.endswith("}")
+    return _ENV_VAR_PATTERN.fullmatch(value.strip()) is not None
+
+
+def _reject_non_standard_json_constant(value: str) -> None:
+    raise ValueError(f"non-standard JSON constant: {value}")
 
 
 def _coerce_expanded_value(value: str) -> Any:
-    """Parse an expanded env var value through YAML to preserve type.
-    
-    Returns the YAML-parsed value for proper types (int, bool, dict, list, None),
-    or the original string if the expanded value is empty or fails to parse.
+    """Decode typed JSON literals while preserving ordinary strings.
+
+    JSON has predictable scalar rules for environment variables. In particular,
+    values such as ``yes``, ``0123``, and ISO dates stay strings instead of
+    receiving PyYAML's implicit boolean, integer, or date types.
     """
     if value == "":
         return value
-    yaml = _import_yaml()
     try:
-        parsed = yaml.safe_load(value)
-    except yaml.YAMLError:
+        parsed = json.loads(value, parse_constant=_reject_non_standard_json_constant)
+    except (json.JSONDecodeError, TypeError, ValueError):
         return value
     return value if parsed is None else parsed
 

--- a/src/onestep/config.py
+++ b/src/onestep/config.py
@@ -146,14 +146,44 @@ def _expand_env_vars(value: Any) -> Any:
     """Recursively expand environment variables in a configuration value.
     
     Supports ${VAR}, ${VAR:-default}, ${VAR:default} syntax in strings.
+    
+    When a string value is entirely a single env var reference like ${VAR},
+    the expanded value is parsed through YAML to preserve the original type
+    (int, bool, dict, list, etc.). Mixed strings like "prefix-${VAR}-suffix"
+    remain as plain strings.
     """
     if isinstance(value, str):
-        return _expand_env_vars_in_string(value)
+        expanded = _expand_env_vars_in_string(value)
+        if _is_pure_env_reference(value):
+            return _coerce_expanded_value(expanded)
+        return expanded
     if isinstance(value, Mapping):
         return {k: _expand_env_vars(v) for k, v in value.items()}
     if isinstance(value, list):
         return [_expand_env_vars(item) for item in value]
     return value
+
+
+def _is_pure_env_reference(value: str) -> bool:
+    """Check if a string is entirely a single ${...} env var reference."""
+    stripped = value.strip()
+    return stripped.startswith("${") and stripped.endswith("}")
+
+
+def _coerce_expanded_value(value: str) -> Any:
+    """Parse an expanded env var value through YAML to preserve type.
+    
+    Returns the YAML-parsed value for proper types (int, bool, dict, list, None),
+    or the original string if the expanded value is empty or fails to parse.
+    """
+    if value == "":
+        return value
+    yaml = _import_yaml()
+    try:
+        parsed = yaml.safe_load(value)
+    except yaml.YAMLError:
+        return value
+    return value if parsed is None else parsed
 
 
 def _load_dotenv(path: str) -> int:

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -34,12 +34,16 @@ def _registered_module(name: str, **attrs):
             sys.modules[name] = previous
 
 
+def _yaml_safe_load(stream):
+    """Mock yaml.safe_load that handles both file handles and strings."""
+    if hasattr(stream, "read"):
+        return json.loads(stream.read())
+    return json.loads(stream)
+
+
 @contextmanager
 def _registered_yaml_module():
-    def safe_load(handle):
-        return json.loads(handle.read())
-
-    with _registered_module("yaml", safe_load=safe_load) as module:
+    with _registered_module("yaml", safe_load=_yaml_safe_load, YAMLError=Exception) as module:
         yield module
 
 
@@ -207,6 +211,104 @@ def test_expand_env_var_present_takes_precedence_over_default(monkeypatch):
     assert _expand_env_var(match) == "bar"
 
 
+def test_expand_env_vars_type_coercion_int(monkeypatch):
+    monkeypatch.setenv("PREFETCH", "5")
+    result = _expand_env_vars({"prefetch": "${PREFETCH}"})
+    assert result["prefetch"] == 5
+    assert isinstance(result["prefetch"], int)
+
+
+def test_expand_env_vars_type_coercion_bool(monkeypatch):
+    monkeypatch.setenv("ENABLED", "true")
+    result = _expand_env_vars({"enabled": "${ENABLED}"})
+    assert result["enabled"] is True
+    assert isinstance(result["enabled"], bool)
+
+
+def test_expand_env_vars_type_coercion_float(monkeypatch):
+    monkeypatch.setenv("RATIO", "3.14")
+    result = _expand_env_vars({"ratio": "${RATIO}"})
+    assert result["ratio"] == 3.14
+    assert isinstance(result["ratio"], float)
+
+
+def test_expand_env_vars_type_coercion_dict(monkeypatch):
+    monkeypatch.setenv("ENGINE_OPTIONS", '{"connect_args": {"timeout": 5}}')
+    result = _expand_env_vars({"engine_options": "${ENGINE_OPTIONS}"})
+    assert result["engine_options"] == {"connect_args": {"timeout": 5}}
+    assert isinstance(result["engine_options"], dict)
+
+
+def test_expand_env_vars_type_coercion_list(monkeypatch):
+    monkeypatch.setenv("ITEMS", "[1, 2, 3]")
+    result = _expand_env_vars({"items": "${ITEMS}"})
+    assert result["items"] == [1, 2, 3]
+    assert isinstance(result["items"], list)
+
+
+def test_expand_env_vars_type_coercion_null(monkeypatch):
+    monkeypatch.setenv("NOT_SET", "null")
+    result = _expand_env_vars({"value": "${NOT_SET}"})
+    # null parsed to None → returns original string
+    assert result["value"] == "null"
+
+
+def test_expand_env_vars_type_coercion_empty_string(monkeypatch):
+    monkeypatch.setenv("EMPTY", "")
+    result = _expand_env_vars({"value": "${EMPTY}"})
+    assert result["value"] == ""
+
+
+def test_expand_env_vars_type_coercion_default_with_type(monkeypatch):
+    monkeypatch.delenv("PREFETCH", raising=False)
+    result = _expand_env_vars({"prefetch": "${PREFETCH:-5}"})
+    assert result["prefetch"] == 5
+    assert isinstance(result["prefetch"], int)
+
+
+def test_expand_env_vars_type_coercion_default_colon_syntax(monkeypatch):
+    monkeypatch.delenv("PREFETCH", raising=False)
+    result = _expand_env_vars({"prefetch": "${PREFETCH:5}"})
+    assert result["prefetch"] == 5
+    assert isinstance(result["prefetch"], int)
+
+
+def test_expand_env_vars_type_coercion_default_bool(monkeypatch):
+    monkeypatch.delenv("ENABLED", raising=False)
+    result = _expand_env_vars({"enabled": "${ENABLED:-true}"})
+    assert result["enabled"] is True
+    assert isinstance(result["enabled"], bool)
+
+
+def test_expand_env_vars_type_coercion_default_float(monkeypatch):
+    monkeypatch.delenv("RATIO", raising=False)
+    result = _expand_env_vars({"ratio": "${RATIO:3.14}"})
+    assert result["ratio"] == 3.14
+    assert isinstance(result["ratio"], float)
+
+
+def test_expand_env_vars_type_coercion_default_string(monkeypatch):
+    monkeypatch.delenv("NAME", raising=False)
+    result = _expand_env_vars({"name": "${NAME:-hello}"})
+    assert result["name"] == "hello"
+    assert isinstance(result["name"], str)
+
+
+def test_expand_env_vars_mixed_string_preserved(monkeypatch):
+    monkeypatch.setenv("HOST", "localhost")
+    # Mixed string with prefix/suffix should stay as string
+    result = _expand_env_vars({"dsn": "mysql://${HOST}:3306/mydb"})
+    assert result["dsn"] == "mysql://localhost:3306/mydb"
+    assert isinstance(result["dsn"], str)
+
+
+def test_expand_env_vars_non_string_values_unchanged(monkeypatch):
+    result = _expand_env_vars({"count": 5, "enabled": True, "ratio": 3.14})
+    assert result["count"] == 5
+    assert result["enabled"] is True
+    assert result["ratio"] == 3.14
+
+
 def test_expand_env_vars_recursive(monkeypatch):
     monkeypatch.setenv("A", "1")
     monkeypatch.setenv("B", "2")
@@ -215,8 +317,11 @@ def test_expand_env_vars_recursive(monkeypatch):
         "tasks": [{"config": {"key": "${B}"}}],
     }
     result = _expand_env_vars(config)
-    assert result["app"]["name"] == "1"
-    assert result["tasks"][0]["config"]["key"] == "2"
+    # Pure ${VAR} references are YAML-coerced: "1" → 1 (int)
+    assert result["app"]["name"] == 1
+    assert isinstance(result["app"]["name"], int)
+    assert result["tasks"][0]["config"]["key"] == 2
+    assert isinstance(result["tasks"][0]["config"]["key"], int)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -259,6 +259,40 @@ def test_expand_env_vars_type_coercion_empty_string(monkeypatch):
     assert result["value"] == ""
 
 
+def test_expand_env_vars_json_string_forces_string_type(monkeypatch):
+    monkeypatch.setenv("VALUE", '"123"')
+
+    result = _expand_env_vars({"value": "${VALUE}"})
+
+    assert result["value"] == "123"
+    assert isinstance(result["value"], str)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "yes",
+        "no",
+        "on",
+        "off",
+        "2026-08-03",
+        "0123",
+        "00123",
+        "NaN",
+        "Infinity",
+        "-Infinity",
+        '{"threshold": NaN}',
+    ],
+)
+def test_expand_env_vars_preserves_non_json_yaml_scalars(monkeypatch, value):
+    monkeypatch.setenv("VALUE", value)
+
+    result = _expand_env_vars({"value": "${VALUE}"})
+
+    assert result["value"] == value
+    assert isinstance(result["value"], str)
+
+
 def test_expand_env_vars_type_coercion_default_with_type(monkeypatch):
     monkeypatch.delenv("PREFETCH", raising=False)
     result = _expand_env_vars({"prefetch": "${PREFETCH:-5}"})
@@ -302,6 +336,16 @@ def test_expand_env_vars_mixed_string_preserved(monkeypatch):
     assert isinstance(result["dsn"], str)
 
 
+def test_expand_env_vars_multiple_references_preserved(monkeypatch):
+    monkeypatch.setenv("MAJOR", "1")
+    monkeypatch.setenv("MINOR", "2")
+
+    result = _expand_env_vars({"version": "${MAJOR}${MINOR}"})
+
+    assert result["version"] == "12"
+    assert isinstance(result["version"], str)
+
+
 def test_expand_env_vars_non_string_values_unchanged(monkeypatch):
     result = _expand_env_vars({"count": 5, "enabled": True, "ratio": 3.14})
     assert result["count"] == 5
@@ -317,7 +361,7 @@ def test_expand_env_vars_recursive(monkeypatch):
         "tasks": [{"config": {"key": "${B}"}}],
     }
     result = _expand_env_vars(config)
-    # Pure ${VAR} references are YAML-coerced: "1" → 1 (int)
+    # Pure ${VAR} references decode JSON literals: "1" -> 1 (int).
     assert result["app"]["name"] == 1
     assert isinstance(result["app"]["name"], int)
     assert result["tasks"][0]["config"]["key"] == 2
@@ -327,6 +371,18 @@ def test_expand_env_vars_recursive(monkeypatch):
 # ---------------------------------------------------------------------------
 # load_yaml_app with env_file
 # ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("app_name", ["yes", "off", "2026-08-03", "0123"])
+def test_load_yaml_app_preserves_string_env_name(tmp_path, monkeypatch, app_name):
+    pytest.importorskip("yaml")
+    monkeypatch.setenv("APP_NAME", app_name)
+    config_path = tmp_path / "app.yaml"
+    config_path.write_text("name: ${APP_NAME}\ntasks: []\n", encoding="utf-8")
+
+    app = load_yaml_app(str(config_path))
+
+    assert app.name == app_name
+
 
 def test_load_yaml_app_with_env_file(tmp_path, monkeypatch):
     env_file = tmp_path / "test.env"


### PR DESCRIPTION
## Problem

When a YAML config uses `${VAR}` for environment variable substitution, the result is always a string, even when the variable contains a typed value:

```yaml
prefetch: ${POSITION_AGENT_ONESTEP_PREFETCH}
persistent: ${POSITION_AGENT_ONESTEP_PERSISTENT}
engine_options: ${POSITION_SINK_ONESTEP_MYSQL_ENGINE_OPTIONS}
```

Users previously needed runtime monkey patches to turn those values into integers, booleans, lists, or mappings.

## Solution

When a string value is exactly one `${VAR}` reference, the expanded value is decoded as a strict JSON literal:

| Environment value | Result | Type |
|---|---|---|
| `5` | `5` | `int` |
| `true` | `True` | `bool` |
| `3.14` | `3.14` | `float` |
| `{"a": 1}` | `{"a": 1}` | `dict` |
| `[1, 2, 3]` | `[1, 2, 3]` | `list` |
| `hello` | `"hello"` | `str` |
| `"123"` | `"123"` | `str` |

Strict JSON decoding avoids PyYAML's implicit conversion of ordinary strings such as `yes`, `off`, `2026-08-03`, and `0123`. JSON `null` and non-standard constants such as `NaN` and `Infinity` also remain strings.

Mixed strings such as `mysql://${HOST}:3306/db` and multiple references such as `${MAJOR}${MINOR}` remain strings. Defaults still support typed values: `${PREFETCH:-5}` becomes integer `5` and `${ENABLED:-true}` becomes boolean `True`.

## Changes

- Decode typed values with strict JSON semantics.
- Require a full regex match before treating a value as a pure environment reference.
- Preserve YAML-specific scalars, ISO dates, leading-zero identifiers, null, and non-finite values as strings.
- Add regression coverage through both `_expand_env_vars()` and real `load_yaml_app()` calls.

## Test plan

- [x] `uv run pytest -q tests/test_config_env.py` (`71 passed`)
- [x] `uv run pytest -q -m "not integration"` (`394 passed`)
- [x] `git diff --check origin/main...HEAD`

No control-plane protocol or reporter payload changes are included.
