### PR TITLE
v0.2.3a1 fix(rabbitmq): use basic.consume for source delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-## onestep-mq 0.2.3
+## onestep-mq 0.2.3a1
 
 - Uses RabbitMQ `basic.consume` push delivery with a prefetch-bounded buffer instead of per-message `basic.get` polling, while preserving batching, acknowledgement, retry, and cancellation semantics.
+- Alpha pre-release for limited-batch rollout. Start with a small number of workers or task instances and expand only after validating latency, throughput, unacked messages, requeue behavior, reconnect stability, and duplicate-delivery handling.
 
 ## onestep-mysql 0.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## onestep-mq 0.2.3
+
+- Uses RabbitMQ `basic.consume` push delivery with a prefetch-bounded buffer instead of per-message `basic.get` polling, while preserving batching, acknowledgement, retry, and cancellation semantics.
+
 ## onestep-mysql 0.3.5
 
 - Preserves the original MySQL exception as the cause of raised connector operation errors so root-cause messages such as invalid datetime values are visible in tracebacks.

--- a/plugins/onestep-rabbitmq/pyproject.toml
+++ b/plugins/onestep-rabbitmq/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-mq"
-version = "0.2.3"
+version = "0.2.3a1"
 description = "RabbitMQ connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-rabbitmq/pyproject.toml
+++ b/plugins/onestep-rabbitmq/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-mq"
-version = "0.2.2"
+version = "0.2.3"
 description = "RabbitMQ connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-rabbitmq/src/onestep_rabbitmq/connector.py
+++ b/plugins/onestep-rabbitmq/src/onestep_rabbitmq/connector.py
@@ -26,6 +26,9 @@ class RabbitMQDelivery(Delivery):
     async def ack(self) -> None:
         await self._message.ack()
 
+    async def release_unstarted(self) -> None:
+        await self._message.nack(requeue=True)
+
     async def retry(self, *, delay_s: float | None = None) -> None:
         if delay_s:
             await asyncio.sleep(delay_s)
@@ -179,6 +182,11 @@ class RabbitMQQueue(Source, Sink):
         self._publish_channel: Any | None = None
         self._queue: Any | None = None
         self._exchange: Any | None = None
+        self._consumer_tag: str | None = None
+        self._consumer_messages: asyncio.Queue[Any] | None = None
+        self._consumer_lock: asyncio.Lock | None = None
+        self._consumer_loop: asyncio.AbstractEventLoop | None = None
+        self._consumer_accepting = False
         self._opened = False
 
     def _connection_secrets(self) -> list[str]:
@@ -193,6 +201,7 @@ class RabbitMQQueue(Source, Sink):
             connection = await self.connector.acquire()
             acquired = True
             self._receive_channel = await connection.channel()
+            self._receive_channel.close_callbacks.add(self._on_receive_channel_closed)
             await self._receive_channel.set_qos(prefetch_count=self.prefetch)
             self._publish_channel = await connection.channel(publisher_confirms=self.publisher_confirms)
             self._queue = await self._receive_channel.declare_queue(
@@ -244,16 +253,12 @@ class RabbitMQQueue(Source, Sink):
         if not self._opened:
             return
         try:
-            if self._publish_channel is not None:
-                await self._publish_channel.close()
-            if self._receive_channel is not None:
-                await self._receive_channel.close()
+            try:
+                await self._cancel_consumer()
+            finally:
+                await self._close_channels()
         finally:
-            self._publish_channel = None
-            self._receive_channel = None
-            self._queue = None
-            self._exchange = None
-            self._opened = False
+            self._clear_transport_state()
             await self.connector.release()
 
     async def fetch(self, limit: int) -> list[Delivery]:
@@ -261,18 +266,21 @@ class RabbitMQQueue(Source, Sink):
             await self.open()
             if self._queue is None:
                 return []
+            messages = await self._ensure_consumer()
             deliveries: list[Delivery] = []
             fetch_limit = max(1, min(limit, self.batch_size))
-            for index in range(fetch_limit):
-                timeout = self.poll_interval_s if index == 0 else 0
+            message = await messages.get()
+            deliveries.append(RabbitMQDelivery(message))
+            while len(deliveries) < fetch_limit:
                 try:
-                    message = await self._queue.get(fail=False, timeout=timeout)
-                except asyncio.TimeoutError:
-                    break
-                if message is None:
+                    message = messages.get_nowait()
+                except asyncio.QueueEmpty:
                     break
                 deliveries.append(RabbitMQDelivery(message))
             return deliveries
+        except asyncio.CancelledError:
+            await self._reset_transport_state(release_connection=True)
+            raise
         except ConnectorOperationError:
             raise
         except Exception as exc:
@@ -287,6 +295,76 @@ class RabbitMQQueue(Source, Sink):
                 raise
             await self._reset_transport_state(release_connection=True)
             raise connector_error from None
+
+    async def _ensure_consumer(self) -> asyncio.Queue[Any]:
+        messages, lock = self._ensure_consumer_state()
+        if self._consumer_tag is not None:
+            return messages
+        async with lock:
+            if self._consumer_tag is None:
+                if self._queue is None:
+                    raise RuntimeError("RabbitMQ queue is not open")
+                self._consumer_accepting = True
+                try:
+                    self._consumer_tag = await self._queue.consume(self._on_message)
+                except BaseException:
+                    self._consumer_accepting = False
+                    raise
+        return messages
+
+    def _ensure_consumer_state(self) -> tuple[asyncio.Queue[Any], asyncio.Lock]:
+        current_loop = asyncio.get_running_loop()
+        if self._consumer_loop is not current_loop:
+            maxsize = self.prefetch if self.prefetch > 0 else 0
+            self._consumer_messages = asyncio.Queue(maxsize=maxsize)
+            self._consumer_lock = asyncio.Lock()
+            self._consumer_loop = current_loop
+        assert self._consumer_messages is not None
+        assert self._consumer_lock is not None
+        return self._consumer_messages, self._consumer_lock
+
+    async def _on_message(self, message: Any) -> None:
+        if not self._consumer_accepting:
+            await message.nack(requeue=True)
+            return
+        messages, _ = self._ensure_consumer_state()
+        try:
+            messages.put_nowait(message)
+        except asyncio.QueueFull:
+            await message.nack(requeue=True)
+
+    async def _on_receive_channel_closed(
+        self, _channel: Any, _exc: BaseException | None
+    ) -> None:
+        if self._consumer_messages is None:
+            return
+        while not self._consumer_messages.empty():
+            self._consumer_messages.get_nowait()
+
+    async def _cancel_consumer(self) -> None:
+        self._consumer_accepting = False
+        consumer_tag = self._consumer_tag
+        self._consumer_tag = None
+        try:
+            if consumer_tag is not None and self._queue is not None:
+                await self._queue.cancel(consumer_tag)
+        finally:
+            await self._requeue_buffered_messages()
+
+    async def _requeue_buffered_messages(self) -> None:
+        if self._consumer_messages is None:
+            return
+        while not self._consumer_messages.empty():
+            message = self._consumer_messages.get_nowait()
+            await message.nack(requeue=True)
+
+    async def _close_channels(self) -> None:
+        try:
+            if self._publish_channel is not None:
+                await self._publish_channel.close()
+        finally:
+            if self._receive_channel is not None:
+                await self._receive_channel.close()
 
     async def send(self, envelope: Envelope) -> None:
         try:
@@ -320,17 +398,25 @@ class RabbitMQQueue(Source, Sink):
 
     async def _reset_transport_state(self, *, release_connection: bool) -> None:
         try:
-            if self._publish_channel is not None:
-                await self._publish_channel.close()
-            if self._receive_channel is not None:
-                await self._receive_channel.close()
+            try:
+                await self._cancel_consumer()
+            finally:
+                await self._close_channels()
         except Exception:
             pass
         finally:
-            self._publish_channel = None
-            self._receive_channel = None
-            self._queue = None
-            self._exchange = None
-            self._opened = False
+            self._clear_transport_state()
             if release_connection:
                 await self.connector.release()
+
+    def _clear_transport_state(self) -> None:
+        self._publish_channel = None
+        self._receive_channel = None
+        self._queue = None
+        self._exchange = None
+        self._consumer_tag = None
+        self._consumer_messages = None
+        self._consumer_lock = None
+        self._consumer_loop = None
+        self._consumer_accepting = False
+        self._opened = False

--- a/plugins/onestep-rabbitmq/tests/integration/test_rabbitmq_live.py
+++ b/plugins/onestep-rabbitmq/tests/integration/test_rabbitmq_live.py
@@ -11,14 +11,22 @@ if not os.getenv("ONESTEP_RABBITMQ_URL"):
     pytest.skip("set ONESTEP_RABBITMQ_URL to run RabbitMQ integration tests", allow_module_level=True)
 
 
+async def wait_for_consumer(queue):
+    while queue._consumer_tag is None:
+        await asyncio.sleep(0)
+
+
 @pytest.mark.integration
 def test_rabbitmq_round_trip_live():
     async def scenario():
         connector = RabbitMQConnector(os.environ["ONESTEP_RABBITMQ_URL"])
         queue_name = f"{os.getenv('ONESTEP_RABBITMQ_QUEUE', 'onestep.integration')}.{uuid.uuid4().hex}"
-        queue = connector.queue(queue_name, poll_interval_s=1.0, auto_delete=True, durable=False, exclusive=True)
+        queue = connector.queue(queue_name, poll_interval_s=10.0, auto_delete=True, durable=False, exclusive=True)
+        waiting_fetch = asyncio.create_task(queue.fetch(1))
+        await asyncio.wait_for(wait_for_consumer(queue), timeout=1.0)
+
         await queue.publish({"value": 1})
-        batch = await queue.fetch(1)
+        batch = await asyncio.wait_for(waiting_fetch, timeout=1.0)
         assert len(batch) == 1
         assert batch[0].payload == {"value": 1}
         await batch[0].ack()

--- a/plugins/onestep-rabbitmq/tests/test_rabbitmq_connector.py
+++ b/plugins/onestep-rabbitmq/tests/test_rabbitmq_connector.py
@@ -20,7 +20,7 @@ class FakeIncomingMessage:
     async def nack(self, requeue=True):
         self.nacked = requeue
         if requeue:
-            self._queue.messages.append(FakeIncomingMessage(self._queue, self.body))
+            self._queue.put(FakeIncomingMessage(self._queue, self.body))
 
     async def reject(self, requeue=False):
         self.rejected = not requeue
@@ -31,17 +31,40 @@ class FakeQueue:
         self.name = name
         self.messages = []
         self.bindings = []
+        self.consumer_callback = None
+        self.consumer_tag = None
+        self.consume_calls = 0
+        self.cancelled_consumer_tags = []
+        self.cancel_error = None
         self.durable = None
         self.auto_delete = None
         self.exclusive = None
         self.arguments = None
 
     async def get(self, fail=False, timeout=None):
-        if self.messages:
-            return self.messages.pop(0)
-        if timeout and timeout > 0:
-            raise asyncio.TimeoutError
-        return None
+        raise AssertionError("RabbitMQ sources must use basic.consume, not basic.get")
+
+    async def consume(self, callback):
+        self.consume_calls += 1
+        self.consumer_callback = callback
+        self.consumer_tag = f"consumer-{self.consume_calls}"
+        pending, self.messages = self.messages, []
+        for message in pending:
+            asyncio.create_task(callback(message))
+        return self.consumer_tag
+
+    async def cancel(self, consumer_tag):
+        self.cancelled_consumer_tags.append(consumer_tag)
+        if self.cancel_error is not None:
+            raise self.cancel_error
+        self.consumer_callback = None
+        self.consumer_tag = None
+
+    def put(self, message):
+        if self.consumer_callback is None:
+            self.messages.append(message)
+            return
+        asyncio.create_task(self.consumer_callback(message))
 
     async def bind(self, exchange, routing_key=None, arguments=None, timeout=None):
         self.bindings.append(
@@ -63,12 +86,12 @@ class FakeExchange:
         self.published.append((message, routing_key))
         if self.name == "__default__":
             queue = self.queue_registry.setdefault(routing_key, FakeQueue(routing_key))
-            queue.messages.append(FakeIncomingMessage(queue, message.body))
+            queue.put(FakeIncomingMessage(queue, message.body))
             return
         for queue in self.queue_registry.values():
             for binding in queue.bindings:
                 if binding["exchange"] is self and binding["routing_key"] == routing_key:
-                    queue.messages.append(FakeIncomingMessage(queue, message.body))
+                    queue.put(FakeIncomingMessage(queue, message.body))
 
 
 class FakeChannel:
@@ -76,6 +99,7 @@ class FakeChannel:
         self.queue_registry = queue_registry
         self.exchange_registry = exchange_registry
         self.default_exchange = FakeExchange("__default__", queue_registry)
+        self.close_callbacks = FakeCallbackCollection(self)
         self.prefetch_count = None
         self.closed = False
 
@@ -103,6 +127,20 @@ class FakeChannel:
 
     async def close(self):
         self.closed = True
+        await self.close_callbacks(None)
+
+
+class FakeCallbackCollection:
+    def __init__(self, sender):
+        self.sender = sender
+        self.callbacks = []
+
+    def add(self, callback):
+        self.callbacks.append(callback)
+
+    async def __call__(self, exc):
+        for callback in self.callbacks:
+            await callback(self.sender, exc)
 
 
 class FakeConnection:
@@ -129,6 +167,11 @@ class FakeMessage:
 
 async def fake_connect_robust(url, **kwargs):
     return FakeConnection()
+
+
+async def wait_for_consumer(queue):
+    while queue._consumer_tag is None:
+        await asyncio.sleep(0)
 
 
 def test_rabbitmq_queue_send_fetch_retry_fail_and_exchange_binding(monkeypatch):
@@ -190,6 +233,132 @@ def test_rabbitmq_queue_send_fetch_retry_fail_and_exchange_binding(monkeypatch):
 
         await events.close()
         await queue.close()
+        await connector.close()
+
+    asyncio.run(scenario())
+
+
+def test_rabbitmq_fetch_uses_one_long_lived_consumer(monkeypatch):
+    fake_driver = SimpleNamespace(
+        connect_robust=fake_connect_robust,
+        Message=FakeMessage,
+        DeliveryMode=SimpleNamespace(PERSISTENT="persistent"),
+    )
+    monkeypatch.setattr(rabbitmq_module, "aio_pika", fake_driver)
+
+    async def scenario():
+        connector = RabbitMQConnector("amqp://guest:guest@localhost/")
+        queue = connector.queue("jobs", prefetch=5, batch_size=3, poll_interval_s=0.5)
+
+        waiting_fetch = asyncio.create_task(queue.fetch(3))
+
+        async def wait_for_consumer():
+            while queue._queue is None or queue._queue.consume_calls == 0:
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(wait_for_consumer(), timeout=0.1)
+        broker_queue = queue._queue
+
+        await queue.publish({"value": 1})
+        first_batch = await asyncio.wait_for(waiting_fetch, timeout=0.1)
+        assert [delivery.payload for delivery in first_batch] == [{"value": 1}]
+        await first_batch[0].release_unstarted()
+        released = await queue.fetch(1)
+        assert [delivery.payload for delivery in released] == [{"value": 1}]
+        await released[0].ack()
+
+        await queue.publish({"value": 2})
+        await queue.publish({"value": 3})
+        second_batch = await queue.fetch(3)
+        assert [delivery.payload for delivery in second_batch] == [
+            {"value": 2},
+            {"value": 3},
+        ]
+        assert broker_queue.consume_calls == 1
+
+        await queue.close()
+        assert broker_queue.cancelled_consumer_tags == ["consumer-1"]
+        await connector.close()
+
+    asyncio.run(scenario())
+
+
+def test_rabbitmq_empty_fetch_is_cancel_safe(monkeypatch):
+    fake_driver = SimpleNamespace(
+        connect_robust=fake_connect_robust,
+        Message=FakeMessage,
+        DeliveryMode=SimpleNamespace(PERSISTENT="persistent"),
+    )
+    monkeypatch.setattr(rabbitmq_module, "aio_pika", fake_driver)
+
+    async def scenario():
+        connector = RabbitMQConnector("amqp://guest:guest@localhost/")
+        queue = connector.queue("jobs", poll_interval_s=10.0)
+
+        fetch = asyncio.create_task(queue.fetch(1))
+        await asyncio.wait_for(wait_for_consumer(queue), timeout=0.1)
+        broker_queue = queue._queue
+        fetch.cancel()
+        await asyncio.gather(fetch, return_exceptions=True)
+
+        assert fetch.cancelled()
+        assert queue._consumer_tag is None
+        assert broker_queue.cancelled_consumer_tags == ["consumer-1"]
+        assert queue._opened is False
+        assert connector._ref_count == 0
+        await queue.close()
+        await connector.close()
+
+    asyncio.run(scenario())
+
+
+def test_rabbitmq_discards_stale_buffer_when_receive_channel_closes(monkeypatch):
+    fake_driver = SimpleNamespace(
+        connect_robust=fake_connect_robust,
+        Message=FakeMessage,
+        DeliveryMode=SimpleNamespace(PERSISTENT="persistent"),
+    )
+    monkeypatch.setattr(rabbitmq_module, "aio_pika", fake_driver)
+
+    async def scenario():
+        connector = RabbitMQConnector("amqp://guest:guest@localhost/")
+        queue = connector.queue("jobs")
+        await queue.open()
+        messages, _ = queue._ensure_consumer_state()
+        broker_queue = queue._queue
+        messages.put_nowait(FakeIncomingMessage(broker_queue, b"stale"))
+
+        await queue._receive_channel.close_callbacks(ConnectionError("closed"))
+
+        assert messages.empty()
+        await queue.close()
+        await connector.close()
+
+    asyncio.run(scenario())
+
+
+def test_rabbitmq_cancel_failure_resets_transport(monkeypatch):
+    fake_driver = SimpleNamespace(
+        connect_robust=fake_connect_robust,
+        Message=FakeMessage,
+        DeliveryMode=SimpleNamespace(PERSISTENT="persistent"),
+    )
+    monkeypatch.setattr(rabbitmq_module, "aio_pika", fake_driver)
+
+    async def scenario():
+        connector = RabbitMQConnector("amqp://guest:guest@localhost/")
+        queue = connector.queue("jobs")
+        fetch = asyncio.create_task(queue.fetch(1))
+        await asyncio.wait_for(wait_for_consumer(queue), timeout=0.1)
+        queue._queue.cancel_error = ConnectionError("connection closed")
+
+        fetch.cancel()
+        await asyncio.gather(fetch, return_exceptions=True)
+
+        assert fetch.cancelled()
+        assert queue._opened is False
+        assert queue._receive_channel is None
+        assert connector._ref_count == 0
         await connector.close()
 
     asyncio.run(scenario())

--- a/uv.lock
+++ b/uv.lock
@@ -1591,7 +1591,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-mq"
-version = "0.2.3"
+version = "0.2.3a1"
 source = { editable = "plugins/onestep-rabbitmq" }
 dependencies = [
     { name = "aio-pika", version = "9.5.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1591,7 +1591,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-mq"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "plugins/onestep-rabbitmq" }
 dependencies = [
     { name = "aio-pika", version = "9.5.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Problem

`RabbitMQQueue.fetch()` used `aio-pika Queue.get()`, which issues one AMQP `basic.get` RPC per message. Empty queues also incurred polling delay, increasing latency and reducing throughput in high-volume workloads.

## Solution

- Register one long-lived `basic.consume` consumer per opened source.
- Buffer deliveries locally with a queue bounded by `prefetch`.
- Preserve `fetch(limit)` batching, ack/retry/fail behavior, and connector error normalization.
- Requeue buffered/unstarted messages on cancellation and discard stale messages when a receive channel closes.
- Release `onestep-mq` as `0.2.3a1`, an alpha pre-release for limited-batch validation.

## Rollout plan

This is intentionally an alpha release. Roll it out to a small number of workers or task instances first; do not upgrade the full fleet immediately. During the first batch, monitor:

- delivery latency and throughput
- unacked message counts and consumer prefetch behavior
- requeue rates and reconnect recovery
- duplicate deliveries and acknowledgement/retry/fail outcomes

Expand the rollout only after the first batch remains stable under representative load.

## Verification

- `uv lock --check`
- `./scripts/run-reliability-checks.sh`
- `uv run pytest -q plugins/onestep-rabbitmq/tests tests/contract/test_official_connector_conformance.py`
- Live RabbitMQ integration: `2 passed`
- `git diff --check` and Python `compileall`

The live test uses `poll_interval_s=10s` and confirms a waiting fetch is awakened by a published message within 1s, demonstrating push delivery rather than polling.
