### PR TITLE
feat(feishu): resolve Bitable relations declaratively

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -91,7 +91,7 @@ jobs:
     needs:
       - detect
       - build
-    if: needs.detect.outputs.has_docs == 'true'
+    if: needs.detect.outputs.has_docs == 'true' && github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@
   each child creates its own pool, while externally supplied connectors are rejected
   when reused across a process boundary.
 
+## onestep-feishu-bitable 0.2.0
+
+- Adds declarative Table Sink `relations` that resolve one or many business keys
+  to Feishu related-record IDs before create, update, or upsert.
+- Supports `error`, `empty`, and `create` behavior for missing related records,
+  including create-and-link, cross-Base relation lookups, and per-Sink
+  single-flight protection for concurrent creates.
+- Adds strict YAML validation, safe control-plane relation descriptors, and
+  documentation for multi-record relations and multi-process creation limits.
+
 ## onestep 1.9.0
 
 - Adds the `ExecutionClient`, immutable execution snapshots, typed result

--- a/docs/broker/feishu-bitable.md
+++ b/docs/broker/feishu-bitable.md
@@ -122,6 +122,76 @@ async def map_order_fields(ctx, payload):
 
 `feishu_bitable_user("u_xxx")` 会返回飞书人员字段需要的 `[{"id": "u_xxx"}]` 结构。`user_id_type` 需要和你提供的人员 ID 类型一致。
 
+## 关联字段
+
+Table Sink 可以用 `relations` 把上游业务键解析成飞书关联字段需要的 `record_id`。例如企业表按“企业名称”唯一标识企业，项目表的“关联企业”允许关联多个企业：
+
+```yaml
+resources:
+  projects:
+    type: feishu_bitable_table_sink
+    connector: feishu
+    app_token: "${FEISHU_APP_TOKEN}"
+    table_id: "${PROJECT_TABLE_ID}"
+    mode: upsert
+    match_fields: [项目编号]
+    relations:
+      关联企业:
+        from: 企业名称
+        table_id: "${ENTERPRISE_TABLE_ID}"
+        key: 企业名称
+        on_missing: create
+        create_fields:
+          数据状态: 待完善
+```
+
+handler 不需要查询企业表，继续返回业务值：
+
+```python
+async def map_project(ctx, payload):
+    return {
+        "项目编号": payload["项目编号"],
+        "项目名称": payload["项目名称"],
+        "企业名称": ["企业A", "企业B", "企业C"],
+    }
+```
+
+Sink 会按企业名称逐项查询，把项目请求转换为：
+
+```python
+{
+    "项目编号": "P-001",
+    "项目名称": "联合建设项目",
+    "关联企业": ["rec_a", "rec_b", "rec_c"],
+}
+```
+
+输入也可以是单个字符串。字符串解析成一个 ID，list 或 tuple 逐项解析；空值被忽略，重复值按第一次出现的顺序去重。`from` 省略时从关联字段本身读取业务值。
+
+`on_missing` 支持三种策略：
+
+| 策略 | 未找到关联记录时的行为 |
+|---|---|
+| `error` | 默认值；任意非空值未找到时整条目标记录失败 |
+| `empty` | 跳过未找到的值；全部未找到时写 `[]`，更新已有记录时会清空旧关联 |
+| `create` | 用 `key` 和 `create_fields` 创建缺失记录，并把新 ID 写入当前关联字段 |
+
+`key` 必须在关联表中保持业务唯一。命中多条记录时 Sink 会失败，不会随机选择。`create` 在同一个 Sink 实例内会避免并发重复创建，但多个 worker 进程或部署实例之间没有全局原子去重保证。
+
+关联表默认与目标表使用相同 `app_token`。跨多维表 Base 关联时，在关系配置中增加 `app_token`：
+
+```yaml
+relations:
+  关联企业:
+    from: 企业名称
+    app_token: "${ENTERPRISE_FEISHU_APP_TOKEN}"
+    table_id: "${ENTERPRISE_TABLE_ID}"
+    key: 企业名称
+    on_missing: error
+```
+
+飞书双向关联的反向字段仍由飞书服务端根据字段配置维护，插件只写当前目标表的关联字段。
+
 ## 重要参数
 
 | 参数 | 说明 |
@@ -131,6 +201,7 @@ async def map_order_fields(ctx, payload):
 | `batch_size` | 每次拉取的最大记录数 |
 | `fallback_scan_page_limit` | 飞书拒绝游标排序时，本地 fallback 扫描最多读取的页数，默认 `100` |
 | `user_id_type` | 人员字段使用的 ID 类型，例如 `open_id`、`union_id`、`user_id` |
+| `relations` | 将业务键解析为关联记录 ID 的字段级 mapping |
 
 `fallback_scan_page_limit` 是防护阀。只有确认表规模和调用配额允许 fallback 扫描时，才提高这个值。
 

--- a/docs/superpowers/plans/2026-08-14-feishu-bitable-relation-resolver.md
+++ b/docs/superpowers/plans/2026-08-14-feishu-bitable-relation-resolver.md
@@ -1,0 +1,221 @@
+# Feishu Bitable Relation Resolver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Add declarative Feishu Bitable relation resolution so table sinks can map one or many business keys to related record IDs, leave missing values empty, or create missing records and write their IDs back.
+
+**Architecture:** Extend the existing FeishuBitableTableSink with normalized immutable relation configurations and a write-time resolution phase. Keep YAML/catalog parsing in resources.py, reuse the connector's existing search/create methods and ConnectorOperationError model, and serialize only safe relation metadata in descriptors.
+
+**Tech Stack:** Python 3.10+, asyncio, onestep Source/Sink APIs, Feishu Bitable HTTP API, pytest, YAML resource registry.
+
+---
+
+### Task 1: Relation configuration contract
+
+**Files:**
+- Modify: plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+- Test: plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
+
+- [ ] **Step 1: Write failing Python API validation tests**
+
+Add tests that construct a sink with a valid relation mapping and assert its normalized fields. Add parametrized invalid cases for an empty relations mapping, unknown relation fields, missing table_id/key, invalid on_missing, create_fields outside create, create_fields containing key, and conflicts with match_fields.
+
+~~~python
+sink = connector.table_sink(
+    app_token="project-app",
+    table_id="projects",
+    mode="upsert",
+    match_fields=["project_id"],
+    relations={
+        "companies": {
+            "from": "company_names",
+            "table_id": "companies",
+            "key": "name",
+            "on_missing": "create",
+        }
+    },
+)
+assert sink.relations[0].target_field == "companies"
+~~~
+
+- [ ] **Step 2: Run validation tests and verify they fail**
+
+Run:
+
+~~~bash
+uv run --all-packages pytest -q plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py -k relation_config
+~~~
+
+Expected: failures because table_sink does not accept relations.
+
+- [ ] **Step 3: Add normalized immutable relation configuration**
+
+Add _FeishuRelationConfig and _normalize_relations(). Extend FeishuBitableConnector.table_sink() and FeishuBitableTableSink.__init__() with relations: Mapping[str, Mapping[str, Any]] | None. Normalize defaults, reject conflicts, copy create_fields, and leave relations as an empty tuple when omitted.
+
+- [ ] **Step 4: Run validation tests and existing sink tests**
+
+Run:
+
+~~~bash
+uv run --all-packages pytest -q plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py -k "relation_config or table_sink"
+~~~
+
+Expected: all selected tests pass.
+
+### Task 2: Single and multi-value relation resolution
+
+**Files:**
+- Modify: plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+- Test: plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
+
+- [ ] **Step 1: Write failing resolution behavior tests**
+
+Cover scalar and three-value inputs, first-seen deduplication, empty inputs, invalid input types, duplicate related records, error missing behavior, empty partial matches, shared from fields, input immutability, and removal of consumed from aliases.
+
+~~~python
+await sink.send(
+    Envelope(
+        body={
+            "project_id": "P-001",
+            "company_names": ["A", "B", "A", "C"],
+        }
+    )
+)
+assert created_project["fields"]["companies"] == ["rec-a", "rec-b", "rec-c"]
+assert "company_names" not in created_project["fields"]
+~~~
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+~~~bash
+uv run --all-packages pytest -q plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py -k relation_resolution
+~~~
+
+Expected: failures because send() still forwards fields unchanged.
+
+- [ ] **Step 3: Implement relation resolution before target matching**
+
+Add helpers that normalize values to ordered unique strings, query with page_size=2, apply error/empty behavior, and return a copied fields mapping with source aliases removed only after all relations resolve. Preserve ConnectorOperationError and wrap payload errors as permanent SEND failures through the existing send() boundary.
+
+- [ ] **Step 4: Run focused resolution and regression tests**
+
+Run:
+
+~~~bash
+uv run --all-packages pytest -q plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py -k "relation_resolution or table_sink"
+~~~
+
+Expected: all selected tests pass.
+
+### Task 3: Create-on-missing, cross-Base routing, and single-flight
+
+**Files:**
+- Modify: plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+- Test: plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
+
+- [ ] **Step 1: Write failing create behavior tests**
+
+Cover creation of one and several missing records, merging found and created IDs in input order, static create_fields, relation app_token overrides, partial create failures that do not write the project, retry after a prior partial create, and two concurrent sends that create the same business value once.
+
+~~~python
+await asyncio.gather(
+    sink.send(Envelope(body={"project_id": "P-1", "company_names": ["A"]})),
+    sink.send(Envelope(body={"project_id": "P-2", "company_names": ["A"]})),
+)
+assert created_company_names == ["A"]
+~~~
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+~~~bash
+uv run --all-packages pytest -q plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py -k relation_create
+~~~
+
+Expected: failures because create-on-missing and relation locks do not exist.
+
+- [ ] **Step 3: Implement create-on-missing and per-value locks**
+
+Add lazy asyncio lock storage on each sink. For create, acquire a lock keyed by app_token/table_id/key/value, query again inside the lock, create only when still missing, extract the created record ID from the Feishu response, and remove idle lock entries safely. Use the relation app_token for search/create and the sink user_id_type consistently.
+
+- [ ] **Step 4: Run create, resolution, and transport tests**
+
+Run:
+
+~~~bash
+uv run --all-packages pytest -q plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py -k "relation_create or relation_resolution or http_error"
+~~~
+
+Expected: all selected tests pass.
+
+### Task 4: YAML, catalog, and descriptor integration
+
+**Files:**
+- Modify: plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/resources.py
+- Modify: plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+- Test: plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
+- Test: plugins/onestep-feishu-bitable/tests/test_feishu_bitable_plugin.py
+
+- [ ] **Step 1: Write failing strict YAML, catalog, and descriptor tests**
+
+Add a valid YAML sink with multiple relations and invalid nested cases matching the Python contract. Assert the resource catalog exposes relations as mapping. Assert descriptor output contains safe relation metadata but no sink or relation app token and no create_fields values.
+
+- [ ] **Step 2: Run focused integration tests and verify they fail**
+
+Run:
+
+~~~bash
+uv run --all-packages pytest -q plugins/onestep-feishu-bitable/tests -k "yaml and relation or catalog or descriptor"
+~~~
+
+Expected: failures because relations is not an allowed resource field.
+
+- [ ] **Step 3: Implement resource and descriptor support**
+
+Add relations to allowed fields and catalog, validate nested relation mappings in strict mode using the same field names and policies, pass relations to table_sink(), and serialize only target_field/from/table_id/key/on_missing/create_field_names/uses_custom_app_token.
+
+- [ ] **Step 4: Run plugin tests**
+
+Run:
+
+~~~bash
+uv run --all-packages pytest -q plugins/onestep-feishu-bitable/tests
+~~~
+
+Expected: the entire plugin suite passes.
+
+### Task 5: Documentation, release metadata, and final validation
+
+**Files:**
+- Modify: docs/broker/feishu-bitable.md
+- Modify: plugins/onestep-feishu-bitable/README.md
+- Modify: plugins/onestep-feishu-bitable/pyproject.toml
+- Modify: CHANGELOG.md or the repository's current plugin release metadata file if required by existing convention
+
+- [ ] **Step 1: Document the supported configuration and operational limits**
+
+Add the enterprise/project YAML example, scalar and list handler payloads, error/empty/create semantics, key uniqueness requirement, cross-Base app_token option, and the multi-process create race limitation. Keep README to a minimal example and link to the full documentation.
+
+- [ ] **Step 2: Update plugin release metadata using repository conventions**
+
+Inspect the latest Feishu plugin release commit and bump the plugin minor version because this adds a backward-compatible public capability. Update only the metadata files that convention requires.
+
+- [ ] **Step 3: Run formatting and focused full validation**
+
+Run:
+
+~~~bash
+uv run --all-packages pytest -q plugins/onestep-feishu-bitable/tests
+uv build --package onestep-feishu-bitable --out-dir dist/plugin --sdist --wheel --clear
+uvx twine check dist/plugin/*
+git diff --check
+~~~
+
+Expected: tests pass, wheel and sdist build, twine reports both distributions valid, and git diff has no whitespace errors.
+
+- [ ] **Step 4: Review the final diff against the design spec**
+
+Verify every changed line maps to relations behavior, configuration, tests, docs, or release metadata. Confirm existing untracked files remain untouched and no credentials or app tokens appear in descriptors, errors, tests, or documentation.

--- a/docs/superpowers/specs/2026-08-14-feishu-bitable-relation-resolver-design.md
+++ b/docs/superpowers/specs/2026-08-14-feishu-bitable-relation-resolver-design.md
@@ -1,0 +1,363 @@
+# Feishu Bitable 关联字段解析设计
+
+## 背景
+
+onestep-feishu-bitable 的 Table Sink 当前将 handler 返回的字段原样写入飞书。这适合
+文本、数字和已经编码完成的人员字段，但飞书关联字段要求写入被关联表的 record_id。
+业务上游通常只有企业名称、企业编码等业务键，不知道飞书记录 ID。
+
+例如，项目上游数据是：
+
+~~~python
+{
+    "项目编号": "P-001",
+    "项目名称": "联合建设项目",
+    "企业名称": ["企业A", "企业B", "企业C"],
+}
+~~~
+
+项目表的“关联企业”字段实际需要：
+
+~~~python
+{"关联企业": ["rec_a", "rec_b", "rec_c"]}
+~~~
+
+如果每个 handler 都自行查询企业表、处理零条或重复匹配、创建缺失企业并转换
+record_id，相同逻辑会散落在业务代码中，错误与重试语义也难以保持一致。
+
+## 目标
+
+- 在现有 feishu_bitable_table_sink 上声明关联字段解析规则。
+- 用目标表的业务键将上游值解析为飞书 record_id。
+- 同一个关联配置同时支持单值和多值输入。
+- 关联记录不存在时支持 error、empty 和 create 三种策略。
+- create 策略创建关联记录后，立即把新 record_id 写入当前目标记录。
+- Python API、YAML strict 校验、资源目录描述和控制面 descriptor 保持一致。
+- 未配置关联规则的现有 Sink 行为完全不变。
+
+## 非目标
+
+- 不从飞书字段元数据自动推断哪些字段是关联字段。
+- 不提供任意工作流、跨任务依赖或通用数据映射 DSL。
+- 不实现模糊匹配、别名匹配或企业名称清洗。
+- 不在首版增加跨请求或持久化的 record_id 缓存。
+- 不保证多个 worker 进程或多个部署实例间自动创建的全局原子去重。
+- 不主动维护双向关联的反向字段；反向关系仍由飞书字段配置和服务端维护。
+
+## 推荐方案
+
+关系解析属于飞书字段写入编码，因此扩展现有 FeishuBitableTableSink，在 send() 的
+目标记录查找和写入之前增加关系解析阶段。
+
+不新增独立 Relation Sink，也不要求 handler 调用 helper。handler 继续输出业务值，
+Table Sink 统一负责：
+
+1. 读取关联字段的输入值。
+2. 在关联表按业务键精确查询。
+3. 按缺失策略处理零条结果。
+4. 将业务值替换成 record_id 数组。
+5. 使用现有 create、update 或 upsert 流程写目标记录。
+
+## 配置契约
+
+### YAML
+
+~~~yaml
+resources:
+  projects:
+    type: feishu_bitable_table_sink
+    connector: feishu
+    app_token: FEISHU_APP_TOKEN
+    table_id: PROJECT_TABLE_ID
+    mode: upsert
+    match_fields: [项目编号]
+    relations:
+      关联企业:
+        from: 企业名称
+        table_id: ENTERPRISE_TABLE_ID
+        key: 企业名称
+        on_missing: create
+        create_fields:
+          数据状态: 待完善
+~~~
+
+relations 是以目标关联字段名为键的 mapping。上述配置表示：从 payload 的“企业名称”
+读取业务值，在企业表的“企业名称”字段上精确查询，并将解析后的 record_id 数组写入
+项目表的“关联企业”。实际部署时 app_token 和 table_id 可继续使用环境变量插值。
+
+### Python API
+
+~~~python
+project_sink = feishu.table_sink(
+    app_token=project_app_token,
+    table_id=project_table_id,
+    mode="upsert",
+    match_fields=["项目编号"],
+    relations={
+        "关联企业": {
+            "from": "企业名称",
+            "table_id": enterprise_table_id,
+            "key": "企业名称",
+            "on_missing": "create",
+            "create_fields": {"数据状态": "待完善"},
+        }
+    },
+)
+~~~
+
+Python API 接受与 YAML 相同的 mapping，并在创建 Sink 时完成标准化和校验。
+
+### 关系配置字段
+
+| 字段 | 必填 | 语义 | 默认值 |
+|---|---:|---|---|
+| table_id | 是 | 被关联的飞书数据表 ID | 无 |
+| key | 是 | 关联表中用于精确匹配的字段；业务上必须唯一 | 无 |
+| from | 否 | 从目标 payload 的哪个字段读取业务值 | 当前关联字段名 |
+| on_missing | 否 | error、empty 或 create | error |
+| create_fields | 否 | 自动创建关联记录时附加的静态字段 | 空 mapping |
+| app_token | 否 | 关联表所在 Base 的 token | 当前 Sink 的 app_token |
+
+create_fields 只能与 on_missing: create 一起使用，并且不能包含或覆盖 key。首版只支持
+静态字段，不解析 payload 模板或表达式。
+
+## 输入和输出
+
+### 单值
+
+~~~python
+{"企业名称": "企业A"}
+~~~
+
+解析为：
+
+~~~python
+{"关联企业": ["rec_a"]}
+~~~
+
+### 多值
+
+~~~python
+{"企业名称": ["企业A", "企业B", "企业C"]}
+~~~
+
+解析为：
+
+~~~python
+{"关联企业": ["rec_a", "rec_b", "rec_c"]}
+~~~
+
+不增加 multiple 配置项。输入值的形状直接表达基数，输出始终是飞书关联字段要求的
+ID 数组。
+
+### 输入标准化
+
+- 字符串是一个业务键。
+- list 或 tuple 是多个业务键；字符串本身始终作为一个业务键。
+- None、空字符串和列表中的空项被忽略。
+- 全部为空时不调用查询 API，目标关联字段编码为 []。
+- 重复业务值按首次出现顺序去重，同一条 payload 内只解析一次。
+- 除字符串、list、tuple 和 None 外的输入类型属于永久 payload 错误。
+- 解析后的 record_id 按标准化业务值的首次出现顺序输出。
+
+## 查找语义
+
+每个唯一、非空业务值使用飞书 records search API 查询，page_size=2，只区分以下状态：
+
+- 一条：使用该记录的 record_id。
+- 零条：应用 on_missing。
+- 两条：业务键不唯一，整条 payload 永久失败。
+
+插件不选择第一条，也不尝试模糊匹配。关联表的 key 唯一性是使用方必须维护的业务
+约束。
+
+## 缺失策略
+
+on_missing 只处理查询成功但返回零条的业务值。网络错误、鉴权错误、限流、非法查询
+或响应格式错误不得被解释为“缺失”。
+
+### error
+
+这是默认策略。任意非空业务值未命中时，整条目标 payload 失败，项目记录不写入。
+
+多值输入中，即使其他企业已成功解析，只要一项缺失，整条项目仍失败。这样不会写入
+不完整关系。
+
+### empty
+
+未命中的业务值被跳过：
+
+- 单值未命中时，目标关联字段为 []。
+- 多值部分命中时，只写已命中的 record_id。
+- 多值全部未命中时，目标关联字段为 []。
+
+对于 update 或 upsert 命中的已有项目，写入 [] 会清空旧关联。empty 的含义是“明确
+写空”，不是“保留目标表旧值”。需要保留旧值的业务不应返回空输入或使用 empty。
+
+### create
+
+每个未命中的业务值都创建一条关联记录。创建字段为：
+
+~~~python
+{
+    **relation.create_fields,
+    relation.key: business_value,
+}
+~~~
+
+创建成功后，从响应中的记录对象读取新 record_id，与已找到的 ID 一起按输入顺序写入
+目标关联字段。
+
+任意创建失败时，当前项目记录不写入。此前已经成功创建的关联记录不会回滚；运行时
+重试会重新查询，找到这些记录后继续处理。因此关联表的业务键必须保持唯一，写入流程
+也按 at-least-once 语义设计。
+
+## 自动创建的并发边界
+
+同一个 Sink 实例内，为 (app_token, table_id, key, business_value) 建立按需
+single-flight 锁。锁只覆盖 create 策略的“二次查询 -> 创建”临界区：
+
+1. 第一次查询未命中。
+2. 获取该业务值的锁。
+3. 在锁内再次查询。
+4. 二次查询仍未命中才创建。
+5. 释放并清理无人等待的锁。
+
+这能避免同一 worker 进程内并发项目为同一企业重复创建。
+
+飞书 Bitable 没有由插件控制的数据库唯一约束，多个进程或部署实例仍可能同时完成
+二次查询并分别创建。因此首版明确不承诺全局原子去重。生产上应优先使用稳定业务键，
+并控制会自动创建相同主数据的并发写入来源。
+
+## 运行时结构
+
+### 关系配置模型
+
+connector.py 增加内部不可变配置模型 _FeishuRelationConfig，保存：
+
+- 目标字段名
+- 源字段名
+- 关联表 app_token
+- 关联表 table_id
+- key
+- on_missing
+- create_fields
+
+FeishuBitableConnector.table_sink() 和 FeishuBitableTableSink.__init__() 增加可选 relations
+参数。初始化时完成全部配置标准化，send() 不再重复解释原始 mapping。
+
+### 解析阶段
+
+FeishuBitableTableSink.send() 的顺序为：
+
+1. _payload_fields() 提取目标字段 mapping。
+2. _resolve_relation_fields() 从同一份原始字段快照读取所有关系输入。
+3. 所有关系解析成功后，消费与目标字段不同的 from 输入别名，再写入解析后的关联字段。
+4. 使用解析后的字段执行现有 match、create 或 update 流程。
+
+关系解析不修改传入的 Envelope.body 或嵌套 fields mapping。
+
+如果 from 与目标关联字段名不同，from 是只供关系解析消费的输入别名，所有关系解析成功
+后会从最终飞书字段中删除。这防止把仅用于关系查找的“企业名称”误写入项目表。多个
+关系可以共享同一个 from；它们都从删除前的原始快照读取，因此结果不依赖配置顺序。
+
+首版禁止关系目标字段出现在 match_fields 中，也禁止与目标字段不同的 from 出现在
+match_fields 中。这样关系解析不会改变目标记录 upsert 的业务定位值，也避免把
+record_id 数组作为现有精确匹配过滤条件。如果项目表还需要保存企业名称，handler 应
+另外输出项目表中的实际目标字段，不能复用被消费的 from 别名。
+
+### 错误模型
+
+- 飞书 search/create 请求继续抛出原有 ConnectorOperationError。
+- 关系解析发生在 Sink 内，因此 operation 使用 ConnectorOperation.SEND。
+- 限流、网络和服务端错误沿用现有分类，可由 runtime 重试。
+- 非法关系配置在构建 Sink 时失败。
+- 非法输入类型、重复匹配、缺失且策略为 error 属于永久错误。
+- 错误信息可以包含字段名、table_id 和 key，但不能包含 app_token 或凭据。
+
+## YAML 和资源目录
+
+resources.py 的 Table Sink allowed fields 增加 relations，catalog 中将其描述为 mapping。
+
+strict 校验递归检查：
+
+- relations 必须是非空 mapping。
+- 每个关系字段名必须是非空字符串。
+- 每个配置必须是 mapping。
+- 只允许 from、app_token、table_id、key、on_missing 和 create_fields。
+- from、app_token、table_id 和 key 必须是非空字符串。
+- on_missing 必须是 error、empty 或 create。
+- create_fields 必须是 mapping，只能与 create 一起使用，且不能包含 key。
+- 关系目标字段不得出现在 Sink 的 match_fields 中。
+- 与目标字段不同的 from 不得出现在 Sink 的 match_fields 中。
+
+资源构建器将原始 relations 传入 connector.table_sink()；运行时构造函数作为 Python API
+的第二道校验，不能只依赖 YAML strict 模式。
+
+## 控制面描述
+
+Table Sink descriptor 增加关系概要，包含目标关联字段名、from、table_id、key、
+on_missing、create_fields 的字段名，以及是否使用独立 app token。
+
+descriptor 不输出任何 app_token 原值。跨 Base 关系的 token 与 Sink token 一样必须脱敏。
+
+## 兼容性
+
+- relations 默认为空，未配置时不执行任何额外 API 调用或字段转换。
+- 现有 create、update、upsert、match_fields 和 user_id_type 行为不变。
+- 现有直接传入 ["rec_xxx"] 的关联字段继续原样透传，只要该字段没有配置在 relations 中。
+- 该能力是插件级新增配置，不需要修改 onestep core runtime。
+
+## 测试
+
+### Connector 行为
+
+- 单值唯一命中后写一个 record_id。
+- 三个企业名称按输入顺序写三个 record_id。
+- 重复输入只查询一次，输出按首次出现顺序去重。
+- 空值和全空列表不发关系查询并写 []。
+- 非法输入类型返回永久错误。
+- 重复匹配返回永久错误且不写项目。
+- error 任一缺失时不写项目。
+- empty 单值缺失写 []，部分缺失保留已命中 ID。
+- create 创建一个或多个缺失企业，并使用响应 ID 写项目。
+- create 部分创建失败时不写项目，重试可查到此前已创建记录。
+- 同一 Sink 内并发创建相同企业只发生一次 create 请求。
+- 查询限流、网络或服务端错误不走 missing 分支。
+- 关系字段转换不修改输入 envelope。
+- from 与目标字段不同后，源字段不出现在飞书目标请求中。
+- 多个关系共享同一 from 时都从原始字段快照正确解析。
+- 关系目标字段或被消费的 from 与 match_fields 冲突时构造失败。
+- 跨 Base 查询和创建使用关系配置的 app_token。
+
+### 配置和描述
+
+- Python API 接受合法关系 mapping 并拒绝非法配置。
+- strict YAML 接受合法的单个和多个 relation 配置。
+- strict YAML 拒绝未知字段、缺少 table_id/key、非法策略和非法 create_fields。
+- catalog 将 relations 暴露为 mapping。
+- descriptor 展示安全概要，且序列化结果不包含任何 app token 或 secret。
+
+### 回归
+
+- 现有 Feishu Bitable 插件测试全部通过。
+- 未配置 relations 的 create/update/upsert 请求体保持不变。
+- 插件包构建和元数据检查通过。
+
+## 文档
+
+更新 docs/broker/feishu-bitable.md：
+
+- 增加企业表和项目表的完整 YAML 示例。
+- 展示单企业和多企业 handler payload。
+- 解释三个缺失策略，特别是 empty 会清空已有关系。
+- 说明 key 必须业务唯一。
+- 说明自动创建在多实例下不提供全局原子去重。
+- 说明跨 Base 时可覆盖关系的 app_token。
+
+插件 README 只加入最小配置示例并链接详细文档，避免复制整份行为说明。
+
+## 发布
+
+实现和验证完成后，按插件发布约定更新 onestep-feishu-bitable 小版本及相应 release
+metadata。设计阶段不提前修改版本。

--- a/plugins/onestep-feishu-bitable/README.md
+++ b/plugins/onestep-feishu-bitable/README.md
@@ -31,3 +31,27 @@ YAML resource types registered by the plugin:
 - `feishu_bitable`
 - `feishu_bitable_incremental`
 - `feishu_bitable_table_sink`
+
+Table sinks can resolve business keys into Feishu relation record IDs:
+
+```yaml
+resources:
+  projects:
+    type: feishu_bitable_table_sink
+    connector: feishu
+    app_token: project-app-token
+    table_id: projects
+    mode: upsert
+    match_fields: [project_id]
+    relations:
+      companies:
+        from: company_names
+        table_id: companies
+        key: name
+        on_missing: create
+```
+
+The input may contain one business key or a list. Missing related records can
+fail the send, be omitted, or be created and linked. See the
+[Feishu Bitable broker documentation](https://onestep.code05.com/broker/feishu-bitable)
+for the complete behavior and concurrency limits.

--- a/plugins/onestep-feishu-bitable/pyproject.toml
+++ b/plugins/onestep-feishu-bitable/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-feishu-bitable"
-version = "0.1.3"
+version = "0.2.0"
 description = "Feishu Bitable connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+++ b/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
@@ -704,7 +704,7 @@ class FeishuBitableTableSink(Sink):
 
     async def send(self, envelope: Envelope) -> None:
         try:
-            fields = _payload_fields(envelope.body)
+            fields = await self._resolve_relation_fields(_payload_fields(envelope.body))
             if self.mode == "create":
                 await self.connector.create_record(
                     app_token=self.app_token,
@@ -757,6 +757,64 @@ class FeishuBitableTableSink(Sink):
                 retry_delay_s=1.0,
                 cause=exc,
             ) from exc
+
+    async def _resolve_relation_fields(self, fields: Mapping[str, Any]) -> dict[str, Any]:
+        if not self.relations:
+            return dict(fields)
+        original = dict(fields)
+        resolved: dict[str, list[str]] = {}
+        consumed_fields: set[str] = set()
+        for relation in self.relations:
+            values = _normalize_relation_values(original.get(relation.source_field), field=relation.source_field)
+            record_ids: list[str] = []
+            for value in values:
+                matches = await self._find_relation_matches(relation, value)
+                if len(matches) > 1:
+                    raise FeishuBitablePayloadError(
+                        f"relation field {relation.target_field!r} value {value!r} "
+                        f"matched {len(matches)} records in table {relation.table_id!r}"
+                    )
+                if matches:
+                    record_ids.append(_record_id(matches[0]))
+                    continue
+                if relation.on_missing == "error":
+                    raise FeishuBitablePayloadError(
+                        f"relation field {relation.target_field!r} value {value!r} "
+                        f"did not match a record in table {relation.table_id!r}"
+                    )
+                if relation.on_missing == "create":
+                    raise FeishuBitablePayloadError(
+                        f"relation field {relation.target_field!r} cannot create missing value {value!r}"
+                    )
+            resolved[relation.target_field] = record_ids
+            if relation.source_field != relation.target_field:
+                consumed_fields.add(relation.source_field)
+
+        result = dict(original)
+        for field_name in consumed_fields:
+            result.pop(field_name, None)
+        result.update(resolved)
+        return result
+
+    async def _find_relation_matches(
+        self,
+        relation: _FeishuRelationConfig,
+        value: str,
+    ) -> list[dict[str, Any]]:
+        data = await self.connector.search_records(
+            app_token=relation.app_token,
+            table_id=relation.table_id,
+            body=_match_search_body({relation.key: value}),
+            page_size=2,
+            user_id_type=self.user_id_type,
+            operation=ConnectorOperation.SEND,
+            source_name=self.name,
+            retry_delay_s=1.0,
+        )
+        raw_items = data.get("items", [])
+        if not isinstance(raw_items, list):
+            raise FeishuBitablePayloadError("feishu_bitable search response data.items must be a list")
+        return [dict(item) for item in raw_items if isinstance(item, Mapping)]
 
     def control_plane_descriptor(self) -> dict[str, Any]:
         return {
@@ -1045,6 +1103,34 @@ def _normalize_relations(
                 create_fields=create_fields,
             )
         )
+    return tuple(normalized)
+
+
+def _normalize_relation_values(value: Any, *, field: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        raw_values = (value,)
+    elif isinstance(value, (list, tuple)):
+        raw_values = tuple(value)
+    else:
+        raise FeishuBitablePayloadError(
+            f"relation source field {field!r} must be a string, list, tuple, or None"
+        )
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in raw_values:
+        if item is None:
+            continue
+        if not isinstance(item, str):
+            raise FeishuBitablePayloadError(
+                f"relation source field {field!r} values must be strings or None"
+            )
+        item = item.strip()
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        normalized.append(item)
     return tuple(normalized)
 
 

--- a/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+++ b/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
@@ -9,6 +9,7 @@ import urllib.request
 from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
@@ -675,6 +676,7 @@ class _FeishuRelationConfig:
 class _FeishuRelationCreateLock:
     lock: asyncio.Lock
     users: int = 0
+    record_id: str | None = None
 
 
 class FeishuBitableTableSink(Sink):
@@ -687,7 +689,7 @@ class FeishuBitableTableSink(Sink):
         mode: str,
         match_fields: Sequence[str] | None,
         user_id_type: str | None,
-        relations: Mapping[str, Mapping[str, Any]] | None,
+        relations: Mapping[str, Mapping[str, Any]] | None = None,
     ) -> None:
         super().__init__(f"feishu_bitable.table_sink:{table_id}")
         normalized_mode = _normalize_mode(mode)
@@ -814,6 +816,8 @@ class FeishuBitableTableSink(Sink):
         entry.users += 1
         try:
             async with entry.lock:
+                if entry.record_id is not None:
+                    return entry.record_id
                 matches = await self._find_relation_matches(relation, value)
                 if len(matches) > 1:
                     raise FeishuBitablePayloadError(
@@ -839,7 +843,8 @@ class FeishuBitableTableSink(Sink):
                         f"feishu_bitable create response for relation field {relation.target_field!r} "
                         "is missing record"
                     )
-                return _record_id(raw_record)
+                entry.record_id = _record_id(raw_record)
+                return entry.record_id
         finally:
             entry.users -= 1
             if entry.users == 0 and self._relation_create_locks.get(lock_key) is entry:
@@ -863,7 +868,11 @@ class FeishuBitableTableSink(Sink):
         raw_items = data.get("items", [])
         if not isinstance(raw_items, list):
             raise FeishuBitablePayloadError("feishu_bitable search response data.items must be a list")
-        return [dict(item) for item in raw_items if isinstance(item, Mapping)]
+        if any(not isinstance(item, Mapping) for item in raw_items):
+            raise FeishuBitablePayloadError(
+                "feishu_bitable search response data.items entries must be mappings"
+            )
+        return [dict(item) for item in raw_items]
 
     def control_plane_descriptor(self) -> dict[str, Any]:
         return {
@@ -1121,7 +1130,7 @@ def _normalize_relations(
         field = f"relations.{target_field}"
         if not isinstance(raw_config, Mapping):
             raise TypeError(f"'{field}' must be a mapping")
-        unknown_fields = sorted(set(raw_config) - _RELATION_FIELDS)
+        unknown_fields = sorted(str(item) for item in raw_config if item not in _RELATION_FIELDS)
         if unknown_fields:
             raise ValueError(f"unsupported fields for {field}: {', '.join(unknown_fields)}")
 
@@ -1145,6 +1154,8 @@ def _normalize_relations(
         if "create_fields" in raw_config and on_missing != "create":
             raise ValueError(f"'{field}.create_fields' requires on_missing 'create'")
         create_fields = dict(raw_create_fields)
+        if any(not isinstance(field_name, str) or not field_name.strip() for field_name in create_fields):
+            raise ValueError(f"'{field}.create_fields' keys must be non-empty strings")
         if key in create_fields:
             raise ValueError(f"'{field}.create_fields' must not contain relation key {key!r}")
 
@@ -1161,7 +1172,7 @@ def _normalize_relations(
                 table_id=table_id,
                 key=key,
                 on_missing=on_missing,
-                create_fields=create_fields,
+                create_fields=MappingProxyType(create_fields),
             )
         )
     return tuple(normalized)

--- a/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+++ b/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
@@ -30,6 +30,8 @@ _AUTOMATIC_CURSOR_FIELD_ALIASES = {
     "最后更新时间": "last_modified_time",
 }
 _USER_ID_TYPES = frozenset({"open_id", "union_id", "user_id"})
+_RELATION_FIELDS = frozenset({"from", "app_token", "table_id", "key", "on_missing", "create_fields"})
+_RELATION_MISSING_POLICIES = frozenset({"error", "empty", "create"})
 
 
 def feishu_bitable_text(value: Any) -> str | None:
@@ -150,6 +152,7 @@ class FeishuBitableConnector:
         mode: str = "upsert",
         match_fields: Sequence[str] | None = None,
         user_id_type: str | None = None,
+        relations: Mapping[str, Mapping[str, Any]] | None = None,
     ) -> "FeishuBitableTableSink":
         return FeishuBitableTableSink(
             connector=self,
@@ -158,6 +161,7 @@ class FeishuBitableConnector:
             mode=mode,
             match_fields=match_fields,
             user_id_type=user_id_type,
+            relations=relations,
         )
 
     async def search_records(
@@ -656,6 +660,17 @@ class FeishuBitableIncrementalSource(Source):
         return records[:limit]
 
 
+@dataclass(frozen=True)
+class _FeishuRelationConfig:
+    target_field: str
+    source_field: str
+    app_token: str
+    table_id: str
+    key: str
+    on_missing: str
+    create_fields: Mapping[str, Any]
+
+
 class FeishuBitableTableSink(Sink):
     def __init__(
         self,
@@ -666,6 +681,7 @@ class FeishuBitableTableSink(Sink):
         mode: str,
         match_fields: Sequence[str] | None,
         user_id_type: str | None,
+        relations: Mapping[str, Mapping[str, Any]] | None,
     ) -> None:
         super().__init__(f"feishu_bitable.table_sink:{table_id}")
         normalized_mode = _normalize_mode(mode)
@@ -674,11 +690,17 @@ class FeishuBitableTableSink(Sink):
         else:
             normalized_match_fields = _normalize_match_fields(match_fields, required=False)
         self.connector = connector
-        self.app_token = _require_non_empty_string(app_token, field="app_token")
+        normalized_app_token = _require_non_empty_string(app_token, field="app_token")
+        self.app_token = normalized_app_token
         self.table_id = _require_non_empty_string(table_id, field="table_id")
         self.mode = normalized_mode
         self.match_fields = normalized_match_fields
         self.user_id_type = _normalize_user_id_type(user_id_type)
+        self.relations = _normalize_relations(
+            relations,
+            default_app_token=normalized_app_token,
+            match_fields=normalized_match_fields,
+        )
 
     async def send(self, envelope: Envelope) -> None:
         try:
@@ -959,6 +981,71 @@ def _normalize_match_fields(value: Sequence[str] | None, *, required: bool) -> t
     if len(set(fields)) != len(fields):
         raise ValueError("'match_fields' must not contain duplicate field names")
     return fields
+
+
+def _normalize_relations(
+    value: Mapping[str, Mapping[str, Any]] | None,
+    *,
+    default_app_token: str,
+    match_fields: Sequence[str],
+) -> tuple[_FeishuRelationConfig, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Mapping):
+        raise TypeError("'relations' must be a mapping")
+    if not value:
+        raise ValueError("'relations' must be a non-empty mapping")
+
+    normalized: list[_FeishuRelationConfig] = []
+    for raw_target_field, raw_config in value.items():
+        target_field = _require_non_empty_string(raw_target_field, field="relations target field")
+        field = f"relations.{target_field}"
+        if not isinstance(raw_config, Mapping):
+            raise TypeError(f"'{field}' must be a mapping")
+        unknown_fields = sorted(set(raw_config) - _RELATION_FIELDS)
+        if unknown_fields:
+            raise ValueError(f"unsupported fields for {field}: {', '.join(unknown_fields)}")
+
+        source_field = _require_non_empty_string(raw_config.get("from", target_field), field=f"{field}.from")
+        app_token = _require_non_empty_string(
+            raw_config.get("app_token", default_app_token),
+            field=f"{field}.app_token",
+        )
+        table_id = _require_non_empty_string(raw_config.get("table_id"), field=f"{field}.table_id")
+        key = _require_non_empty_string(raw_config.get("key"), field=f"{field}.key")
+        on_missing = _require_non_empty_string(
+            raw_config.get("on_missing", "error"),
+            field=f"{field}.on_missing",
+        ).lower()
+        if on_missing not in _RELATION_MISSING_POLICIES:
+            raise ValueError(f"'{field}.on_missing' must be one of 'error', 'empty', or 'create'")
+
+        raw_create_fields = raw_config.get("create_fields", {})
+        if not isinstance(raw_create_fields, Mapping):
+            raise TypeError(f"'{field}.create_fields' must be a mapping")
+        if "create_fields" in raw_config and on_missing != "create":
+            raise ValueError(f"'{field}.create_fields' requires on_missing 'create'")
+        create_fields = dict(raw_create_fields)
+        if key in create_fields:
+            raise ValueError(f"'{field}.create_fields' must not contain relation key {key!r}")
+
+        if target_field in match_fields:
+            raise ValueError(f"relation target field {target_field!r} must not appear in match_fields")
+        if source_field != target_field and source_field in match_fields:
+            raise ValueError(f"relation source field {source_field!r} must not appear in match_fields")
+
+        normalized.append(
+            _FeishuRelationConfig(
+                target_field=target_field,
+                source_field=source_field,
+                app_token=app_token,
+                table_id=table_id,
+                key=key,
+                on_missing=on_missing,
+                create_fields=create_fields,
+            )
+        )
+    return tuple(normalized)
 
 
 def _match_values(fields: Mapping[str, Any], match_fields: Sequence[str]) -> dict[str, Any]:

--- a/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+++ b/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
@@ -876,6 +876,18 @@ class FeishuBitableTableSink(Sink):
                 "mode": self.mode,
                 "match_fields": list(self.match_fields),
                 "user_id_type": self.user_id_type,
+                "relations": [
+                    {
+                        "target_field": relation.target_field,
+                        "from": relation.source_field,
+                        "table_id": relation.table_id,
+                        "key": relation.key,
+                        "on_missing": relation.on_missing,
+                        "create_field_names": sorted(relation.create_fields),
+                        "uses_custom_app_token": relation.app_token != self.app_token,
+                    }
+                    for relation in self.relations
+                ],
             },
         }
 

--- a/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+++ b/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
@@ -671,6 +671,12 @@ class _FeishuRelationConfig:
     create_fields: Mapping[str, Any]
 
 
+@dataclass
+class _FeishuRelationCreateLock:
+    lock: asyncio.Lock
+    users: int = 0
+
+
 class FeishuBitableTableSink(Sink):
     def __init__(
         self,
@@ -701,6 +707,7 @@ class FeishuBitableTableSink(Sink):
             default_app_token=normalized_app_token,
             match_fields=normalized_match_fields,
         )
+        self._relation_create_locks: dict[tuple[str, str, str, str], _FeishuRelationCreateLock] = {}
 
     async def send(self, envelope: Envelope) -> None:
         try:
@@ -783,9 +790,7 @@ class FeishuBitableTableSink(Sink):
                         f"did not match a record in table {relation.table_id!r}"
                     )
                 if relation.on_missing == "create":
-                    raise FeishuBitablePayloadError(
-                        f"relation field {relation.target_field!r} cannot create missing value {value!r}"
-                    )
+                    record_ids.append(await self._find_or_create_relation_record(relation, value))
             resolved[relation.target_field] = record_ids
             if relation.source_field != relation.target_field:
                 consumed_fields.add(relation.source_field)
@@ -795,6 +800,50 @@ class FeishuBitableTableSink(Sink):
             result.pop(field_name, None)
         result.update(resolved)
         return result
+
+    async def _find_or_create_relation_record(
+        self,
+        relation: _FeishuRelationConfig,
+        value: str,
+    ) -> str:
+        lock_key = (relation.app_token, relation.table_id, relation.key, value)
+        entry = self._relation_create_locks.get(lock_key)
+        if entry is None:
+            entry = _FeishuRelationCreateLock(asyncio.Lock())
+            self._relation_create_locks[lock_key] = entry
+        entry.users += 1
+        try:
+            async with entry.lock:
+                matches = await self._find_relation_matches(relation, value)
+                if len(matches) > 1:
+                    raise FeishuBitablePayloadError(
+                        f"relation field {relation.target_field!r} value {value!r} "
+                        f"matched {len(matches)} records in table {relation.table_id!r}"
+                    )
+                if matches:
+                    return _record_id(matches[0])
+                fields = dict(relation.create_fields)
+                fields[relation.key] = value
+                data = await self.connector.create_record(
+                    app_token=relation.app_token,
+                    table_id=relation.table_id,
+                    fields=fields,
+                    user_id_type=self.user_id_type,
+                    operation=ConnectorOperation.SEND,
+                    source_name=self.name,
+                    retry_delay_s=1.0,
+                )
+                raw_record = data.get("record")
+                if not isinstance(raw_record, Mapping):
+                    raise FeishuBitablePayloadError(
+                        f"feishu_bitable create response for relation field {relation.target_field!r} "
+                        "is missing record"
+                    )
+                return _record_id(raw_record)
+        finally:
+            entry.users -= 1
+            if entry.users == 0 and self._relation_create_locks.get(lock_key) is entry:
+                self._relation_create_locks.pop(lock_key, None)
 
     async def _find_relation_matches(
         self,

--- a/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/resources.py
+++ b/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/resources.py
@@ -198,9 +198,7 @@ def _validate_feishu_bitable_table_sink(ctx: ResourceValidationContext, spec: Ma
     if mode not in {"upsert", "create", "update"}:
         raise ValueError(f"unsupported {ctx.field}.mode {raw_mode!r}")
     match_fields: list[str] = []
-    if mode in {"upsert", "update"}:
-        match_fields = ctx.require_non_empty_string_list(spec, "match_fields", field=f"{ctx.field}.match_fields")
-    elif "match_fields" in spec:
+    if mode in {"upsert", "update"} or "match_fields" in spec:
         match_fields = ctx.require_non_empty_string_list(spec, "match_fields", field=f"{ctx.field}.match_fields")
     _validate_feishu_user_id_type(ctx, spec.get("user_id_type"), field=f"{ctx.field}.user_id_type")
     if "relations" in spec:
@@ -249,6 +247,13 @@ def _validate_feishu_relations(
             create_fields = raw_config.get("create_fields")
             if not isinstance(create_fields, Mapping):
                 raise TypeError(f"'{relation_field}.create_fields' must be a mapping")
+            if any(
+                not isinstance(field_name, str) or not field_name.strip()
+                for field_name in create_fields
+            ):
+                raise ValueError(
+                    f"'{relation_field}.create_fields' keys must be non-empty strings"
+                )
             if on_missing != "create":
                 raise ValueError(f"'{relation_field}.create_fields' requires on_missing 'create'")
             if key in create_fields:

--- a/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/resources.py
+++ b/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/resources.py
@@ -31,9 +31,11 @@ _FEISHU_INCREMENTAL_FIELDS = frozenset(
     }
 )
 _FEISHU_TABLE_SINK_FIELDS = frozenset(
-    {"type", "connector", "app_token", "table_id", "mode", "match_fields", "user_id_type"}
+    {"type", "connector", "app_token", "table_id", "mode", "match_fields", "user_id_type", "relations"}
 )
 _USER_ID_TYPES = frozenset({"open_id", "union_id", "user_id"})
+_RELATION_FIELDS = frozenset({"from", "app_token", "table_id", "key", "on_missing", "create_fields"})
+_RELATION_MISSING_POLICIES = frozenset({"error", "empty", "create"})
 _FEISHU_BITABLE_CATALOG = ResourceCatalogEntry(
     type="feishu_bitable",
     roles=("connector",),
@@ -76,6 +78,7 @@ _FEISHU_TABLE_SINK_CATALOG = ResourceCatalogEntry(
         ResourceCatalogField("mode", "string", default="upsert", options=("upsert", "create", "update")),
         ResourceCatalogField("match_fields", "string_list", required=True),
         ResourceCatalogField("user_id_type", "string", options=tuple(sorted(_USER_ID_TYPES))),
+        ResourceCatalogField("relations", "mapping"),
     ),
     topology_fields=("app_token", "table_id", "mode", "match_fields"),
 )
@@ -154,6 +157,7 @@ def _build_feishu_bitable_table_sink(ctx: ResourceBuildContext, spec: Mapping[st
         mode=spec.get("mode", "upsert"),
         match_fields=spec.get("match_fields"),
         user_id_type=spec.get("user_id_type"),
+        relations=spec.get("relations"),
     )
 
 
@@ -193,11 +197,68 @@ def _validate_feishu_bitable_table_sink(ctx: ResourceValidationContext, spec: Ma
     mode = ctx.string_value(raw_mode, field=f"{ctx.field}.mode").strip().lower()
     if mode not in {"upsert", "create", "update"}:
         raise ValueError(f"unsupported {ctx.field}.mode {raw_mode!r}")
+    match_fields: list[str] = []
     if mode in {"upsert", "update"}:
-        ctx.require_non_empty_string_list(spec, "match_fields", field=f"{ctx.field}.match_fields")
+        match_fields = ctx.require_non_empty_string_list(spec, "match_fields", field=f"{ctx.field}.match_fields")
     elif "match_fields" in spec:
-        ctx.require_non_empty_string_list(spec, "match_fields", field=f"{ctx.field}.match_fields")
+        match_fields = ctx.require_non_empty_string_list(spec, "match_fields", field=f"{ctx.field}.match_fields")
     _validate_feishu_user_id_type(ctx, spec.get("user_id_type"), field=f"{ctx.field}.user_id_type")
+    if "relations" in spec:
+        _validate_feishu_relations(
+            ctx,
+            spec.get("relations"),
+            match_fields=match_fields,
+            field=f"{ctx.field}.relations",
+        )
+
+
+def _validate_feishu_relations(
+    ctx: ResourceValidationContext,
+    value: Any,
+    *,
+    match_fields: list[str],
+    field: str,
+) -> None:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"'{field}' must be a mapping")
+    if not value:
+        raise ValueError(f"'{field}' must be a non-empty mapping")
+    for raw_target_field, raw_config in value.items():
+        target_field = ctx.string_value(raw_target_field, field=f"{field} target field").strip()
+        relation_field = f"{field}.{target_field}"
+        if not isinstance(raw_config, Mapping):
+            raise TypeError(f"'{relation_field}' must be a mapping")
+        ctx.validate_unknown_fields(raw_config, _RELATION_FIELDS, field=relation_field)
+        source_field = ctx.string_value(
+            raw_config.get("from", target_field),
+            field=f"{relation_field}.from",
+        ).strip()
+        if "app_token" in raw_config:
+            ctx.string_value(raw_config.get("app_token"), field=f"{relation_field}.app_token")
+        ctx.string_value(raw_config.get("table_id"), field=f"{relation_field}.table_id")
+        key = ctx.string_value(raw_config.get("key"), field=f"{relation_field}.key").strip()
+        on_missing = ctx.string_value(
+            raw_config.get("on_missing", "error"),
+            field=f"{relation_field}.on_missing",
+        ).strip().lower()
+        if on_missing not in _RELATION_MISSING_POLICIES:
+            raise ValueError(
+                f"'{relation_field}.on_missing' must be one of 'error', 'empty', or 'create'"
+            )
+        if "create_fields" in raw_config:
+            create_fields = raw_config.get("create_fields")
+            if not isinstance(create_fields, Mapping):
+                raise TypeError(f"'{relation_field}.create_fields' must be a mapping")
+            if on_missing != "create":
+                raise ValueError(f"'{relation_field}.create_fields' requires on_missing 'create'")
+            if key in create_fields:
+                raise ValueError(
+                    f"'{relation_field}.create_fields' must not contain relation key {key!r}"
+                )
+        if target_field in match_fields:
+            raise ValueError(f"relation target field {target_field!r} must not appear in match_fields")
+        if source_field != target_field and source_field in match_fields:
+            raise ValueError(f"relation source field {source_field!r} must not appear in match_fields")
 
 
 def _validate_feishu_user_id_type(ctx: ResourceValidationContext, value: Any, *, field: str) -> None:

--- a/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
+++ b/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
@@ -1090,6 +1090,183 @@ def test_feishu_relation_resolution_rejects_unsafe_values_before_target_write(fa
     asyncio.run(scenario())
 
 
+def test_feishu_relation_create_resolves_found_and_missing_values_in_order_with_cross_base_token() -> None:
+    async def scenario() -> None:
+        connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+        existing = {"A": "rec-a"}
+        searched: list[dict[str, Any]] = []
+        related_creates: list[dict[str, Any]] = []
+        project_creates: list[dict[str, Any]] = []
+
+        async def search_records(**kwargs):
+            searched.append(kwargs)
+            value = kwargs["body"]["filter"]["conditions"][0]["value"][0]
+            record_id = existing.get(value)
+            return {"items": [] if record_id is None else [{"record_id": record_id}]}
+
+        async def create_record(**kwargs):
+            if kwargs["table_id"] == "companies":
+                related_creates.append(kwargs)
+                value = kwargs["fields"]["name"]
+                record_id = f"rec-{value.lower()}"
+                existing[value] = record_id
+                return {"record": {"record_id": record_id}}
+            project_creates.append(kwargs)
+            return {"record": {"record_id": "project"}}
+
+        connector.search_records = search_records  # type: ignore[method-assign]
+        connector.create_record = create_record  # type: ignore[method-assign]
+        sink = connector.table_sink(
+            app_token="project-app",
+            table_id="projects",
+            mode="create",
+            user_id_type="user_id",
+            relations={
+                "companies": {
+                    "from": "company_names",
+                    "app_token": "company-app",
+                    "table_id": "companies",
+                    "key": "name",
+                    "on_missing": "create",
+                    "create_fields": {"status": "pending"},
+                }
+            },
+        )
+
+        await sink.send(Envelope(body={"project_id": "P-1", "company_names": ["A", "B", "C"]}))
+
+        assert project_creates[0]["fields"]["companies"] == ["rec-a", "rec-b", "rec-c"]
+        assert [call["fields"] for call in related_creates] == [
+            {"status": "pending", "name": "B"},
+            {"status": "pending", "name": "C"},
+        ]
+        assert all(call["app_token"] == "company-app" for call in searched)
+        assert all(call["app_token"] == "company-app" for call in related_creates)
+        assert all(call["user_id_type"] == "user_id" for call in searched + related_creates)
+
+    asyncio.run(scenario())
+
+
+def test_feishu_relation_create_partial_failure_does_not_write_project_and_retry_reuses_created_record() -> None:
+    async def scenario() -> None:
+        connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+        existing: dict[str, str] = {}
+        fail_c = True
+        related_creates: list[str] = []
+        project_creates: list[dict[str, Any]] = []
+
+        async def search_records(**kwargs):
+            value = kwargs["body"]["filter"]["conditions"][0]["value"][0]
+            record_id = existing.get(value)
+            return {"items": [] if record_id is None else [{"record_id": record_id}]}
+
+        async def create_record(**kwargs):
+            nonlocal fail_c
+            if kwargs["table_id"] == "companies":
+                value = kwargs["fields"]["name"]
+                related_creates.append(value)
+                if value == "C" and fail_c:
+                    fail_c = False
+                    raise ConnectorOperationError(
+                        backend="feishu_bitable",
+                        operation=ConnectorOperation.SEND,
+                        kind=ConnectorErrorKind.TRANSIENT,
+                        source_name=kwargs["source_name"],
+                    )
+                record_id = f"rec-{value.lower()}"
+                existing[value] = record_id
+                return {"record": {"record_id": record_id}}
+            project_creates.append(kwargs)
+            return {"record": {"record_id": "project"}}
+
+        connector.search_records = search_records  # type: ignore[method-assign]
+        connector.create_record = create_record  # type: ignore[method-assign]
+        sink = connector.table_sink(
+            app_token="app-token",
+            table_id="projects",
+            mode="create",
+            relations={
+                "companies": {
+                    "from": "company_names",
+                    "table_id": "companies",
+                    "key": "name",
+                    "on_missing": "create",
+                }
+            },
+        )
+        envelope = Envelope(body={"project_id": "P-1", "company_names": ["B", "C"]})
+
+        with pytest.raises(ConnectorOperationError) as raised:
+            await sink.send(envelope)
+        assert raised.value.kind is ConnectorErrorKind.TRANSIENT
+        assert project_creates == []
+
+        await sink.send(envelope)
+
+        assert related_creates == ["B", "C", "C"]
+        assert project_creates[0]["fields"]["companies"] == ["rec-b", "rec-c"]
+
+    asyncio.run(scenario())
+
+
+def test_feishu_relation_create_single_flight_prevents_duplicate_create_in_one_sink() -> None:
+    async def scenario() -> None:
+        connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+        existing: dict[str, str] = {}
+        initial_queries = 0
+        both_initial_queries = asyncio.Event()
+        related_creates: list[str] = []
+        project_creates: list[dict[str, Any]] = []
+
+        async def search_records(**kwargs):
+            nonlocal initial_queries
+            value = kwargs["body"]["filter"]["conditions"][0]["value"][0]
+            if value not in existing and initial_queries < 2:
+                initial_queries += 1
+                if initial_queries == 2:
+                    both_initial_queries.set()
+                await both_initial_queries.wait()
+            record_id = existing.get(value)
+            return {"items": [] if record_id is None else [{"record_id": record_id}]}
+
+        async def create_record(**kwargs):
+            if kwargs["table_id"] == "companies":
+                value = kwargs["fields"]["name"]
+                related_creates.append(value)
+                existing[value] = "rec-a"
+                return {"record": {"record_id": "rec-a"}}
+            project_creates.append(kwargs)
+            return {"record": {"record_id": "project"}}
+
+        connector.search_records = search_records  # type: ignore[method-assign]
+        connector.create_record = create_record  # type: ignore[method-assign]
+        sink = connector.table_sink(
+            app_token="app-token",
+            table_id="projects",
+            mode="create",
+            relations={
+                "companies": {
+                    "from": "company_names",
+                    "table_id": "companies",
+                    "key": "name",
+                    "on_missing": "create",
+                }
+            },
+        )
+
+        await asyncio.gather(
+            sink.send(Envelope(body={"project_id": "P-1", "company_names": ["A"]})),
+            sink.send(Envelope(body={"project_id": "P-2", "company_names": ["A"]})),
+        )
+
+        assert related_creates == ["A"]
+        assert len(project_creates) == 2
+        assert all(call["fields"]["companies"] == ["rec-a"] for call in project_creates)
+        assert sink._relation_create_locks == {}
+
+    asyncio.run(scenario())
+
+
 def test_feishu_http_error_classifies_rate_limit_as_throttled() -> None:
     async def scenario() -> None:
         def handler(request: dict[str, Any]) -> tuple[int, dict[str, Any]]:

--- a/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
+++ b/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
@@ -648,6 +648,22 @@ def test_yaml_builds_feishu_bitable_resources_in_strict_mode() -> None:
                     "table_id": "dst",
                     "match_fields": ["shop_id", "order_no"],
                     "user_id_type": "user_id",
+                    "relations": {
+                        "companies": {
+                            "from": "company_names",
+                            "table_id": "companies",
+                            "key": "name",
+                            "on_missing": "empty",
+                        },
+                        "auditors": {
+                            "from": "auditor_names",
+                            "app_token": "auditor-app",
+                            "table_id": "auditors",
+                            "key": "name",
+                            "on_missing": "create",
+                            "create_fields": {"status": "pending"},
+                        },
+                    },
                 },
             },
             "tasks": [
@@ -668,6 +684,58 @@ def test_yaml_builds_feishu_bitable_resources_in_strict_mode() -> None:
     assert app.resources["source"].fallback_scan_page_limit == 3
     assert app.resources["sink"].user_id_type == "user_id"
     assert app.resources["sink"].match_fields == ("shop_id", "order_no")
+    assert [relation.target_field for relation in app.resources["sink"].relations] == ["companies", "auditors"]
+    assert app.resources["sink"].relations[1].app_token == "auditor-app"
+
+
+@pytest.mark.parametrize(
+    ("relations", "message"),
+    [
+        ({}, "relations.*non-empty mapping"),
+        ({"companies": {"table_id": "companies"}}, "relations.companies.key"),
+        (
+            {"companies": {"table_id": "companies", "key": "name", "unknown": True}},
+            "unsupported fields.*unknown",
+        ),
+        (
+            {"companies": {"table_id": "companies", "key": "name", "on_missing": "skip"}},
+            "on_missing",
+        ),
+        (
+            {"companies": {"table_id": "companies", "key": "name", "create_fields": {"x": 1}}},
+            "create_fields.*on_missing.*create",
+        ),
+    ],
+)
+def test_yaml_rejects_invalid_feishu_relation_config_in_strict_mode(
+    relations: Any,
+    message: str,
+) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        load_app_config(
+            {
+                "apiVersion": "onestep/v1alpha1",
+                "kind": "App",
+                "app": {"name": "feishu-sync"},
+                "resources": {
+                    "feishu_bitable": {
+                        "type": "feishu_bitable",
+                        "app_id": "app-id",
+                        "app_secret": "secret",
+                    },
+                    "sink": {
+                        "type": "feishu_bitable_table_sink",
+                        "connector": "feishu_bitable",
+                        "app_token": "app-token",
+                        "table_id": "dst",
+                        "mode": "create",
+                        "relations": relations,
+                    },
+                },
+                "tasks": [],
+            },
+            strict=True,
+        )
 
 
 def test_yaml_rejects_unknown_feishu_fields_in_strict_mode() -> None:
@@ -812,6 +880,16 @@ def test_feishu_descriptors_redact_app_token_and_omit_credentials() -> None:
         table_id="tbl",
         mode="upsert",
         match_fields=["order_no"],
+        relations={
+            "companies": {
+                "from": "company_names",
+                "app_token": "relation-token-secret",
+                "table_id": "companies",
+                "key": "name",
+                "on_missing": "create",
+                "create_fields": {"internal_note": "private-value"},
+            }
+        },
     )
 
     payload = json.dumps(
@@ -825,6 +903,11 @@ def test_feishu_descriptors_redact_app_token_and_omit_credentials() -> None:
     assert '"app_token": "<redacted>"' in payload
     assert "order_no" in payload
     assert "updated_at" in payload
+    assert "relation-token-secret" not in payload
+    assert "private-value" not in payload
+    assert '"target_field": "companies"' in payload
+    assert '"create_field_names": ["internal_note"]' in payload
+    assert '"uses_custom_app_token": true' in payload
 
 
 def test_feishu_relation_config_normalizes_python_api_mapping() -> None:

--- a/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
+++ b/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
@@ -827,6 +827,109 @@ def test_feishu_descriptors_redact_app_token_and_omit_credentials() -> None:
     assert "updated_at" in payload
 
 
+def test_feishu_relation_config_normalizes_python_api_mapping() -> None:
+    connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+    create_fields = {"status": "pending"}
+
+    sink = connector.table_sink(
+        app_token="project-app",
+        table_id="projects",
+        mode="upsert",
+        match_fields=["project_id"],
+        relations={
+            "companies": {
+                "from": "company_names",
+                "table_id": "companies",
+                "key": "name",
+                "on_missing": "CREATE",
+                "create_fields": create_fields,
+            }
+        },
+    )
+    create_fields["status"] = "changed"
+
+    assert len(sink.relations) == 1
+    relation = sink.relations[0]
+    assert relation.target_field == "companies"
+    assert relation.source_field == "company_names"
+    assert relation.app_token == "project-app"
+    assert relation.table_id == "companies"
+    assert relation.key == "name"
+    assert relation.on_missing == "create"
+    assert relation.create_fields == {"status": "pending"}
+
+
+@pytest.mark.parametrize(
+    ("relations", "match_fields", "error", "message"),
+    [
+        ({}, [], ValueError, "relations.*non-empty mapping"),
+        ([], [], TypeError, "relations.*mapping"),
+        ({"companies": []}, [], TypeError, "relations.companies.*mapping"),
+        ({"companies": {"table_id": "companies"}}, [], ValueError, "relations.companies.key"),
+        ({"companies": {"key": "name"}}, [], ValueError, "relations.companies.table_id"),
+        (
+            {"companies": {"table_id": "companies", "key": "name", "unknown": True}},
+            [],
+            ValueError,
+            "unsupported fields.*unknown",
+        ),
+        (
+            {"companies": {"table_id": "companies", "key": "name", "on_missing": "skip"}},
+            [],
+            ValueError,
+            "on_missing",
+        ),
+        (
+            {"companies": {"table_id": "companies", "key": "name", "create_fields": {"x": 1}}},
+            [],
+            ValueError,
+            "create_fields.*on_missing.*create",
+        ),
+        (
+            {
+                "companies": {
+                    "table_id": "companies",
+                    "key": "name",
+                    "on_missing": "create",
+                    "create_fields": {"name": "override"},
+                }
+            },
+            [],
+            ValueError,
+            "create_fields.*key",
+        ),
+        (
+            {"companies": {"table_id": "companies", "key": "name"}},
+            ["companies"],
+            ValueError,
+            "target field.*match_fields",
+        ),
+        (
+            {"companies": {"from": "company_names", "table_id": "companies", "key": "name"}},
+            ["company_names"],
+            ValueError,
+            "source field.*match_fields",
+        ),
+    ],
+)
+def test_feishu_relation_config_rejects_invalid_python_api_mapping(
+    relations: Any,
+    match_fields: list[str],
+    error: type[Exception],
+    message: str,
+) -> None:
+    connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+
+    with pytest.raises(error, match=message):
+        connector.table_sink(
+            app_token="project-app",
+            table_id="projects",
+            mode="create" if not match_fields else "upsert",
+            match_fields=match_fields,
+            relations=relations,
+        )
+
+
 def test_feishu_http_error_classifies_rate_limit_as_throttled() -> None:
     async def scenario() -> None:
         def handler(request: dict[str, Any]) -> tuple[int, dict[str, Any]]:

--- a/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
+++ b/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
@@ -705,6 +705,17 @@ def test_yaml_builds_feishu_bitable_resources_in_strict_mode() -> None:
             {"companies": {"table_id": "companies", "key": "name", "create_fields": {"x": 1}}},
             "create_fields.*on_missing.*create",
         ),
+        (
+            {
+                "companies": {
+                    "table_id": "companies",
+                    "key": "name",
+                    "on_missing": "create",
+                    "create_fields": {1: "invalid"},
+                }
+            },
+            "create_fields.*non-empty strings",
+        ),
     ],
 )
 def test_yaml_rejects_invalid_feishu_relation_config_in_strict_mode(
@@ -982,6 +993,19 @@ def test_feishu_relation_config_normalizes_python_api_mapping() -> None:
             "create_fields.*key",
         ),
         (
+            {
+                "companies": {
+                    "table_id": "companies",
+                    "key": "name",
+                    "on_missing": "create",
+                    "create_fields": {1: "invalid"},
+                }
+            },
+            [],
+            ValueError,
+            "create_fields.*non-empty strings",
+        ),
+        (
             {"companies": {"table_id": "companies", "key": "name"}},
             ["companies"],
             ValueError,
@@ -1173,6 +1197,42 @@ def test_feishu_relation_resolution_rejects_unsafe_values_before_target_write(fa
     asyncio.run(scenario())
 
 
+def test_feishu_relation_resolution_rejects_malformed_search_items_before_missing_policy() -> None:
+    async def scenario() -> None:
+        connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+        created: list[dict[str, Any]] = []
+
+        async def search_records(**kwargs):
+            return {"items": ["not-a-record"]}
+
+        async def create_record(**kwargs):
+            created.append(kwargs)
+            return {"record": {"record_id": "created"}}
+
+        connector.search_records = search_records  # type: ignore[method-assign]
+        connector.create_record = create_record  # type: ignore[method-assign]
+        sink = connector.table_sink(
+            app_token="app-token",
+            table_id="projects",
+            mode="create",
+            relations={
+                "companies": {
+                    "table_id": "companies",
+                    "key": "name",
+                    "on_missing": "create",
+                }
+            },
+        )
+
+        with pytest.raises(ConnectorOperationError) as raised:
+            await sink.send(Envelope(body={"companies": "A"}))
+
+        assert raised.value.kind is ConnectorErrorKind.PERMANENT
+        assert created == []
+
+    asyncio.run(scenario())
+
+
 def test_feishu_relation_create_resolves_found_and_missing_values_in_order_with_cross_base_token() -> None:
     async def scenario() -> None:
         connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
@@ -1303,14 +1363,13 @@ def test_feishu_relation_create_single_flight_prevents_duplicate_create_in_one_s
 
         async def search_records(**kwargs):
             nonlocal initial_queries
-            value = kwargs["body"]["filter"]["conditions"][0]["value"][0]
-            if value not in existing and initial_queries < 2:
+            if initial_queries < 2:
                 initial_queries += 1
                 if initial_queries == 2:
                     both_initial_queries.set()
                 await both_initial_queries.wait()
-            record_id = existing.get(value)
-            return {"items": [] if record_id is None else [{"record_id": record_id}]}
+            await asyncio.sleep(0)
+            return {"items": []}
 
         async def create_record(**kwargs):
             if kwargs["table_id"] == "companies":

--- a/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
+++ b/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
@@ -930,6 +930,166 @@ def test_feishu_relation_config_rejects_invalid_python_api_mapping(
         )
 
 
+def test_feishu_relation_resolution_maps_scalar_and_ordered_unique_list_without_mutating_input() -> None:
+    async def scenario() -> None:
+        connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+        searched_values: list[str] = []
+        created: list[dict[str, Any]] = []
+
+        async def search_records(**kwargs):
+            value = kwargs["body"]["filter"]["conditions"][0]["value"][0]
+            searched_values.append(value)
+            return {"items": [{"record_id": f"rec-{value.lower()}"}]}
+
+        async def create_record(**kwargs):
+            created.append(kwargs)
+            return {"record": {"record_id": "project"}}
+
+        connector.search_records = search_records  # type: ignore[method-assign]
+        connector.create_record = create_record  # type: ignore[method-assign]
+        sink = connector.table_sink(
+            app_token="project-app",
+            table_id="projects",
+            mode="create",
+            relations={
+                "companies": {
+                    "from": "company_names",
+                    "table_id": "companies",
+                    "key": "name",
+                }
+            },
+        )
+        scalar = {"project_id": "P-1", "company_names": "A"}
+        multiple = {"project_id": "P-2", "company_names": ["A", "B", "A", "", None, "C"]}
+
+        await sink.send(Envelope(body=scalar))
+        await sink.send(Envelope(body={"fields": multiple}))
+
+        assert searched_values == ["A", "A", "B", "C"]
+        assert created[0]["fields"] == {"project_id": "P-1", "companies": ["rec-a"]}
+        assert created[1]["fields"] == {
+            "project_id": "P-2",
+            "companies": ["rec-a", "rec-b", "rec-c"],
+        }
+        assert scalar == {"project_id": "P-1", "company_names": "A"}
+        assert multiple == {"project_id": "P-2", "company_names": ["A", "B", "A", "", None, "C"]}
+
+    asyncio.run(scenario())
+
+
+def test_feishu_relation_resolution_empty_skips_missing_values_and_handles_empty_input() -> None:
+    async def scenario() -> None:
+        connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+        searched_values: list[str] = []
+        created: list[dict[str, Any]] = []
+
+        async def search_records(**kwargs):
+            value = kwargs["body"]["filter"]["conditions"][0]["value"][0]
+            searched_values.append(value)
+            if value == "B":
+                return {"items": []}
+            return {"items": [{"record_id": f"rec-{value.lower()}"}]}
+
+        async def create_record(**kwargs):
+            created.append(kwargs)
+            return {"record": {"record_id": "project"}}
+
+        connector.search_records = search_records  # type: ignore[method-assign]
+        connector.create_record = create_record  # type: ignore[method-assign]
+        sink = connector.table_sink(
+            app_token="project-app",
+            table_id="projects",
+            mode="create",
+            relations={
+                "companies": {
+                    "from": "company_names",
+                    "table_id": "companies",
+                    "key": "name",
+                    "on_missing": "empty",
+                }
+            },
+        )
+
+        await sink.send(Envelope(body={"project_id": "P-1", "company_names": ["A", "B", "C"]}))
+        await sink.send(Envelope(body={"project_id": "P-2", "company_names": [None, " "]}))
+
+        assert searched_values == ["A", "B", "C"]
+        assert created[0]["fields"]["companies"] == ["rec-a", "rec-c"]
+        assert created[1]["fields"]["companies"] == []
+
+    asyncio.run(scenario())
+
+
+def test_feishu_relation_resolution_shared_source_uses_original_field_snapshot() -> None:
+    async def scenario() -> None:
+        connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+        created: list[dict[str, Any]] = []
+
+        async def search_records(**kwargs):
+            value = kwargs["body"]["filter"]["conditions"][0]["value"][0]
+            return {"items": [{"record_id": f"{kwargs['table_id']}-{value.lower()}"}]}
+
+        async def create_record(**kwargs):
+            created.append(kwargs)
+            return {"record": {"record_id": "project"}}
+
+        connector.search_records = search_records  # type: ignore[method-assign]
+        connector.create_record = create_record  # type: ignore[method-assign]
+        sink = connector.table_sink(
+            app_token="project-app",
+            table_id="projects",
+            mode="create",
+            relations={
+                "companies": {"from": "names", "table_id": "companies", "key": "name"},
+                "auditors": {"from": "names", "table_id": "auditors", "key": "name"},
+            },
+        )
+
+        await sink.send(Envelope(body={"project_id": "P-1", "names": ["A", "B"]}))
+
+        assert created[0]["fields"] == {
+            "project_id": "P-1",
+            "companies": ["companies-a", "companies-b"],
+            "auditors": ["auditors-a", "auditors-b"],
+        }
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("failure", ["missing", "duplicate", "invalid"])
+def test_feishu_relation_resolution_rejects_unsafe_values_before_target_write(failure: str) -> None:
+    async def scenario() -> None:
+        connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+        created: list[dict[str, Any]] = []
+
+        async def search_records(**kwargs):
+            if failure == "missing":
+                return {"items": []}
+            return {"items": [{"record_id": "rec-1"}, {"record_id": "rec-2"}]}
+
+        async def create_record(**kwargs):
+            created.append(kwargs)
+            return {"record": {"record_id": "project"}}
+
+        connector.search_records = search_records  # type: ignore[method-assign]
+        connector.create_record = create_record  # type: ignore[method-assign]
+        sink = connector.table_sink(
+            app_token="project-app",
+            table_id="projects",
+            mode="create",
+            relations={"companies": {"table_id": "companies", "key": "name"}},
+        )
+        value: Any = {"bad": "shape"} if failure == "invalid" else "A"
+
+        with pytest.raises(ConnectorOperationError) as raised:
+            await sink.send(Envelope(body={"companies": value}))
+
+        assert raised.value.kind is ConnectorErrorKind.PERMANENT
+        assert created == []
+
+    asyncio.run(scenario())
+
+
 def test_feishu_http_error_classifies_rate_limit_as_throttled() -> None:
     async def scenario() -> None:
         def handler(request: dict[str, Any]) -> tuple[int, dict[str, Any]]:

--- a/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_plugin.py
+++ b/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_plugin.py
@@ -22,3 +22,4 @@ def test_feishu_bitable_plugin_registers_catalog_metadata() -> None:
     assert catalog["feishu_bitable_table_sink"].roles == ("sink",)
     assert catalog["feishu_bitable_table_sink"].connector_types == ("feishu_bitable",)
     assert sink_fields["app_token"].secret is True
+    assert sink_fields["relations"].type == "mapping"

--- a/uv.lock
+++ b/uv.lock
@@ -1582,7 +1582,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-feishu-bitable"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "plugins/onestep-feishu-bitable" }
 dependencies = [
     { name = "onestep" },


### PR DESCRIPTION
## Summary

- add declarative Feishu Bitable Table Sink `relations` configuration
- resolve scalar or list business keys to related record IDs with stable order and deduplication
- support `error`, `empty`, and `create` missing-record policies, cross-Base lookups, and per-Sink concurrent create single-flight
- expose strict YAML/catalog validation and safe control-plane relation metadata
- document the enterprise/project workflow and prepare `onestep-feishu-bitable` 0.2.0

## Operational boundary

The create policy prevents duplicate creation within one Sink instance. Feishu does not expose a plugin-controlled unique constraint, so separate worker processes or deployments still need a stable unique business key and controlled creation ownership.

## Validation

- `uv run --all-packages pytest -q plugins/onestep-feishu-bitable/tests` - 53 passed
- `./scripts/run-reliability-checks.sh` - core 441 passed; every runnable official plugin suite passed; Kafka skipped by the script on Python 3.9
- `npm run build` in `docs/` - passed
- `uv build --package onestep-feishu-bitable --out-dir dist/plugin --sdist --wheel --clear` - passed
- `uvx twine check dist/plugin/*` - wheel and sdist passed
- targeted Ruff checks and `git diff --check` - passed
