### PR TITLE
fix(feishu-bitable): flush partial batches on timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   each child creates its own pool, while externally supplied connectors are rejected
   when reused across a process boundary.
 
+## onestep-feishu-bitable 0.3.5
+- Fixes partial batches never reaching Feishu when `flush_interval_s` expires:
+  the scheduled flush task no longer cancels itself before the batch API call.
+- Makes flush-timer cleanup task-identity-safe so an older cancelled timer cannot
+  clear a newer scheduled flush.
 ## onestep-feishu-bitable 0.3.4
 
 - Fixes silent data loss in batch mode: background timer flush exceptions

--- a/docs/superpowers/plans/2026-08-14-feishu-bitable-batch-timer-flush.md
+++ b/docs/superpowers/plans/2026-08-14-feishu-bitable-batch-timer-flush.md
@@ -1,0 +1,58 @@
+# Feishu Bitable Batch Timer Flush Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure a Feishu Bitable sink with `batch_size > 1` submits a partial batch when its flush timer expires.
+
+**Architecture:** Keep the existing sink buffer and Feishu `batch_create`/`batch_update` APIs. The timer must retain its own task identity while it runs; only a separately scheduled timer is cancelled when a synchronous threshold or close flush takes over.
+
+**Tech Stack:** Python 3.9+, asyncio, pytest, local JSON HTTP test server.
+
+---
+
+### Task 1: Reproduce automatic partial-batch flush
+
+**Files:**
+- Modify: `plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py`
+
+- [ ] **Step 1: Add a failing HTTP integration-style unit test**
+
+Create a `mode="create"`, `batch_size=2`, `flush_interval_s=0.01` sink, send one envelope, wait beyond the interval, and assert one `/batch_create` request contains that record before `close()` is called.
+
+- [ ] **Step 2: Run the focused test to verify the current failure**
+
+Run: `uv run --all-packages python -m pytest -q plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py -k automatic_partial_batch`
+
+Expected: FAIL because the timer cancels itself before the batch request reaches the server.
+
+### Task 2: Preserve the running timer during automatic flush
+
+**Files:**
+- Modify: `plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py`
+
+- [ ] **Step 1: Make timer cleanup task-identity-safe**
+
+Compare `self._flush_task` to `asyncio.current_task()` before cancellation. A timer calling `_flush_buffer()` must not cancel or clear its own task reference; timer completion and cancellation handlers clear the reference only when it still points to that same timer.
+
+- [ ] **Step 2: Run the focused regression test**
+
+Run: `uv run --all-packages python -m pytest -q plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py -k automatic_partial_batch`
+
+Expected: PASS with exactly one batch create request containing the partial batch.
+
+### Task 3: Release plugin 0.3.5
+
+**Files:**
+- Modify: `plugins/onestep-feishu-bitable/pyproject.toml`
+- Modify: `CHANGELOG.md`
+- Modify: `uv.lock`
+
+- [ ] **Step 1: Bump the plugin version and document the timer-flush fix**
+
+Set `onestep-feishu-bitable` to `0.3.5`; describe that scheduled partial-batch flushes no longer cancel themselves. Regenerate the workspace lockfile.
+
+- [ ] **Step 2: Verify the distribution**
+
+Run: `uv build --package onestep-feishu-bitable --out-dir dist/plugin --sdist --wheel --clear && uvx twine check dist/plugin/*`
+
+Expected: wheel and source distribution metadata both pass.

--- a/plugins/onestep-feishu-bitable/pyproject.toml
+++ b/plugins/onestep-feishu-bitable/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-feishu-bitable"
-version = "0.3.4"
+version = "0.3.5"
 description = "Feishu Bitable connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+++ b/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
@@ -905,19 +905,20 @@ class FeishuBitableTableSink(Sink):
 
     async def _flush_after_interval(self) -> None:
         """Flush the buffer after flush_interval_s of inactivity."""
+        timer_task = asyncio.current_task()
         try:
             await asyncio.sleep(self._flush_interval_s)
             lock = self._ensure_buffer_lock()
             async with lock:
                 if self._buffer and self._flush_error is None:
                     await self._flush_buffer()
-                self._flush_task = None
         except asyncio.CancelledError:
-            self._flush_task = None
             raise
         except BaseException as exc:
-            self._flush_task = None
             self._flush_error = exc
+        finally:
+            if self._flush_task is timer_task:
+                self._flush_task = None
 
     async def _flush_buffer(self) -> None:
         """Flush buffered records with batched relation resolution and write.
@@ -928,7 +929,8 @@ class FeishuBitableTableSink(Sink):
         if not self._buffer:
             return
         items = self._buffer[:]
-        if self._flush_task is not None:
+        current_task = asyncio.current_task()
+        if self._flush_task is not None and self._flush_task is not current_task:
             self._flush_task.cancel()
             self._flush_task = None
 

--- a/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
+++ b/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
@@ -1621,6 +1621,41 @@ def test_feishu_batch_create_flushes_on_threshold() -> None:
     asyncio.run(scenario())
 
 
+def test_feishu_batch_create_automatically_flushes_partial_batch() -> None:
+    async def scenario() -> None:
+        batch_requests: list[dict[str, Any]] = []
+        flushed = asyncio.Event()
+
+        def handler(request: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+            if request["target"] == "/open-apis/auth/v3/tenant_access_token/internal":
+                return 200, {"code": 0, "tenant_access_token": "tenant-token", "expire": 7200}
+            if request["target"].endswith("/batch_create"):
+                batch_requests.append(request["body"])
+                flushed.set()
+                return 200, {"code": 0, "data": {"records": [{"record_id": "rec0", "fields": {}}]}}
+            return 200, {"code": 0, "data": {}}
+
+        server, _, base_url = await _start_json_server(handler)
+        try:
+            connector = FeishuBitableConnector(app_id="app-id", app_secret="secret", base_url=base_url)
+            sink = connector.table_sink(
+                app_token="app-token",
+                table_id="tbl",
+                mode="create",
+                batch_size=2,
+                flush_interval_s=0.01,
+            )
+            await sink.send(Envelope(body={"order_no": "A001"}))
+            await asyncio.wait_for(flushed.wait(), timeout=1.0)
+
+            assert batch_requests == [{"records": [{"fields": {"order_no": "A001"}}]}]
+        finally:
+            await sink.close()
+            await _close_server(server)
+
+    asyncio.run(scenario())
+
+
 def test_feishu_batch_upsert_splits_creates_and_updates() -> None:
     async def scenario() -> None:
         create_batches: list[dict[str, Any]] = []

--- a/uv.lock
+++ b/uv.lock
@@ -1582,7 +1582,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-feishu-bitable"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "plugins/onestep-feishu-bitable" }
 dependencies = [
     { name = "onestep" },


### PR DESCRIPTION
## Summary

- prevent the scheduled Feishu Bitable flush task from cancelling itself
- make flush-task cleanup identity-safe
- add a real HTTP regression test for a partial batch flushed by `flush_interval_s`
- bump `onestep-feishu-bitable` to 0.3.5

## Root cause

With `batch_size > 1`, a partial batch relies on the scheduled timer. The timer entered `_flush_buffer()`, which cancelled `self._flush_task`; because that reference pointed to the currently running timer, cancellation was delivered at the next network await and no batch API request reached Feishu.

## Behavior

- a full batch still flushes immediately at the configured threshold
- a partial batch now flushes when `flush_interval_s` expires
- `batch_size=1` remains immediate single-record delivery

## Validation

- `uv run --all-packages python -m pytest -q plugins/onestep-feishu-bitable/tests` — 63 passed
- plugin wheel and sdist built successfully
- `twine check` passed for both artifacts
- `git diff --check` passed

Publishing remains owned by the existing GitHub Actions workflow after merge to `main`; no local deployment or PyPI upload was performed.