### PR TITLE
feat(sync): reliable MySQL to Feishu insert pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@
 - Makes direct PostgreSQL execution backends process-safe for pre-fork deployments:
   each child creates its own pool, while externally supplied connectors are rejected
   when reused across a process boundary.
+## onestep-feishu-bitable 0.4.0
+- Adds opt-in, bounded destination-key preload for single-field Insert sinks.
+- Makes buffered sends complete only after their item is confirmed created or pre-existing.
+- Reconciles ambiguous batch writes by exact-searching only affected keys before creating confirmed misses.
+- Requires one active writer per indexed destination table and retains no record IDs or durable ledger.
+## onestep-mysql 0.5.0
+- Retries the same incremental logical row with incremented delivery attempts.
+- Coalesces contiguous cursor acknowledgements into event-loop commit waves without crossing failed gaps.
+- Keeps the existing persisted cursor representation compatible with prior releases.
 
 ## onestep-feishu-bitable 0.3.5
 - Fixes partial batches never reaching Feishu when `flush_interval_s` expires:

--- a/docs/broker/feishu-bitable.md
+++ b/docs/broker/feishu-bitable.md
@@ -205,6 +205,38 @@ relations:
 
 `fallback_scan_page_limit` 是防护阀。只有确认表规模和调用配额允许 fallback 扫描时，才提高这个值。
 
+## 高吞吐 Insert 增量同步
+
+不可变操作记录可以为 `insert` Sink 开启 `insert_key_index`：Sink 启动时只分页读取
+一个 `match_fields` 字段到内存集合，正常处理不再逐条调用 Search。目标表 5 万条、
+页大小 500 时，启动扫描约 100 次。扫描达到 `insert_index_max_pages` 仍未结束会
+直接启动失败，不会使用截断索引。
+
+```yaml
+follow_record_table:
+  type: feishu_bitable_table_sink
+  connector: feishu
+  app_token: "${FEISHU_APP_TOKEN}"
+  table_id: "${FEISHU_TABLE_ID}"
+  mode: insert
+  match_fields: [编号]
+  batch_size: 100
+  flush_interval_s: 1
+  insert_key_index: true
+  insert_index_page_size: 500
+  insert_index_max_pages: 200
+  ambiguous_write_max_rounds: 3
+```
+
+该模式仅支持一个匹配字段且不能同时配置 `relations`。每次 `send()` 只有在记录已
+存在或所属批次确认创建成功后才返回，因此上游 Delivery 不会在私有缓冲区仍未落盘时
+提前确认。超时、断链或不完整响应会先精确查询受影响批次，再只创建明确缺失的键；
+查询失败永远不会被当作“不存在”。
+
+内存索引要求同一 `(app_token, table_id)` 只有一个活动写入实例。手工新增或第二个
+worker 会造成启动后竞态。该模式不保存 record ID，也不提供持久幂等账本、更新、删除、
+CDC 或多写者 exactly-once 保证。
+
 ## 下一步
 
 - [YAML 任务定义](/yaml-task-definition) - 查看插件资源注册和严格校验

--- a/docs/broker/mysql.md
+++ b/docs/broker/mysql.md
@@ -307,8 +307,9 @@ batch_size=1000
 # 表队列：可高并发（行级锁）
 @app.task(source=source, concurrency=16)
 
-# 增量同步：建议单并发（保持顺序）
-@app.task(source=incremental, concurrency=1)
+# 增量同步可并发处理；Runner 每轮仍只调用一次 fetch(limit)
+# concurrency 限制处理中 Delivery，不会发起 100 条并发 SELECT
+@app.task(source=incremental, concurrency=100)
 ```
 
 ### 4. 连接池
@@ -321,4 +322,29 @@ db = MySQLConnector(
     "&max_overflow=20"
     "&pool_recycle=3600"
 )
+```
+
+### 5. 可靠持久游标与重试
+
+生产增量同步应显式绑定 `mysql_cursor_store` 和稳定 `state_key`。成功记录可以乱序
+完成，但持久游标只推进到连续成功前缀；同一批同时释放的确认会合并为一个状态写。
+失败重试会重新投递同一逻辑行并增加 `Envelope.attempts`，缺口重试期间不会继续发出
+后续 SQL 查询。达到任务 `max_attempts` 后 Source 停在失败行之前。进程重启从已持久
+游标恢复，未提交的行会重放。
+
+```yaml
+mysql_cursors:
+  type: mysql_cursor_store
+  connector: mysql_source
+  table: onestep_cursor
+  auto_create: true
+
+follow_records:
+  type: mysql_incremental
+  connector: mysql_source
+  table: view_follow_record_sync
+  key: unionKey
+  cursor: [dataCreateTime, unionKey]
+  state: mysql_cursors
+  state_key: follow-record-sync-v1
 ```

--- a/docs/superpowers/plans/2026-08-14-feishu-insert-incremental-sync.md
+++ b/docs/superpowers/plans/2026-08-14-feishu-insert-incremental-sync.md
@@ -1,0 +1,1191 @@
+# Feishu Insert Incremental Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the single-writer `view_follow_record_sync` MySQL incremental → Feishu Bitable Insert chain fast and crash-safe by preloading destination keys, awaiting per-item batch outcomes, reconciling ambiguous writes, retrying the same MySQL row, and coalescing contiguous cursor commits.
+
+**Architecture:** Keep the change inside `FeishuBitableTableSink` and `IncrementalTableSource`; do not add a runtime batching abstraction. The Feishu sink pages one configured Insert match field into an in-memory set at open, groups concurrent sends behind per-key waiters, batch-creates only absent keys, and exact-searches only uncertain batch members; MySQL requeues the same logical delivery with incremented attempts and persists only the highest contiguous acknowledged cursor once per event-loop commit wave.
+
+**Tech Stack:** Python 3.9+, asyncio, onestep Source/Delivery/Sink contracts, SQLAlchemy async MySQL/SQLite, Feishu Bitable HTTP API, strict YAML resource plugins, pytest, uv/hatch builds, VitePress docs.
+
+---
+
+## Read first
+
+- Design contract: `docs/superpowers/specs/2026-08-14-feishu-insert-incremental-sync-design.md`
+- Runtime ordering: `src/onestep/runtime/executor.py:100-179,530-619`
+- Source loop/concurrency: `src/onestep/runtime/runner.py:45-109`
+- Plugin lifecycle: `src/onestep/app.py:691-752`
+- MySQL incremental source: `plugins/onestep-mysql/src/onestep_mysql/connector.py:638-760`
+- Feishu sink and batch matching: `plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py:763-977,1091-1163,1293-1311`
+- MySQL strict resources: `plugins/onestep-mysql/src/onestep_mysql/resources.py`
+- Feishu strict resources: `plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/resources.py`
+
+## File map and responsibilities
+
+**Create**
+
+- `plugins/onestep-feishu-bitable/tests/test_feishu_insert_incremental_chain.py` — cross-plugin `DeliveryExecutor` proof and deterministic 100k request-count benchmark; no production I/O.
+- `example/mysql_feishu_insert.yaml` — corrected lowercase strict YAML for the approved workload.
+
+**Modify**
+
+- `plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py` — destination index scan, key normalization, reliable per-key waiters, threshold/timer/close flush, uncertain-write reconciliation, privacy-safe Feishu logs.
+- `plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/resources.py` — Feishu option catalog, strict validation, and builder wiring.
+- `plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py` — focused index, waiter, recovery, shutdown, privacy, and strict YAML tests using the existing fake/local HTTP style.
+- `plugins/onestep-feishu-bitable/tests/test_feishu_bitable_plugin.py` — catalog assertions for new public fields.
+- `plugins/onestep-feishu-bitable/README.md` — concise Insert-index example and single-writer/recovery caveats.
+- `plugins/onestep-feishu-bitable/pyproject.toml` — backward-compatible minor version bump.
+- `plugins/onestep-mysql/src/onestep_mysql/connector.py` — logical-row retry queue, terminal gap block, coalesced cursor commits, MySQL aggregate logs.
+- `plugins/onestep-mysql/tests/test_mysql_incremental.py` — retry identity/attempt, gap, coalescing, save failure, close, and privacy tests.
+- `plugins/onestep-mysql/README.md` — durable incremental cursor and retry semantics.
+- `plugins/onestep-mysql/pyproject.toml` — backward-compatible minor version bump.
+- `docs/broker/feishu-bitable.md` — Insert key-index contract, startup bound, reliable batches, ambiguity, single writer.
+- `docs/broker/mysql.md` — durable cursor, contiguous/coalesced commits, logical-row retry.
+- `docs/yaml-task-definition.md` — cross-plugin strict example and three distinct batch/concurrency knobs.
+- `skills/onestep/references/connectors.md` — concise current connector wiring reference for this supported chain.
+- `CHANGELOG.md` — compatibility and operational behavior for both plugin releases.
+- `uv.lock` — regenerated plugin versions.
+
+No core runtime source file changes. No relation code changes except preserving existing regression behavior. No captain application or deployment file changes.
+
+## Dependency order and invariants
+
+1. Feishu public configuration and index loading land before normal-path routing.
+2. Reliable batch waiters land before MySQL cursor/retry changes; otherwise the cursor can still acknowledge a private buffer.
+3. Ambiguous recovery lands before the chain test enables durable acknowledgement.
+4. MySQL retry lands before cursor coalescing so tests can pin failed-gap behavior.
+5. Documentation/release metadata land only after behavior and validation are green.
+
+At every checkpoint, preserve these invariants:
+
+- `Sink.send()` returns only for confirmed-created or confirmed-pre-existing input.
+- No exact destination lookup occurs on the normal indexed path.
+- No create follows an uncertain write until exact lookup confirms missing.
+- A MySQL cursor moves only across a contiguous prefix of successful sink waiters.
+- Logs contain counts/durations/outcomes, never credentials, payloads, keys, cursor values, or record IDs.
+
+### Task 1: Add and validate the opt-in Insert index configuration
+
+**Files:**
+- Modify: `plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py:119-177,763-817`
+- Modify: `plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/resources.py:20-105,143-220,260-300`
+- Test: `plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py`
+- Test: `plugins/onestep-feishu-bitable/tests/test_feishu_bitable_plugin.py`
+
+- [ ] **Step 1: Write failing Python and strict YAML contract tests**
+
+Add these complete tests:
+
+```python
+def test_feishu_insert_key_index_config_normalizes_python_api() -> None:
+    connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+    sink = connector.table_sink(
+        app_token="app-token",
+        table_id="tbl",
+        mode="insert",
+        match_fields=["编号"],
+        batch_size=100,
+        insert_key_index=True,
+        insert_index_page_size=500,
+        insert_index_max_pages=200,
+        ambiguous_write_max_rounds=3,
+    )
+    assert sink.insert_key_index is True
+    assert sink.insert_index_page_size == 500
+    assert sink.insert_index_max_pages == 200
+    assert sink.ambiguous_write_max_rounds == 3
+
+
+@pytest.mark.parametrize(
+    "overrides, message",
+    [
+        ({"mode": "upsert"}, "insert_key_index.*mode.*insert"),
+        ({"match_fields": ["编号", "来源"]}, "exactly one match field"),
+        ({"relations": {"关联": {"table_id": "rel", "key": "编号"}}}, "relations"),
+        ({"insert_index_page_size": 0}, "insert_index_page_size.*>= 1"),
+        ({"insert_index_max_pages": 0}, "insert_index_max_pages.*>= 1"),
+        ({"ambiguous_write_max_rounds": 0}, "ambiguous_write_max_rounds.*>= 1"),
+    ],
+)
+def test_feishu_insert_key_index_rejects_unsupported_config(
+    overrides: dict[str, object], message: str
+) -> None:
+    connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+    config = {
+        "app_token": "app-token",
+        "table_id": "tbl",
+        "mode": "insert",
+        "match_fields": ["编号"],
+        "insert_key_index": True,
+    }
+    config.update(overrides)
+    with pytest.raises((TypeError, ValueError), match=message):
+        connector.table_sink(**config)
+
+
+def test_yaml_builds_indexed_insert_sink_in_strict_mode() -> None:
+    app = load_app_config(
+        {
+            "apiVersion": "onestep/v1alpha1",
+            "kind": "App",
+            "app": {"name": "follow-record-sync"},
+            "resources": {
+                "feishu": {"type": "feishu_bitable", "app_id": "id", "app_secret": "secret"},
+                "sink": {
+                    "type": "feishu_bitable_table_sink",
+                    "connector": "feishu",
+                    "app_token": "token",
+                    "table_id": "table",
+                    "mode": "insert",
+                    "match_fields": ["编号"],
+                    "batch_size": 100,
+                    "insert_key_index": True,
+                    "insert_index_page_size": 500,
+                    "insert_index_max_pages": 200,
+                    "ambiguous_write_max_rounds": 3,
+                },
+            },
+            "tasks": [],
+        },
+        strict=True,
+    )
+    assert app.resources["sink"].insert_key_index is True
+```
+
+Extend the plugin catalog test to assert types/defaults for all four new fields.
+
+- [ ] **Step 2: Run the contract tests and confirm the red phase**
+
+Run:
+
+```bash
+uv run --all-packages pytest -q \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_plugin.py \
+  -k "insert_key_index_config or indexed_insert_sink or catalog"
+```
+
+Expected: FAIL with `TypeError: table_sink() got an unexpected keyword argument 'insert_key_index'` and strict YAML unknown-field errors.
+
+- [ ] **Step 3: Implement the minimal configuration boundary**
+
+Add constants and arguments exactly as follows:
+
+```python
+_DEFAULT_INSERT_INDEX_PAGE_SIZE = 500
+_DEFAULT_INSERT_INDEX_MAX_PAGES = 200
+_DEFAULT_AMBIGUOUS_WRITE_MAX_ROUNDS = 3
+
+# FeishuBitableConnector.table_sink and FeishuBitableTableSink.__init__
+insert_key_index: bool = False,
+insert_index_page_size: int = _DEFAULT_INSERT_INDEX_PAGE_SIZE,
+insert_index_max_pages: int = _DEFAULT_INSERT_INDEX_MAX_PAGES,
+ambiguous_write_max_rounds: int = _DEFAULT_AMBIGUOUS_WRITE_MAX_ROUNDS,
+```
+
+Use `_normalize_positive_int(value, field, maximum=None)` for all three integers,
+cap page size at `_MAX_PAGE_SIZE`, require an actual boolean for
+`insert_key_index`, and reject enabled configurations unless mode is `insert`,
+`match_fields` has length one, and relations is empty. Add the same fields to
+`allowed_fields`, catalog, validation, and builder wiring in `resources.py`.
+
+- [ ] **Step 4: Run focused tests**
+
+Run the Step 2 command again.
+
+Expected: PASS; the catalog exposes `boolean/integer` fields and existing strict YAML remains valid.
+
+- [ ] **Step 5: Commit the configuration contract**
+
+```bash
+git add plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py \
+  plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/resources.py \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_plugin.py
+git commit -m "feat(feishu): configure indexed insert mode"
+```
+
+### Task 2: Page the destination match field into a bounded startup index
+
+**Files:**
+- Modify: `plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py:174-214,763-817`
+- Test: `plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py`
+
+- [ ] **Step 1: Write failing startup scan and canonical-key tests**
+
+Add tests named:
+
+```text
+test_feishu_insert_index_open_pages_match_field_only
+test_feishu_insert_index_open_rejects_truncated_scan
+test_feishu_insert_index_open_rejects_duplicate_page_token
+test_feishu_insert_index_canonicalizes_source_and_destination_keys
+test_feishu_insert_index_counts_missing_and_duplicate_keys_without_logging_values
+```
+
+The main paging test uses a fake `search_records()` returning two pages and asserts:
+
+```python
+assert calls == [
+    {"body": {"field_names": ["编号"]}, "page_size": 2, "page_token": None},
+    {"body": {"field_names": ["编号"]}, "page_size": 2, "page_token": "p2"},
+]
+assert sink._insert_keys == {"A-1", "A-2", "A-3"}
+```
+
+The max-pages test configures `insert_index_max_pages=1`, returns `has_more=True`,
+and expects a `ConnectorOperationError` containing `insert_index_max_pages=1` but no
+key values or app token. The duplicate-token test proves the scan fails rather than
+looping. Cover strings, finite numbers, booleans, empty strings, non-finite floats,
+and mappings through one `_canonical_insert_key()` helper.
+
+- [ ] **Step 2: Verify the scan tests fail**
+
+```bash
+uv run --all-packages pytest -q \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py \
+  -k "insert_index_open or canonicalizes_source"
+```
+
+Expected: FAIL because `FeishuBitableTableSink.open()` and `_insert_keys` do not exist.
+
+- [ ] **Step 3: Implement the bounded scan**
+
+Add:
+
+```python
+async def open(self) -> None:
+    if not self.insert_key_index or self._index_loaded:
+        return
+    await self._load_insert_key_index()
+
+async def _load_insert_key_index(self) -> None:
+    page_token: str | None = None
+    seen_tokens: set[str] = set()
+    loaded: set[str] = set()
+    for page_number in range(1, self.insert_index_max_pages + 1):
+        data = await self.connector.search_records(
+            app_token=self.app_token,
+            table_id=self.table_id,
+            body={"field_names": [self.match_fields[0]]},
+            page_size=self.insert_index_page_size,
+            page_token=page_token,
+            user_id_type=self.user_id_type,
+            operation=ConnectorOperation.OPEN,
+            source_name=self.name,
+            retry_delay_s=1.0,
+        )
+        raw_items = data.get("items", [])
+        if not isinstance(raw_items, list):
+            raise FeishuBitablePayloadError("insert index response items must be a list")
+        for raw_item in raw_items:
+            if not isinstance(raw_item, Mapping):
+                raise FeishuBitablePayloadError("insert index item must be a mapping")
+            raw_fields = raw_item.get("fields")
+            if not isinstance(raw_fields, Mapping):
+                missing_key_records += 1
+                continue
+            try:
+                key = _canonical_insert_key(raw_fields.get(self.match_fields[0]))
+            except FeishuBitablePayloadError:
+                missing_key_records += 1
+                continue
+            if key in loaded:
+                duplicate_keys += 1
+            loaded.add(key)
+        has_more = bool(data.get("has_more"))
+        next_token = data.get("page_token")
+        if not has_more:
+            self._insert_keys = loaded
+            self._index_loaded = True
+            return
+        if not isinstance(next_token, str) or not next_token or next_token in seen_tokens:
+            raise FeishuBitablePayloadError("insert index pagination did not advance")
+        seen_tokens.add(next_token)
+        page_token = next_token
+    raise FeishuBitablePayloadError(
+        f"insert index exceeded insert_index_max_pages={self.insert_index_max_pages}"
+    )
+```
+
+Store only canonical keys. Do not store records or IDs. Wrap payload/shape problems as
+privacy-safe OPEN connector errors. Emit one completion/failure log with pages, keys,
+missing-key count, duplicate count, duration, page size, and max pages.
+
+- [ ] **Step 4: Run scan tests and all Feishu source paging regressions**
+
+```bash
+uv run --all-packages pytest -q \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py \
+  -k "insert_index_open or canonicalizes_source or incremental_source"
+```
+
+Expected: PASS; startup does not begin with a truncated set.
+
+- [ ] **Step 5: Commit destination indexing**
+
+```bash
+git add plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
+git commit -m "feat(feishu): preload insert destination keys"
+```
+
+### Task 3: Make buffered sends await their own batch outcome
+
+**Files:**
+- Modify: `plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py:763-977,1145-1163`
+- Test: `plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py:1500-1810`
+
+- [ ] **Step 1: Write failing per-item completion tests**
+
+Add tests named:
+
+```text
+test_feishu_insert_send_waits_for_its_batch_write
+test_feishu_insert_100_concurrent_sends_form_one_batch
+test_feishu_insert_index_hit_completes_without_search_or_write
+test_feishu_insert_concurrent_duplicate_key_creates_once
+test_feishu_insert_batch_failure_completes_every_member_with_error
+test_feishu_insert_timer_flush_completes_partial_batch_waiters
+test_feishu_insert_close_drains_partial_batch_and_every_waiter
+test_feishu_insert_close_failure_fails_every_waiter
+test_feishu_insert_cancelled_sender_leaves_no_waiter_after_close
+```
+
+The central test must block the connector write:
+
+```python
+send_tasks = [
+    asyncio.create_task(sink.send(Envelope(body={"编号": f"K-{i:03d}"})))
+    for i in range(100)
+]
+await asyncio.wait_for(write_started.wait(), timeout=1.0)
+assert not any(task.done() for task in send_tasks)
+release_write.set()
+await asyncio.gather(*send_tasks)
+assert len(created_batches) == 1
+assert len(created_batches[0]) == 100
+assert sink.inflight_waiter_count == 0
+```
+
+For batch failure, assert all gathered results are the same connector failure class,
+not hung Futures, and `_pending_by_key` is empty.
+
+- [ ] **Step 2: Run tests and verify premature completion**
+
+```bash
+uv run --all-packages pytest -q \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py \
+  -k "send_waits_for_its_batch or 100_concurrent or every_member or concurrent_duplicate or index_hit"
+```
+
+Expected: FAIL because below-threshold `send()` returns before the write and the
+current bare `_buffer` cannot assign outcomes to members.
+
+- [ ] **Step 3: Introduce localized pending-key groups**
+
+Add only sink-private types:
+
+```python
+class _InsertState(str, Enum):
+    BUFFERED = "buffered"
+    WRITING = "writing"
+    RECOVERING = "recovering"
+
+@dataclass
+class _PendingInsert:
+    key: str
+    fields: dict[str, Any]
+    waiters: list[asyncio.Future[None]]
+    buffered_at: float
+    state: _InsertState = _InsertState.BUFFERED
+```
+
+Replace the indexed Insert path's bare buffer with:
+
+```python
+self._pending_by_key: dict[str, _PendingInsert] = {}
+self._pending_order: deque[str] = deque()
+self._flush_lock: asyncio.Lock | None = None
+self._inflight_waiter_count = 0
+```
+
+Keep existing non-indexed and relation paths behaviorally compatible. Factor
+`_complete_pending(pending, exc=None)` so every waiter is completed once and removed
+from accounting. `send()` joins duplicate keys, elects a threshold flusher under the
+lock, releases the lock, flushes if elected, and awaits its own Future.
+
+- [ ] **Step 4: Rewrite threshold/timer/close flush around a sealed batch**
+
+Implement:
+
+```python
+async def _flush_indexed_insert(self, *, reason: str) -> None:
+    async with self._ensure_flush_lock():
+        batch = self._seal_indexed_batch()
+        if not batch:
+            return
+        await self._write_indexed_batch(batch, reason=reason)
+```
+
+A batch is at most `_batch_size` distinct keys. On confirmed success, validate response
+cardinality, add keys to `_insert_keys`, then complete waiters. On definite failure,
+fail every member and remove the batch. Timer identity cleanup must retain the 0.3.5
+self-cancellation fix. Close rejects new sends, cancels only a separate timer, flushes
+all remaining batches, and asserts no waiter remains.
+
+- [ ] **Step 5: Run focused and existing batching tests**
+
+```bash
+uv run --all-packages pytest -q \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py \
+  -k "feishu_insert or batch_create or batch_upsert or automatically_flushes"
+```
+
+Expected: PASS. In particular, 100 concurrent sends produce one create and remain
+pending until its result.
+
+- [ ] **Step 6: Commit reliable batching**
+
+```bash
+git add plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
+git commit -m "fix(feishu): await buffered insert outcomes"
+```
+
+### Task 4: Reconcile ambiguous writes before retrying creates
+
+**Files:**
+- Modify: `plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py:923-977,1091-1143,1293-1311`
+- Test: `plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py`
+
+- [ ] **Step 1: Add failing uncertainty and partial-recovery tests**
+
+Add tests named:
+
+```text
+test_feishu_insert_ambiguous_batch_reconciles_found_keys_without_repeat
+test_feishu_insert_ambiguous_batch_creates_only_confirmed_missing_keys
+test_feishu_insert_recovery_rejects_duplicate_match
+test_feishu_insert_recovery_search_error_is_not_missing
+test_feishu_insert_recovery_exhaustion_fails_only_unresolved_waiters
+test_feishu_insert_retry_of_uncertain_key_searches_before_create
+test_feishu_insert_short_success_response_enters_recovery
+test_feishu_insert_http_disconnect_after_accept_does_not_duplicate_create
+```
+
+For a four-key batch where search finds K1/K3, assert the next create body contains
+only K2/K4. For the real HTTP test, make the first `/batch_create` handler record keys
+then close without a valid response; subsequent `/search` returns those accepted keys.
+Assert there is exactly one create request.
+
+- [ ] **Step 2: Verify the recovery tests fail**
+
+```bash
+uv run --all-packages pytest -q \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py \
+  -k "ambiguous_batch or recovery_ or uncertain_key or disconnect_after_accept or short_success"
+```
+
+Expected: FAIL because current flush propagates the write error or the executor repeats
+`send()` without an uncertainty barrier.
+
+- [ ] **Step 3: Implement exact-search recovery for affected keys only**
+
+Add:
+
+```python
+self._uncertain_keys: set[str] = set()
+
+async def _reconcile_ambiguous_insert_batch(
+    self,
+    batch: list[_PendingInsert],
+    *,
+    reason: str,
+) -> None:
+    unresolved = {item.key: item for item in batch}
+    for round_number in range(1, self.ambiguous_write_max_rounds + 1):
+        found, missing = await self._search_affected_insert_keys(unresolved.values())
+        self._confirm_found(found)
+        unresolved = {key: unresolved[key] for key in missing}
+        if not unresolved:
+            return
+        try:
+            await self._batch_create_pending(list(unresolved.values()))
+        except ConnectorOperationError as exc:
+            if _is_ambiguous_write_error(exc):
+                continue
+            self._fail_pending(unresolved.values(), exc)
+            return
+        self._confirm_created(unresolved.values())
+        return
+    self._fail_pending(
+        unresolved.values(),
+        ConnectorOperationError(
+            backend="feishu_bitable",
+            operation=ConnectorOperation.SEND,
+            kind=ConnectorErrorKind.UNCERTAIN,
+            source_name=self.name,
+            message=(
+                "feishu_bitable insert recovery exhausted "
+                f"after {self.ambiguous_write_max_rounds} rounds"
+            ),
+        ),
+    )
+```
+
+Use exact `_find_matches()` with `page_size=2` and semaphore 20. Treat
+`UNCERTAIN`, `DISCONNECTED`, `TRANSIENT`, and `THROTTLED` write outcomes as ambiguous;
+never turn search errors into misses. Before buffering a key present in
+`_uncertain_keys`, run the same exact reconciliation gate. Remove uncertainty only
+when the key is found or create is confirmed.
+
+- [ ] **Step 4: Pass the focused recovery matrix**
+
+Run the Step 2 command again.
+
+Expected: PASS; no test issues a second create for a key that the recovery search found.
+
+- [ ] **Step 5: Run all Feishu tests**
+
+```bash
+uv run --all-packages pytest -q plugins/onestep-feishu-bitable/tests
+```
+
+Expected: all tests pass, including relation and timer regressions.
+
+- [ ] **Step 6: Commit ambiguity handling**
+
+```bash
+git add plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py
+git commit -m "fix(feishu): reconcile uncertain insert batches"
+```
+
+### Task 5: Retry the same MySQL logical row with bounded attempts
+
+**Files:**
+- Modify: `plugins/onestep-mysql/src/onestep_mysql/connector.py:638-760`
+- Test: `plugins/onestep-mysql/tests/test_mysql_incremental.py`
+
+- [ ] **Step 1: Write failing retry identity and gap tests**
+
+Add tests named:
+
+```text
+test_mysql_incremental_retry_requeues_same_logical_row_with_incremented_attempt
+test_mysql_incremental_retry_pauses_new_sql_fetches_until_gap_resolves
+test_mysql_incremental_retry_does_not_duplicate_pending_cursor_token
+test_mysql_incremental_max_attempts_runs_attempts_zero_one_two
+test_mysql_incremental_exhaustion_blocks_source_before_failed_cursor
+test_mysql_incremental_restart_replays_uncommitted_failed_row
+```
+
+Use a real SQLite incremental source with rows 1 and 2 and `DeliveryExecutor` plus a
+sink that fails row 1. The MaxAttempts test must assert:
+
+```python
+assert seen == [(1, 0), (1, 1), (1, 2)]
+assert await state.load("sync") is None
+assert len(source._pending) == 1
+```
+
+The delayed-retry test starts `delivery.retry(delay_s=0.05)`, calls `fetch(10)` during
+the delay, and asserts no SQL suffix row is returned. After the delay, the same row is
+returned first with attempts incremented.
+
+- [ ] **Step 2: Reproduce the current no-op retry defect**
+
+```bash
+uv run --all-packages pytest -q \
+  plugins/onestep-mysql/tests/test_mysql_incremental.py \
+  -k "retry_requeues or retry_pauses or max_attempts_runs or exhaustion_blocks or restart_replays"
+```
+
+Expected: FAIL because `IncrementalDelivery.retry()` only sleeps, does not increment
+attempts, and `_fetched_cursor` remains beyond the failed row.
+
+- [ ] **Step 3: Add a source-local retry state**
+
+Add:
+
+```python
+@dataclass
+class _IncrementalPendingRow:
+    token: tuple[Any, ...]
+    body: dict[str, Any]
+    meta: dict[str, Any]
+    retry_envelope: Envelope | None = None
+    retry_ready_at: float | None = None
+    retry_inflight: bool = False
+    terminal_error: Exception | None = None
+```
+
+Replace `_pending: deque[tuple[Any, ...]]` with a deque of these rows and a token map.
+`retry_token()` creates an envelope with copied body/meta and `attempts + 1`, marks the
+head retrying before sleeping, then makes it ready. `fetch()` returns ready retries
+first and returns `[]` without SQL while the head is delayed/in flight. It never
+appends the same token twice.
+
+`IncrementalDelivery.fail()` delegates to `fail_token()`, stores a permanent blocked
+error, and subsequent fetch raises a redacted permanent FETCH error. `ack_token()`
+removes the row only through the contiguous commit path. Do not put this behavior in
+the handler or `DeliveryExecutor`.
+
+- [ ] **Step 4: Run retry tests and existing cursor tests**
+
+```bash
+uv run --all-packages pytest -q \
+  plugins/onestep-mysql/tests/test_mysql_incremental.py \
+  -k "retry or exhaustion or cursor or pending_gap or tie_breaker"
+```
+
+Expected: PASS; attempts are 0/1/2 and no durable cursor crosses the failed row.
+
+- [ ] **Step 5: Commit logical-row retry**
+
+```bash
+git add plugins/onestep-mysql/src/onestep_mysql/connector.py \
+  plugins/onestep-mysql/tests/test_mysql_incremental.py
+git commit -m "fix(mysql): retry incremental logical rows"
+```
+
+### Task 6: Coalesce contiguous cursor saves without weakening crash safety
+
+**Files:**
+- Modify: `plugins/onestep-mysql/src/onestep_mysql/connector.py:655-760`
+- Test: `plugins/onestep-mysql/tests/test_mysql_incremental.py`
+
+- [ ] **Step 1: Add failing commit-wave tests**
+
+Add tests named:
+
+```text
+test_mysql_incremental_coalesces_100_contiguous_acks_into_one_save
+test_mysql_incremental_out_of_order_gap_does_not_schedule_cursor_save
+test_mysql_incremental_cursor_save_failure_keeps_prefix_pending
+test_mysql_incremental_ack_waits_for_its_commit_wave
+test_mysql_incremental_ack_arriving_during_save_gets_second_commit
+test_mysql_incremental_close_drains_active_cursor_commit
+```
+
+Use a recording `CursorStore`:
+
+```python
+class RecordingCursorStore(InMemoryCursorStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.saves: list[list[object]] = []
+        self.release_save = asyncio.Event()
+
+    async def save(self, key: str, value: object) -> None:
+        self.saves.append(list(value))
+        await super().save(key, value)
+```
+
+Fetch 100 rows, start 100 `ack()` tasks without awaiting them individually, then
+`await asyncio.gather(*acks)`. Assert `state.saves == [[100, 100]]` for the chosen
+cursor fixture. In the save-failure test, assert `_pending` and `_acked` still contain
+the prefix and a subsequent ack/flush can save it.
+
+- [ ] **Step 2: Confirm current write amplification**
+
+```bash
+uv run --all-packages pytest -q \
+  plugins/onestep-mysql/tests/test_mysql_incremental.py \
+  -k "coalesces_100 or commit_wave or save_failure or close_drains_active"
+```
+
+Expected: FAIL because current `ack_token()` calls `state.save()` synchronously for
+each newly contiguous row.
+
+- [ ] **Step 3: Implement the event-loop commit coordinator**
+
+Add fields:
+
+```python
+self._commit_task: asyncio.Task[None] | None = None
+self._commit_error: BaseException | None = None
+```
+
+Implement `_ensure_commit_task()` and `_flush_commits()` with this exact order:
+
+1. `await asyncio.sleep(0)` to gather the current acknowledgement wave;
+2. under `_runtime_commit_lock()`, find the highest contiguous acknowledged pending row;
+3. release the lock and `await state.save(state_key, list(highest.token))`;
+4. reacquire the lock, remove only the saved prefix, update `_committed_cursor`, and
+   clear their acknowledged markers;
+5. if another contiguous prefix appeared during save, loop and save it; otherwise exit;
+6. clear `_commit_task` only if task identity still matches.
+
+Every in-order ack captures and awaits the active task. On save failure, do not remove
+pending rows or advance `_committed_cursor`; propagate to all ack callers waiting on
+that wave. `close()` awaits the task and propagates `_commit_error`.
+
+- [ ] **Step 4: Run coalescing tests**
+
+Run the Step 2 command again.
+
+Expected: PASS; one normal commit for 100 simultaneously released sink waiters, and a
+second save only when an ack arrives after the first snapshot.
+
+- [ ] **Step 5: Run the full MySQL plugin suite**
+
+```bash
+uv run --all-packages pytest -q -m "not integration" plugins/onestep-mysql/tests
+```
+
+Expected: all non-integration MySQL tests pass.
+
+- [ ] **Step 6: Commit coalesced commits**
+
+```bash
+git add plugins/onestep-mysql/src/onestep_mysql/connector.py \
+  plugins/onestep-mysql/tests/test_mysql_incremental.py
+git commit -m "perf(mysql): coalesce incremental cursor commits"
+```
+
+### Task 7: Add privacy-safe operational telemetry
+
+**Files:**
+- Modify: `plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py`
+- Modify: `plugins/onestep-mysql/src/onestep_mysql/connector.py`
+- Test: `plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py`
+- Test: `plugins/onestep-mysql/tests/test_mysql_incremental.py`
+
+- [ ] **Step 1: Write failing structured-log tests**
+
+Add:
+
+```text
+test_feishu_insert_logs_index_batch_waiter_lookup_and_recovery_aggregates
+test_feishu_insert_logs_never_include_secrets_payload_keys_cursors_or_record_ids
+test_mysql_incremental_logs_fetch_retry_commit_and_cursor_lag_aggregates
+test_mysql_incremental_logs_never_include_dsn_payload_key_or_cursor_values
+```
+
+Use `caplog` and sentinel secrets/values. Assert aggregate extras exist:
+
+```python
+assert {
+    "scan_pages", "scan_keys", "duration_s", "page_size", "max_pages"
+} <= index_record.__dict__.keys()
+assert {
+    "batch_size", "oldest_batch_age_s", "inflight_waiter_count", "flush_reason"
+} <= batch_record.__dict__.keys()
+```
+
+Serialize `record.getMessage()` plus allowed extras and assert none of
+`mysql://user:password@host/db`, `app-token-secret`, `union-key-secret`,
+`record-id-secret`, payload field values, or cursor tuple values appears.
+
+- [ ] **Step 2: Run telemetry tests and verify missing fields**
+
+```bash
+uv run --all-packages pytest -q \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py \
+  plugins/onestep-mysql/tests/test_mysql_incremental.py \
+  -k "logs_index_batch or logs_fetch_retry or logs_never_include"
+```
+
+Expected: FAIL because these connector-stage aggregate records do not yet exist.
+
+- [ ] **Step 3: Add module loggers and bounded aggregate fields**
+
+Define one module logger in each connector. Emit exactly the events from the design:
+
+```python
+logger.info(
+    "feishu insert batch write",
+    extra={
+        "event": "feishu_insert_batch_write",
+        "batch_size": len(batch),
+        "duration_s": duration,
+        "outcome": outcome,
+        "flush_reason": reason,
+        "recovery_round": recovery_round,
+        "inflight_waiter_count": self.inflight_waiter_count,
+    },
+)
+```
+
+and analogous `mysql_incremental_fetch`, `mysql_incremental_retry`, and
+`mysql_incremental_cursor_commit` records. `fetched_cursor_lag_rows` is a count of
+pending rows, never a cursor value. Include source fetch count/size/duration, index
+pages/keys/duration, normal lookup avoided count, recovery lookup count, write
+outcome/duration, batch age/size, waiter count, committed/fetched lag count, and retry
+counts across the records.
+
+- [ ] **Step 4: Run telemetry and connector suites**
+
+```bash
+uv run --all-packages pytest -q \
+  plugins/onestep-feishu-bitable/tests \
+  plugins/onestep-mysql/tests -m "not integration"
+```
+
+Expected: both plugin suites pass; privacy sentinel assertions pass.
+
+- [ ] **Step 5: Commit observability**
+
+```bash
+git add plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py \
+  plugins/onestep-feishu-bitable/tests/test_feishu_bitable_connector.py \
+  plugins/onestep-mysql/src/onestep_mysql/connector.py \
+  plugins/onestep-mysql/tests/test_mysql_incremental.py
+git commit -m "feat(connectors): expose insert sync telemetry"
+```
+
+### Task 8: Prove the chain and the 100k request-count model
+
+**Files:**
+- Create: `plugins/onestep-feishu-bitable/tests/test_feishu_insert_incremental_chain.py`
+
+- [ ] **Step 1: Write the failing real-executor cursor-boundary test**
+
+Create a SQLite `view_follow_record_sync` fixture with 100 rows, a recording cursor
+store, an indexed Feishu sink whose batch write blocks, and a `OneStepApp` task with
+`concurrency=100`. Drive fetched deliveries through `DeliveryExecutor.execute()`:
+
+```python
+executions = [asyncio.create_task(executor.execute(delivery)) for delivery in batch]
+await asyncio.wait_for(write_started.wait(), timeout=1.0)
+assert await state.load("follow-record-sync-v1") is None
+assert not any(task.done() for task in executions)
+release_write.set()
+outcomes = await asyncio.gather(*executions)
+assert all(outcome.completion == "succeeded" for outcome in outcomes)
+assert await state.load("follow-record-sync-v1") == [100, "K-000100"]
+assert state.save_count == 1
+```
+
+- [ ] **Step 2: Write the deterministic 100k synthetic request-count benchmark**
+
+Add `test_indexed_insert_100k_request_count_benchmark`. It must use fakes only and:
+
+```python
+existing = {f"K-{i:06d}" for i in range(50_000)}
+incoming = [f"K-{i:06d}" for i in range(100_000)]
+
+async def run_benchmark(sink: FeishuBitableTableSink) -> None:
+    await sink.open()
+    for offset in range(0, len(incoming), 100):
+        await asyncio.gather(*(
+            sink.send(Envelope(body={"编号": key}))
+            for key in incoming[offset:offset + 100]
+        ))
+    await sink.close()
+
+assert fake.search_page_requests == 100
+assert fake.normal_exact_search_requests == 0
+assert fake.batch_create_requests == 500
+assert fake.data_requests == 600
+assert all(size == 100 for size in fake.create_batch_sizes)
+assert sink.inflight_waiter_count == 0
+assert not hasattr(sink, "record_ids")
+```
+
+Feed input in bounded waves of 100 concurrent sends so the test itself does not create
+100,000 tasks simultaneously.
+
+- [ ] **Step 3: Run chain tests and verify the first failure**
+
+```bash
+uv run --all-packages pytest -q \
+  plugins/onestep-feishu-bitable/tests/test_feishu_insert_incremental_chain.py
+```
+
+Expected before Tasks 3–6: FAIL because sends complete before the blocked write, retry
+does not preserve identity, and cursor saves are not coalesced. After those tasks:
+PASS with the exact request counts above.
+
+- [ ] **Step 4: Run three repetitions to catch waiter/timer races**
+
+```bash
+for run in 1 2 3; do
+  uv run --all-packages pytest -q \
+    plugins/onestep-feishu-bitable/tests/test_feishu_insert_incremental_chain.py || exit 1
+done
+```
+
+Expected: all three runs pass with identical request counts and zero leaked waiters.
+
+- [ ] **Step 5: Commit the chain proof**
+
+```bash
+git add plugins/onestep-feishu-bitable/tests/test_feishu_insert_incremental_chain.py
+git commit -m "test(sync): prove indexed insert cursor boundary"
+```
+
+### Task 9: Document the supported workload and strict YAML
+
+**Files:**
+- Create: `example/mysql_feishu_insert.yaml`
+- Modify: `docs/broker/feishu-bitable.md`
+- Modify: `docs/broker/mysql.md`
+- Modify: `docs/yaml-task-definition.md`
+- Modify: `plugins/onestep-feishu-bitable/README.md`
+- Modify: `plugins/onestep-mysql/README.md`
+- Modify: `skills/onestep/references/connectors.md`
+
+- [ ] **Step 1: Add the exact lowercase workload example**
+
+Create `example/mysql_feishu_insert.yaml` using the full YAML from the design. Keep
+these exact workload values:
+
+```yaml
+follow_records:
+  type: mysql_incremental
+  connector: mysql_source
+  table: view_follow_record_sync
+  key: unionKey
+  cursor: [dataCreateTime, unionKey]
+  batch_size: 1000
+  state: mysql_cursors
+  state_key: follow-record-sync-v1
+
+follow_record_table:
+  type: feishu_bitable_table_sink
+  connector: feishu
+  app_token: "${FEISHU_APP_TOKEN}"
+  table_id: "${FEISHU_TABLE_ID}"
+  mode: insert
+  match_fields: [编号]
+  batch_size: 100
+  insert_key_index: true
+  insert_index_page_size: 500
+  insert_index_max_pages: 200
+  ambiguous_write_max_rounds: 3
+```
+
+The task uses `concurrency: 100`, `max_attempts: 3`, and optional
+`config.batch_size: 100` with a comment that it is handler-only.
+
+- [ ] **Step 2: Add a tiny importable example handler for strict validation**
+
+Because `onestep check --strict` resolves handler references, use YAML passthrough by
+omitting `handler` and retaining `emit`; the source view must already expose destination
+field names including `编号`. Document that captain applications with a mapping handler
+should replace passthrough with their own `handler.ref` without moving retry or batching
+logic into it.
+
+- [ ] **Step 3: Update connector and YAML documentation**
+
+Document all of these without adding broader sync promises:
+
+- startup scan bounds and `D=50,000` / page-size-500 model;
+- single active writer requirement and manual-write caveat;
+- per-item completion and shutdown guarantee;
+- exact-search recovery only after ambiguous writes;
+- durable `mysql_cursor_store`, explicit `state_key`, contiguous prefix, and coalesced
+  commit semantics;
+- retry of the same logical row and restart attempts reset;
+- migration from old in-memory cursor by full replay plus destination skip;
+- no relation IDs, durable ledger, update/delete, CDC, or multi-writer guarantee;
+- task `config.batch_size` is handler-only; source resource batch size, sink resource
+  batch size, and task concurrency are independent.
+
+- [ ] **Step 4: Validate strict YAML with dummy environment values**
+
+```bash
+MYSQL_DSN='sqlite://' \
+FEISHU_APP_ID='app-id' \
+FEISHU_APP_SECRET='secret' \
+FEISHU_APP_TOKEN='app-token' \
+FEISHU_TABLE_ID='table-id' \
+uv run --all-packages onestep check --strict example/mysql_feishu_insert.yaml
+```
+
+Expected: exit 0 and output identifies app `follow-record-sync`; there are no unknown
+fields or uppercase enum-value failures.
+
+- [ ] **Step 5: Build the docs site**
+
+```bash
+pnpm --dir docs install --frozen-lockfile
+pnpm --dir docs build
+```
+
+Expected: VitePress build exits 0. Existing non-blocking dead-link warnings may remain;
+no new warning points at the modified pages.
+
+- [ ] **Step 6: Commit documentation**
+
+```bash
+git add example/mysql_feishu_insert.yaml \
+  docs/broker/feishu-bitable.md docs/broker/mysql.md docs/yaml-task-definition.md \
+  plugins/onestep-feishu-bitable/README.md plugins/onestep-mysql/README.md \
+  skills/onestep/references/connectors.md
+git commit -m "docs(sync): describe reliable mysql to feishu insert"
+```
+
+### Task 10: Release metadata, compatibility gates, and packages
+
+**Files:**
+- Modify: `plugins/onestep-feishu-bitable/pyproject.toml`
+- Modify: `plugins/onestep-mysql/pyproject.toml`
+- Modify: `CHANGELOG.md`
+- Modify: `uv.lock`
+
+- [ ] **Step 1: Record compatibility impact in the changelog**
+
+Add unreleased plugin entries stating:
+
+```markdown
+## onestep-feishu-bitable 0.4.0
+- Adds opt-in, bounded destination-key preload for single-field Insert sinks.
+- Makes buffered sends complete only after their item is confirmed created or pre-existing.
+- Reconciles ambiguous batch writes by exact-searching only affected keys before creating confirmed misses.
+- Requires one active writer per indexed destination table and retains no record IDs or durable ledger.
+
+## onestep-mysql 0.5.0
+- Retries the same incremental logical row with incremented delivery attempts.
+- Coalesces contiguous cursor acknowledgements into event-loop commit waves without crossing failed gaps.
+- Keeps the existing persisted cursor representation compatible with prior releases.
+```
+
+Use these minor versions unless `main` has advanced to an equal/newer release; in that
+case choose the next minor version while preserving the same release semantics.
+
+- [ ] **Step 2: Bump versions and regenerate the lock**
+
+```bash
+uv lock
+```
+
+Expected: `uv.lock` shows the chosen local versions for `onestep-feishu-bitable` and
+`onestep-mysql`; unrelated dependency versions do not churn.
+
+- [ ] **Step 3: Run focused plugin suites and strict YAML again**
+
+```bash
+uv run --all-packages pytest -q plugins/onestep-feishu-bitable/tests
+uv run --all-packages pytest -q -m "not integration" plugins/onestep-mysql/tests
+MYSQL_DSN='sqlite://' FEISHU_APP_ID='app-id' FEISHU_APP_SECRET='secret' \
+FEISHU_APP_TOKEN='app-token' FEISHU_TABLE_ID='table-id' \
+uv run --all-packages onestep check --strict example/mysql_feishu_insert.yaml
+```
+
+Expected: all tests pass and strict validation exits 0.
+
+- [ ] **Step 4: Build and inspect both distributions**
+
+```bash
+rm -rf dist/feishu-plugin dist/mysql-plugin
+uv build --package onestep-feishu-bitable --out-dir dist/feishu-plugin --sdist --wheel
+uv build --package onestep-mysql --out-dir dist/mysql-plugin --sdist --wheel
+uvx twine check dist/feishu-plugin/* dist/mysql-plugin/*
+```
+
+Expected: four artifacts build; twine reports every wheel/sdist `PASSED`.
+
+- [ ] **Step 5: Commit releases**
+
+```bash
+git add plugins/onestep-feishu-bitable/pyproject.toml \
+  plugins/onestep-mysql/pyproject.toml CHANGELOG.md uv.lock
+git commit -m "chore(plugins): release reliable insert sync"
+```
+
+### Task 11: Full regression, self-review, and no-mistakes handoff
+
+**Files:**
+- Review: every file listed in the file map
+
+- [ ] **Step 1: Run core and all plugin reliability suites**
+
+```bash
+uv run pytest -q -m "not integration"
+ONESTEP_PYTHON_BIN="$(pwd)/.venv/bin/python" ./scripts/run-reliability-checks.sh
+```
+
+Expected: core non-integration tests and every runnable plugin suite pass; Kafka may be
+reported skipped only when its documented Python/dependency condition applies.
+
+- [ ] **Step 2: Run syntax, whitespace, and package checks**
+
+```bash
+uv run python -m compileall -q src \
+  plugins/onestep-feishu-bitable/src plugins/onestep-mysql/src
+git diff --check HEAD~7..HEAD
+git status --short
+```
+
+Expected: compileall and diff check exit 0. Status contains only intentional files from
+the file map; no credentials, generated caches, production files, or unrelated edits.
+
+- [ ] **Step 3: Re-run the 100k benchmark and YAML/docs gates**
+
+```bash
+uv run --all-packages pytest -q \
+  plugins/onestep-feishu-bitable/tests/test_feishu_insert_incremental_chain.py \
+  -k "100k_request_count_benchmark or cursor_boundary"
+MYSQL_DSN='sqlite://' FEISHU_APP_ID='app-id' FEISHU_APP_SECRET='secret' \
+FEISHU_APP_TOKEN='app-token' FEISHU_TABLE_ID='table-id' \
+uv run --all-packages onestep check --strict example/mysql_feishu_insert.yaml
+pnpm --dir docs build
+```
+
+Expected: request counts are exactly 100 scans + 500 creates + 0 normal exact searches;
+strict YAML and docs build pass.
+
+- [ ] **Step 4: Perform the mandatory fresh-eyes self-review**
+
+Check the final diff against every design section and record the result in the
+implementation handoff:
+
+```text
+[ ] Scope is only Feishu indexed Insert batching and MySQL incremental durability/retry/coalescing.
+[ ] No generic runtime batch-delivery API or core ordering change exists.
+[ ] Every send waiter is completed once on success, pre-existing, failure, cancellation, or close.
+[ ] Every ambiguous create path exact-searches affected keys before another create.
+[ ] Cursor save occurs only after contiguous successful/pre-existing sink completion.
+[ ] Retry attempts refer to the same logical row and stop at MaxAttempts.
+[ ] Startup/round/page/concurrency/waiter bounds are enforced and tested.
+[ ] No DSN, token, payload, key value, record ID, or cursor value enters logs/descriptors/errors.
+[ ] Strict YAML uses lowercase enum values and explains all three batch/concurrency controls.
+[ ] Placeholder scan reports no incomplete or defer-until-later instructions.
+[ ] Type/function/property names are consistent across code, tests, docs, and catalog.
+[ ] Existing relation behavior and non-indexed Feishu behavior remain green.
+```
+
+- [ ] **Step 5: Make one final checkpoint commit if validation caused changes**
+
+```bash
+git add -A
+git diff --cached --quiet || git commit -m "test(sync): complete reliability validation"
+```
+
+Expected: either no staged changes or one small validation-only commit; never squash
+away the earlier TDD checkpoints during implementation.
+
+- [ ] **Step 6: Hand off to no-mistakes; do not push directly**
+
+First read the complete current `/Users/miclon/.agents/skills/no-mistakes/SKILL.md`,
+then run:
+
+```bash
+no-mistakes axi run --intent "Implement the approved single-writer MySQL incremental to Feishu Bitable Insert design: bounded destination key preload, per-item reliable batching, affected-key ambiguous recovery, same-row MaxAttempts retry, contiguous coalesced cursor commits, privacy-safe telemetry, strict YAML/docs, and plugin releases; do not add a generic runtime batching API or deploy production." --yes
+```
+
+Expected: drive every returned gate according to the skill until the tool reports
+`outcome: checks-passed` or `outcome: passed`. Never restart/update the shared daemon.
+On any daemon error, stop and report the exact blocker to the coordinator. The
+no-mistakes executor—not the worker—owns any push, PR, and CI phases.
+
+## Execution handoff
+
+Plan complete and saved to
+`docs/superpowers/plans/2026-08-14-feishu-insert-incremental-sync.md`.
+
+Execution must use one of these modes:
+
+1. **Subagent-Driven (recommended):** use `superpowers:subagent-driven-development`,
+   dispatch a fresh worker per task, and perform specification then code-quality review
+   at each checkpoint.
+2. **Inline Execution:** use `superpowers:executing-plans`, execute tasks in order, and
+   stop at each commit/validation checkpoint.
+
+The executor must not mix modes mid-task, skip red-phase commands, push directly, open
+a PR manually, or access production.

--- a/docs/superpowers/specs/2026-08-14-feishu-insert-incremental-sync-design.md
+++ b/docs/superpowers/specs/2026-08-14-feishu-insert-incremental-sync-design.md
@@ -1,0 +1,640 @@
+# Feishu Insert Incremental Sync Design
+
+## Status and decision record
+
+This document formalizes the captain-approved design for one production-shaped chain:
+immutable operation-log rows in MySQL are read from `view_follow_record_sync` and
+inserted into one Feishu Bitable table. `unionKey` is globally unique across every
+upstream data source. The MySQL cursor is `(dataCreateTime, unionKey)` and the Feishu
+match field is `编号`.
+
+The chosen design is deliberately narrower than a general synchronization system:
+
+1. opt-in Insert mode preloads the destination key field into memory;
+2. every buffered send waits for its own durable-or-pre-existing outcome;
+3. uncertain batch writes are reconciled by exact key lookup before any repeat;
+4. MySQL owns durable, contiguous cursor progress and logical-row retry;
+5. cursor writes are coalesced at an event-loop commit boundary.
+
+The alternative designs were rejected for this workload:
+
+- A durable idempotency ledger gives stronger multi-process guarantees but violates
+  the approved boundary and adds schema and operational ownership.
+- Per-row destination search preserves statelessness but retains the measured
+  100,000-search bottleneck.
+- CDC, reconciliation snapshots, update/upsert, deletes, and a workflow abstraction
+  solve different products and are not part of this change.
+
+There are no unresolved product choices in this design.
+
+## Goals
+
+- Make normal Insert processing require no exact Feishu search per input row.
+- Do not acknowledge a MySQL delivery until its specific destination key is either
+  confirmed present or its create is confirmed successful.
+- Preserve batches of 100 with task concurrency 100; waiting for confirmation must
+  not serialize the chain to one record at a time.
+- Never blindly repeat a batch after a transport or service outcome that might have
+  committed.
+- Persist only the MySQL composite cursor. Do not persist Feishu record IDs, payload
+  hashes, or an idempotency mapping.
+- Retry the same logical MySQL row with incremented `Envelope.attempts`, so
+  `MaxAttempts` is effective before later restart recovery.
+- Bound startup scanning, in-flight waiters, retries, and recovery work.
+- Emit useful counters, sizes, durations, and outcomes without exposing credentials,
+  payloads, or business key values.
+- Keep current behavior unchanged unless the new Insert index is explicitly enabled.
+
+## Non-goals
+
+- Relation resolution or any related-table record ID handling.
+- Retaining destination record IDs.
+- A durable idempotency ledger or mapping table.
+- Correctness with independent writers targeting the same Feishu table.
+- Updates, upserts, deletion propagation, mutable-row synchronization, CDC, or
+  snapshot reconciliation.
+- Changes to the captain's handler or production deployment.
+- A generic runtime batching API. The reliable buffer remains a Feishu sink concern;
+  retry and cursor changes remain a MySQL incremental-source concern.
+
+## Existing defects and constraints
+
+At the starting revision `b415779`:
+
+- `DeliveryExecutor` sends to sinks before `delivery.ack()`
+  (`src/onestep/runtime/executor.py`, `_apply_success` and `_send_to_sink`). This order
+  is correct only if `Sink.send()` means the sink operation has completed.
+- `FeishuBitableTableSink.send()` appends below-threshold records to `_buffer` and
+  returns. The executor therefore acknowledges and the incremental source can persist
+  cursors before Feishu receives the batch.
+- Insert uses `_batch_match_and_split()`, which performs one exact search per distinct
+  key before batch create. Batch size reduces writes but not normal lookup count.
+- `IncrementalDelivery.retry()` only sleeps. It neither increments attempts nor makes
+  the same row fetchable again. Because `_fetched_cursor` has already moved beyond the
+  row, `MaxAttempts` does not retry that logical row in the running process.
+- `IncrementalTableSource.ack_token()` saves once for each in-order acknowledgement.
+  With a reliable Feishu batch releasing 100 waiters together, this can turn one
+  destination write into roughly 100 cursor-store writes.
+
+The existing Source/Delivery/runtime contract is sufficient. No core API or execution
+ordering change is required.
+
+## Configuration contract
+
+The feature is opt-in and limited to the approved safe combination:
+
+| Field | Type | Default | Meaning |
+|---|---|---:|---|
+| `insert_key_index` | boolean | `false` | Preload and use an in-memory key index for Insert mode. |
+| `insert_index_page_size` | integer | `500` | Destination records requested per startup page; normalized to Feishu's maximum 500. |
+| `insert_index_max_pages` | integer | `200` | Hard startup scan bound. At defaults, at most 100,000 destination records are examined. |
+| `ambiguous_write_max_rounds` | integer | `3` | Maximum exact-search/create reconciliation rounds for one uncertain batch. |
+| `batch_size` | integer | `1` | Feishu sink write boundary; the captain uses 100. |
+| `flush_interval_s` | number | `1.0` | Maximum age of a partial buffered batch. |
+
+`insert_key_index: true` is valid only when all of these hold:
+
+- `mode` is lowercase `insert`;
+- `match_fields` contains exactly one field;
+- `relations` is absent.
+
+Both Python construction and strict YAML validation enforce the same rules. This
+restriction keeps the implementation surgical and makes the index a set of canonical
+text keys rather than a general expression or composite-key engine. The captain's
+field is `编号`.
+
+The source uses existing `mysql_cursor_store` wiring. No new MySQL YAML fields are
+required. An explicit stable `state_key` is required in the workload documentation so
+renaming a YAML resource cannot reset progress accidentally.
+
+### Canonical key
+
+The indexed match value is normalized as text:
+
+- non-empty strings are stripped;
+- finite integers, finite floats, and booleans use their stable string form;
+- other values and empty text are permanent payload errors.
+
+The same function processes destination scan values, incoming payload values, and
+recovery search values. The key is held only in memory and is never logged. Records in
+the destination that lack a usable `编号` are counted as `missing_key_records` and do
+not enter the index. Duplicate destination keys collapse in the set and increment an
+aggregate duplicate count.
+
+## Components and responsibilities
+
+### Feishu destination key index
+
+`FeishuBitableTableSink.open()` performs the opt-in scan before task runners start.
+It repeatedly calls the existing records search endpoint with:
+
+```python
+{
+    "field_names": [self.match_fields[0]],
+}
+```
+
+and follows `page_token`, requesting `insert_index_page_size` records. Only the match
+field is requested. The scan stops on `has_more == false`. If Feishu still reports
+another page after `insert_index_max_pages`, startup fails with a misconfiguration
+error; it never starts with a known-truncated index.
+
+The bound is observable as pages, keys, missing-key records, duplicate keys, duration,
+configured page size, and configured maximum pages. For the captain's approximately
+50,000 destination keys, page size 500 requires about 100 startup requests and remains
+below the default 200-page limit.
+
+The set is authoritative for normal processing during that sink instance:
+
+- key present: complete that send as confirmed pre-existing;
+- key absent: place it in the reliable buffer without a normal exact lookup;
+- confirmed create: add the key before completing its waiters.
+
+No destination record ID is read into durable state or retained by the sink.
+
+### Reliable buffered item and key group
+
+The buffer owns `_PendingInsert` entries rather than bare field dictionaries:
+
+```python
+@dataclass
+class _PendingInsert:
+    key: str
+    fields: dict[str, Any]
+    waiters: list[asyncio.Future[None]]
+    buffered_at: float
+    state: _InsertState
+```
+
+A key has one buffered payload and one or more waiters. A second concurrent send for
+the same absent key joins the existing key group instead of creating a duplicate
+record. Insert semantics make the first buffered payload authoritative; all joined
+waiters represent the same globally unique operation key.
+
+`send()` performs these actions:
+
+1. reject new work after close begins;
+2. parse and canonicalize the match key;
+3. if the key is indexed, record an avoided lookup and return successfully;
+4. if the key is marked uncertain, perform bounded exact reconciliation before any
+   normal buffering;
+5. create a waiter and append or join the pending key group under the buffer lock;
+6. elect one threshold flusher or ensure one timer flusher exists;
+7. release the lock;
+8. run the elected flush if applicable, then await this send's waiter.
+
+The lock is never held while a caller awaits its waiter or while network I/O runs.
+With concurrency 100 and batch size 100, 100 delivery tasks can enter `send()`; the
+100th elects the flush and all 100 complete from one batch result. If fewer than 100
+new keys are buffered—for example because some inputs already exist—the independent
+flush timer commits the partial batch.
+
+### MySQL logical-row retry queue
+
+The MySQL source retains cursor ordering in `_pending`, and adds a source-local queue
+of retry deliveries. A retry delivery contains the same payload and cursor token with
+`Envelope.attempts + 1`.
+
+`IncrementalDelivery.retry(delay_s)` delegates to the source. The source immediately
+marks that token retrying, which pauses new SQL reads beyond the gap; after the
+requested bounded delay, it enqueues that same logical row. `fetch(limit)` drains
+ready retry deliveries before issuing a new SQL query and returns no new rows while a
+retry token is delayed or in flight. It does not append the cursor token to `_pending`
+a second time.
+
+This is the smallest design consistent with the existing contract: runtime policy
+continues to call `Delivery.retry()`, while the source decides how its claimed logical
+row becomes available again. The business handler contains no retry bookkeeping.
+
+When `MaxAttempts` is exhausted, `IncrementalDelivery.fail()` marks the source blocked
+at that cursor and the next fetch raises a permanent, privacy-safe
+`ConnectorOperationError`. The durable cursor remains before the failed row and the
+worker stops rather than accumulating an unbounded suffix behind an uncommittable gap.
+A process restart retries from the durable cursor with attempts reset, which is normal
+at-least-once restart behavior. Operators must correct a permanent payload or raise
+the configured attempt budget before restarting.
+
+### Coalesced cursor commit coordinator
+
+The source continues to advance only through the contiguous prefix of `_pending`
+whose tokens were acknowledged after their sink waiters completed.
+
+Instead of saving inside every `ack_token()` call, the first acknowledgement that
+makes the head contiguous schedules one `_flush_commits()` task. The task yields once
+to the event loop, snapshots the highest contiguous acknowledged token, and performs
+one `state.save(state_key, list(highest))`. Acknowledgements arriving during the save
+are included in a subsequent loop iteration before the commit task exits.
+
+Exact safety boundary:
+
+- an in-order `ack_token()` that participates in the active commit waits for that
+  commit task;
+- out-of-order acknowledgements beyond a gap may return, as they do today, but cannot
+  move the durable cursor;
+- `_pending` entries are removed and `_committed_cursor` changes only after the store
+  save succeeds;
+- on save failure, pending/acknowledged state remains retryable and the triggering
+  acknowledgement receives the error;
+- source close drains the active commit task or propagates its error.
+
+A crash before the coalesced save replays already-created rows. The Feishu startup
+index confirms them pre-existing, so replay is safe. A cursor is never persisted past
+an unconfirmed sink waiter, so coalescing does not introduce data loss.
+
+## Per-record state transitions
+
+```text
+FETCHED(attempt=0)
+  -> HANDLER_OK
+  -> SINK_SEND
+       -> KEY_INDEX_HIT -> CONFIRMED_PREEXISTING
+       -> BUFFERED -> WRITE_INFLIGHT -> CONFIRMED_CREATED
+       -> BUFFERED -> WRITE_INFLIGHT -> RECOVERY_LOOKUP
+            -> FOUND -> CONFIRMED_PREEXISTING
+            -> MISSING -> RECOVERY_CREATE -> CONFIRMED_CREATED
+            -> UNRESOLVED/PERMANENT_ERROR -> SEND_FAILED
+  -> ACK_PENDING
+       -> OUT_OF_ORDER_ACKED (held behind a gap)
+       -> CURSOR_COMMIT_PENDING
+       -> CURSOR_COMMITTED
+
+SEND_FAILED
+  -> runtime immediate connector retry (same sink instance)
+  -> source MaxAttempts retry of SAME_LOGICAL_ROW(attempt + 1)
+  -> terminal source block when the configured attempt budget is exhausted
+```
+
+A send returns only from `CONFIRMED_PREEXISTING` or `CONFIRMED_CREATED`. It raises for
+all error states. Therefore the existing executor's subsequent `delivery.ack()` is no
+longer premature.
+
+## Per-batch state transitions
+
+```text
+COLLECTING
+  -- unique key count == batch_size --> SEALED(reason=threshold)
+  -- oldest age == flush_interval_s --> SEALED(reason=timer)
+  -- sink close --------------------> SEALED(reason=close)
+
+SEALED -> WRITING
+  -> HTTP/API CONFIRMED SUCCESS
+       -> index all member keys
+       -> complete all member waiters successfully
+       -> remove batch
+  -> DEFINITE FAILURE
+       -> complete all member waiters with the error
+       -> remove batch
+  -> AMBIGUOUS FAILURE
+       -> mark all member keys uncertain
+       -> RECONCILING
+            -> exact-search only affected keys
+            -> complete found keys successfully and index them
+            -> batch-create only keys confirmed missing
+            -> repeat at most ambiguous_write_max_rounds
+            -> complete unresolved keys with error; retain their uncertain marks
+```
+
+A successful batch response is confirmed only when the API reports success and its
+`records` list contains one response record per submitted unique key. A malformed or
+short success response enters reconciliation because the actual write outcome cannot
+be assigned safely.
+
+A definite failure is a permanent or misconfigured connector error that proves the
+write was rejected. `UNCERTAIN`, disconnected, transient, and throttled write errors
+are treated conservatively as ambiguous. Exact-search errors never mean “missing.”
+
+## Ambiguous-outcome recovery
+
+Recovery is local to the affected batch. It never scans the full destination and never
+checks unrelated keys.
+
+For each round:
+
+1. exact-search every unresolved key with `page_size=2` and bounded concurrency 20;
+2. more than one match is a permanent destination uniqueness error;
+3. one match confirms success and adds the key to the index;
+4. zero matches confirms the key is currently missing;
+5. create only the confirmed-missing subset as one batch;
+6. validate that batch response; on another ambiguous result, begin the next round.
+
+Found-key waiters may complete while unresolved members continue recovery. A definite
+create failure completes only the keys submitted in that failed create; already found
+keys remain successful.
+
+Unresolved keys remain in an in-memory `uncertain_keys` set even after their current
+waiters receive an error. A runtime retry of such a key must exact-search first and may
+create only after a confirmed miss. Thus the executor's built-in immediate retry and
+the source's later logical-row retry cannot blindly duplicate an uncertain write.
+
+On process restart the full destination scan reconstructs the index and replaces the
+non-durable uncertainty set. With no durable ledger, the design necessarily relies on
+Feishu list/search reflecting accepted creates by the next bounded recovery or restart
+scan. This is the strongest supported ambiguity handling within the explicit no-ledger
+boundary; it is not an exactly-once or multi-writer guarantee.
+
+## Startup and restart flow
+
+1. Build resources and validate strict YAML.
+2. Open the MySQL connector and cursor store.
+3. Open `mysql_incremental`; load the existing cursor list under the explicit
+   `state_key`. Missing state means the beginning of the view.
+4. Open the Feishu sink; page `编号` into the bounded in-memory set.
+5. Only after every resource opens successfully, start task runners.
+6. Fetch from `(dataCreateTime, unionKey) > committed_cursor`, ordered by the same
+   tuple and limited by source batch size and available task concurrency.
+7. Process with task concurrency 100 and sink batch size 100.
+
+After a crash:
+
+- any cursor already saved is not refetched;
+- any destination write confirmed before an unsaved cursor can replay;
+- the rebuilt destination key index turns that replay into confirmed pre-existing
+  success without another create;
+- any ambiguous accepted write is discovered by the startup scan, subject to the
+  Feishu visibility assumption above.
+
+## Shutdown and cancellation
+
+Runtime drain first stops fetches and waits for in-flight deliveries. Those deliveries
+remain in flight while their sink waiters are pending, so a normal drain naturally
+allows threshold or timer flushes to finish.
+
+`FeishuBitableTableSink.close()` then:
+
+1. atomically rejects new sends and cancels only a separate scheduled timer;
+2. seals and flushes any remaining buffer with `reason=close`;
+3. applies the same ambiguous recovery policy;
+4. completes every remaining waiter successfully or exceptionally;
+5. verifies the pending-key map and in-flight waiter count are zero.
+
+If close itself cannot finish because network/recovery fails, all unresolved waiters
+receive the final connector error before close raises. No Future is left pending.
+Cancelled send coroutines do not remove buffered key groups; close still flushes or
+fails them. Since cancelled deliveries are not acknowledged, restart replay is safe.
+
+`IncrementalTableSource.close()` awaits an active cursor commit task and clears queued
+retry envelopes only after preserving the durable cursor. Queued or in-flight rows
+that were not acknowledged replay after restart.
+
+## Single-writer limitation
+
+Correct normal operation requires one active `FeishuBitableTableSink` writer for the
+configured `(app_token, table_id)`.
+
+The in-memory set is updated only by this sink. A second process, manual destination
+inserts, or another application can create a key after startup without updating the
+set, causing a create race. Feishu does not provide a plugin-controlled unique
+constraint that closes that race. No process lock is added.
+
+“Multiple data sources” in the approved workload means their immutable rows are
+already unified by `view_follow_record_sync` and globally unique `unionKey`; it does
+not mean multiple independent destination writers. Deployment must use one active
+worker instance for this table. Scaling occurs through `concurrency: 100` inside that
+worker.
+
+## Performance model
+
+Let:
+
+- `D` be destination keys at startup;
+- `N` be incoming rows;
+- `E` be incoming keys already in the startup/current index;
+- `B` be Feishu batch size (100);
+- `P` be startup page size (500);
+- `A` be ambiguous batches (normally zero).
+
+Normal Feishu request count is approximately:
+
+```text
+startup scans = ceil(D / P)
+batch creates = ceil((N - E) / B)
+normal exact searches = 0
+recovery exact searches <= A * B * ambiguous_write_max_rounds
+```
+
+At `D=50,000`, `N=100,000`, and 50,000 overlapping keys, normal traffic is about 100
+startup pages plus 500 creates: 600 data requests, excluding token acquisition. With
+no overlap it is about 1,100 requests. The current path is about 100,000 exact searches
+plus writes.
+
+Memory is `O(min(D, page_size * max_pages) + B + concurrency)` key/waiter entries. At
+default bounds, at most 100,000 scanned records can contribute keys. The implementation
+benchmark measures request counts and bounded objects, not wall-clock performance
+against production.
+
+## Observability and privacy
+
+Plugins emit structured log records with numeric aggregate fields. They do not add a
+new core metrics API. Existing task events continue to expose end-to-end outcomes;
+connector logs supply the missing internal stages.
+
+### MySQL fields
+
+- `event=mysql_incremental_fetch`: `fetch_count`, `requested_limit`, `row_count`,
+  `duration_s`, `pending_cursor_rows`, `fetched_cursor_lag_rows`.
+- `event=mysql_incremental_retry`: `retry_count`, `attempt`, `delay_s`,
+  `pending_cursor_rows`.
+- `event=mysql_incremental_cursor_commit`: `cursor_save_count`,
+  `coalesced_ack_count`, `duration_s`, `outcome`, `pending_cursor_rows`,
+  `fetched_cursor_lag_rows`.
+
+`fetched_cursor_lag_rows` is a count of fetched tokens not covered by the committed
+prefix. Composite cursor values themselves are not logged.
+
+### Feishu fields
+
+- `event=feishu_insert_index_scan`: `scan_pages`, `scan_keys`,
+  `missing_key_records`, `duplicate_keys`, `duration_s`, `outcome`,
+  `page_size`, `max_pages`.
+- `event=feishu_insert_buffer`: `buffered_batch_size`, `oldest_batch_age_s`,
+  `inflight_waiter_count`, `flush_reason`.
+- `event=feishu_insert_batch_write`: `batch_size`, `duration_s`, `outcome`,
+  `flush_reason`, `recovery_round`.
+- `event=feishu_insert_lookup`: cumulative `normal_lookup_avoided_count`,
+  `recovery_lookup_count`, `outcome`.
+- `event=feishu_insert_retry`: `retry_count`, `recovery_round`, `unresolved_count`.
+
+Allowed outcomes are bounded strings such as `success`, `preexisting`, `ambiguous`,
+`permanent_error`, and `exhausted`. Logs never include DSNs, app secrets, app tokens,
+payloads, field values, `unionKey`, `编号`, record IDs, search bodies, or cursor values.
+Tests inspect `LogRecord` extras and serialized messages for privacy.
+
+## Migration and rolling upgrade
+
+1. Release the reliable Feishu sink and MySQL retry/commit changes with
+   `insert_key_index` defaulting to false.
+2. Add durable `mysql_cursor_store` and the explicit `state_key` to strict YAML before
+   enabling the index.
+3. Stop the old worker completely. Do not overlap old and new workers; this is both a
+   rolling-upgrade safeguard and the single-writer requirement.
+4. Start the new worker with `insert_key_index: true` and inspect the startup scan
+   completion record before accepting source processing.
+
+If the old deployment used only `InMemoryCursorStore`, there is no cursor to migrate.
+The new worker starts from the beginning, but the destination preload skips all keys
+already present. This replay is intentional and avoids inventing a cursor from an
+unknown in-memory position.
+
+The persisted cursor representation remains the existing JSON list, so a new MySQL
+plugin can read old durable state and the previous plugin can read newly committed
+state.
+
+### Rollback
+
+- To retain reliability while reducing change surface, set `insert_key_index: false`;
+  Insert falls back to exact searches but keeps per-item completion waiters and safe
+  cursor acknowledgement.
+- A binary rollback must stop the new worker first. Do not run old and new binaries
+  concurrently.
+- Do not roll back to a Feishu plugin whose buffered `send()` returns before write
+  completion while incremental cursor persistence is enabled. If such a rollback is
+  unavoidable, stop processing and reconcile destination/source state before resume.
+- The durable cursor needs no schema downgrade.
+
+## Correct strict YAML for the captain workload
+
+```yaml
+apiVersion: onestep/v1alpha1
+kind: App
+
+app:
+  name: follow-record-sync
+  shutdown_timeout_s: 120
+  strict_env: true
+
+resources:
+  mysql_source:
+    type: mysql
+    dsn: "${MYSQL_DSN}"
+
+  mysql_cursors:
+    type: mysql_cursor_store
+    connector: mysql_source
+    table: onestep_cursor
+    auto_create: true
+
+  follow_records:
+    type: mysql_incremental
+    connector: mysql_source
+    table: view_follow_record_sync
+    key: unionKey
+    cursor: [dataCreateTime, unionKey]
+    batch_size: 1000
+    poll_interval_s: 1.0
+    state: mysql_cursors
+    state_key: follow-record-sync-v1
+
+  feishu:
+    type: feishu_bitable
+    app_id: "${FEISHU_APP_ID}"
+    app_secret: "${FEISHU_APP_SECRET}"
+    timeout_s: 10.0
+
+  follow_record_table:
+    type: feishu_bitable_table_sink
+    connector: feishu
+    app_token: "${FEISHU_APP_TOKEN}"
+    table_id: "${FEISHU_TABLE_ID}"
+    mode: insert
+    match_fields: [编号]
+    batch_size: 100
+    flush_interval_s: 1.0
+    insert_key_index: true
+    insert_index_page_size: 500
+    insert_index_max_pages: 200
+    ambiguous_write_max_rounds: 3
+
+tasks:
+  - name: insert_follow_records
+    source: follow_records
+    emit: follow_record_table
+    handler:
+      ref: app.tasks.follow_record:map_follow_record
+    concurrency: 100
+    timeout_s: 120
+    retry:
+      type: max_attempts
+      max_attempts: 3
+      delay_s: 1.0
+    config:
+      batch_size: 100
+```
+
+All enum-like values (`type`, `mode`, and retry `type`) are lowercase. The schema's
+`apiVersion` and `kind` retain their required spelling.
+
+`tasks[].config.batch_size` is only handler data available as
+`ctx.task_config["batch_size"]`; it does not batch runtime deliveries. The independent
+controls are:
+
+- `follow_records.batch_size`: maximum rows returned by one source fetch, further
+  capped by available task concurrency;
+- `follow_record_table.batch_size`: Feishu write batch size;
+- `tasks[].concurrency`: maximum concurrent delivery executions.
+
+## Test strategy
+
+### Feishu unit and integration-style tests
+
+- Startup scans all pages, requests only `编号`, updates the index, and fails closed at
+  the page limit.
+- Python and strict YAML validation accept only the supported opt-in combination.
+- Existing keys complete without exact search or write.
+- 100 concurrent absent sends produce one batch create, and no send completes while
+  the write is blocked.
+- Timer and close flushes complete every member; write failure raises through every
+  member; cancellation leaves no unresolved Future.
+- Duplicate concurrent keys create once and complete all joined waiters.
+- Confirmed creates update the set before waiter completion.
+- Ambiguous success, partial visibility, repeated ambiguity, duplicate matches,
+  recovery exhaustion, and retry-after-exhaustion follow the defined state machine.
+- A real local HTTP server simulates connection loss after accepting a batch, then
+  exposes accepted keys to search; no duplicate create occurs.
+- Structured logs expose aggregate fields and omit secrets, payloads, keys, cursor
+  values, and record IDs.
+
+### MySQL tests
+
+- A sink failure followed by `MaxAttempts(3)` executes the same cursor token with
+  attempts 0, 1, and 2.
+- Retry does not append duplicate `_pending` tokens, pauses new SQL reads while the
+  cursor gap is retrying, and dispatches the ready retry before any later row.
+- Exhaustion leaves durable state before the failed row and blocks further fetch.
+- Out-of-order successes cannot move the cursor across a failed/waiting row.
+- 100 contiguous concurrent acknowledgements produce one coalesced cursor save in the
+  normal scheduling case.
+- Save failure leaves tokens pending and a later retry can persist the same prefix.
+- Source close drains a pending save.
+- Existing SQLite restart and cursor tie-break tests remain green.
+
+### End-to-end contract and benchmark
+
+A fake MySQL source/Feishu connector chain runs 100 concurrent deliveries through the
+real `DeliveryExecutor` ordering and proves the durable cursor remains unchanged until
+the Feishu batch is confirmed.
+
+A deterministic 100,000-row synthetic request-count benchmark preloads 50,000
+existing destination keys in 100 pages, then processes 100,000 keys with 50,000
+overlap. It asserts:
+
+- 100 startup scans;
+- zero normal exact searches;
+- 500 batch creates at size 100;
+- 600 total destination data requests, excluding token acquisition;
+- no retained record IDs and no pending waiters at completion.
+
+The benchmark uses fakes and count assertions rather than production timing, making
+it stable in CI.
+
+## Compatibility and release impact
+
+No stable onestep core API changes. Existing Feishu configurations preserve per-row
+search behavior because `insert_key_index` defaults to false. Reliable completion
+changes the timing contract of buffered sends to match the documented Sink contract:
+`send()` now means the item has completed rather than merely entered a private buffer.
+
+The Feishu and MySQL plugins each receive a backward-compatible minor release because
+they add public configuration/behavior and change operational guarantees. Their
+`pyproject.toml`, root `CHANGELOG.md`, and `uv.lock` entries are updated using repository
+release conventions. Documentation updates cover both plugins and the cross-plugin
+example.

--- a/docs/yaml-task-definition.md
+++ b/docs/yaml-task-definition.md
@@ -890,3 +890,14 @@ files can use the provided `type` values without changing onestep core.
 
 The repository includes plugin packages under `plugins/`, each with its own
 entry point and release workflow.
+
+## MySQL to Feishu insert controls
+
+`mysql_incremental.batch_size` limits rows returned by one source fetch, and the
+runtime further caps that fetch by available task concurrency.
+`feishu_bitable_table_sink.batch_size` is the Feishu write boundary.
+`tasks[].concurrency` is the maximum number of in-flight deliveries. These are
+independent; `tasks[].config.batch_size` would only be arbitrary data exposed as
+`ctx.task_config` and does not batch either connector. See
+`example/mysql_feishu_insert.yaml` for the strict lowercase, durable-cursor
+configuration.

--- a/example/mysql_feishu_insert.yaml
+++ b/example/mysql_feishu_insert.yaml
@@ -1,0 +1,60 @@
+apiVersion: onestep/v1alpha1
+kind: App
+
+app:
+  name: follow-record-sync
+  shutdown_timeout_s: 120
+  strict_env: true
+
+resources:
+  mysql_source:
+    type: mysql
+    dsn: "${MYSQL_DSN}"
+
+  mysql_cursors:
+    type: mysql_cursor_store
+    connector: mysql_source
+    table: onestep_cursor
+    auto_create: true
+
+  follow_records:
+    type: mysql_incremental
+    connector: mysql_source
+    table: view_follow_record_sync
+    key: unionKey
+    cursor: [dataCreateTime, unionKey]
+    batch_size: 1000
+    poll_interval_s: 1
+    state: mysql_cursors
+    state_key: follow-record-sync-v1
+
+  feishu:
+    type: feishu_bitable
+    app_id: "${FEISHU_APP_ID}"
+    app_secret: "${FEISHU_APP_SECRET}"
+    timeout_s: 10
+
+  follow_record_table:
+    type: feishu_bitable_table_sink
+    connector: feishu
+    app_token: "${FEISHU_APP_TOKEN}"
+    table_id: "${FEISHU_TABLE_ID}"
+    mode: insert
+    match_fields: [编号]
+    batch_size: 100
+    flush_interval_s: 1
+    insert_key_index: true
+    insert_index_page_size: 500
+    insert_index_max_pages: 200
+    ambiguous_write_max_rounds: 3
+
+tasks:
+  - name: insert_follow_records
+    source: follow_records
+    emit: follow_record_table
+    concurrency: 100
+    timeout_s: 120
+    retry:
+      type: max_attempts
+      max_attempts: 3
+      delay_s: 1

--- a/plugins/onestep-feishu-bitable/README.md
+++ b/plugins/onestep-feishu-bitable/README.md
@@ -55,3 +55,10 @@ The input may contain one business key or a list. Missing related records can
 fail the send, be omitted, or be created and linked. See the
 [Feishu Bitable broker documentation](https://onestep.code05.com/broker/feishu-bitable)
 for the complete behavior and concurrency limits.
+
+For immutable, insert-only logs, `insert_key_index: true` preloads one unique
+`match_fields` value and removes normal per-row destination searches. It is
+single-writer only, cannot be combined with `relations`, retains no record IDs,
+and waits for each batch member's confirmed outcome before returning from
+`send()`. Ambiguous writes are searched by affected key before confirmed misses
+are recreated. See `example/mysql_feishu_insert.yaml`.

--- a/plugins/onestep-feishu-bitable/pyproject.toml
+++ b/plugins/onestep-feishu-bitable/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-feishu-bitable"
-version = "0.3.5"
+version = "0.4.0"
 description = "Feishu Bitable connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+++ b/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
@@ -19,6 +19,8 @@ from onestep.connectors.base import Delivery, Sink, Source
 from onestep.resilience import ConnectorErrorKind, ConnectorOperation, ConnectorOperationError
 from onestep.state import CursorStore, InMemoryCursorStore
 
+logger = logging.getLogger(__name__)
+
 _DEFAULT_BASE_URL = "https://open.feishu.cn"
 _DEFAULT_TIMEOUT_S = 10.0
 _DEFAULT_BATCH_SIZE = 100
@@ -840,6 +842,132 @@ class FeishuBitableTableSink(Sink):
         self._flush_task: asyncio.Task[None] | None = None
         self._flush_error: Exception | None = None
         self._closed = False
+        # Insert key index state
+        self._insert_keys: set[str] | None = None
+        self._index_loaded = False
+        self._scan_duplicate_keys = 0
+        self._scan_missing_key_records = 0
+
+    async def open(self) -> None:
+        """Open the sink and, if insert_key_index is enabled, preload destination keys."""
+        if self.insert_key_index and not self._index_loaded:
+            await self._load_insert_key_index()
+
+    async def _load_insert_key_index(self) -> None:
+        """Page the configured match field into a bounded in-memory set.
+
+        The scan requests only the match field, stops at insert_index_max_pages,
+        and fails closed if the destination table has more records than the bound.
+        """
+        page_token: str | None = None
+        seen_tokens: set[str] = set()
+        loaded: set[str] = set()
+        missing_key_records = 0
+        duplicate_keys = 0
+        start_time = time.monotonic()
+
+        for page_number in range(1, self.insert_index_max_pages + 1):
+            try:
+                data = await self.connector.search_records(
+                    app_token=self.app_token,
+                    table_id=self.table_id,
+                    body={"field_names": [self.match_fields[0]]},
+                    page_size=self.insert_index_page_size,
+                    page_token=page_token,
+                    user_id_type=self.user_id_type,
+                    operation=ConnectorOperation.OPEN,
+                    source_name=self.name,
+                    retry_delay_s=1.0,
+                )
+            except ConnectorOperationError:
+                raise
+            except Exception as exc:
+                raise ConnectorOperationError(
+                    backend="feishu_bitable",
+                    operation=ConnectorOperation.OPEN,
+                    kind=ConnectorErrorKind.PERMANENT,
+                    source_name=self.name,
+                    retry_delay_s=1.0,
+                    cause=exc,
+                    message="feishu_bitable insert index scan failed",
+                ) from exc
+
+            raw_items = data.get("items", [])
+            if not isinstance(raw_items, list):
+                raise ConnectorOperationError(
+                    backend="feishu_bitable",
+                    operation=ConnectorOperation.OPEN,
+                    kind=ConnectorErrorKind.PERMANENT,
+                    source_name=self.name,
+                    retry_delay_s=1.0,
+                    message="feishu_bitable insert index response items must be a list",
+                )
+
+            for raw_item in raw_items:
+                if not isinstance(raw_item, Mapping):
+                    missing_key_records += 1
+                    continue
+                raw_fields = raw_item.get("fields")
+                if not isinstance(raw_fields, Mapping):
+                    missing_key_records += 1
+                    continue
+                try:
+                    key = _canonical_insert_key(raw_fields.get(self.match_fields[0]))
+                except FeishuBitablePayloadError:
+                    missing_key_records += 1
+                    continue
+                if key in loaded:
+                    duplicate_keys += 1
+                loaded.add(key)
+
+            has_more = bool(data.get("has_more"))
+            next_token = data.get("page_token")
+            if not has_more:
+                self._insert_keys = loaded
+                self._index_loaded = True
+                self._scan_duplicate_keys = duplicate_keys
+                self._scan_missing_key_records = missing_key_records
+                duration = time.monotonic() - start_time
+                logger.info(
+                    "feishu insert index scan",
+                    extra={
+                        "event": "feishu_insert_index_scan",
+                        "scan_pages": page_number,
+                        "scan_keys": len(loaded),
+                        "missing_key_records": missing_key_records,
+                        "duplicate_keys": duplicate_keys,
+                        "duration_s": round(duration, 3),
+                        "outcome": "success",
+                        "page_size": self.insert_index_page_size,
+                        "max_pages": self.insert_index_max_pages,
+                    },
+                )
+                return
+
+            if not isinstance(next_token, str) or not next_token or next_token in seen_tokens:
+                raise ConnectorOperationError(
+                    backend="feishu_bitable",
+                    operation=ConnectorOperation.OPEN,
+                    kind=ConnectorErrorKind.PERMANENT,
+                    source_name=self.name,
+                    retry_delay_s=1.0,
+                    message="feishu_bitable insert index pagination did not advance",
+                )
+            seen_tokens.add(next_token)
+            page_token = next_token
+
+        # Exhausted max_pages while Feishu still has more
+        raise ConnectorOperationError(
+            backend="feishu_bitable",
+            operation=ConnectorOperation.OPEN,
+            kind=ConnectorErrorKind.PERMANENT,
+            source_name=self.name,
+            retry_delay_s=1.0,
+            message=(
+                "feishu_bitable insert index exceeded "
+                f"insert_index_max_pages={self.insert_index_max_pages}"
+            ),
+        )
 
     def _ensure_buffer_lock(self) -> asyncio.Lock:
         if self._buffer_lock is None:
@@ -1483,6 +1611,41 @@ def _normalize_mode(value: str) -> str:
     if normalized not in {"upsert", "create", "update", "insert"}:
         raise ValueError("mode must be one of 'upsert', 'create', 'update', or 'insert'")
     return normalized
+
+
+_DELETED = object()
+
+
+def _canonical_insert_key(value: Any) -> str:
+    """Normalize a match field value to its canonical string form.
+
+    Returns the canonical key or raises FeishuBitablePayloadError if the
+    value cannot be used as a stable insert key.
+    """
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            raise FeishuBitablePayloadError("insert key value is empty after stripping")
+        return stripped
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    if isinstance(value, (int, float)):
+        if value != value or abs(value) == float("inf"):
+            raise FeishuBitablePayloadError(
+                "insert key value must be a finite number"
+            )
+        return str(value)
+    if value is None:
+        raise FeishuBitablePayloadError("insert key value must not be None")
+    if isinstance(value, (dict, list, set, tuple)):
+        raise FeishuBitablePayloadError(
+            "insert key value must be a string, number, or boolean, "
+            "got {!r}".format(type(value).__name__)
+        )
+    raise FeishuBitablePayloadError(
+        "insert key value must be a string, number, or boolean, "
+        "got {!r}".format(type(value).__name__)
+    )
 
 
 def _normalize_insert_key_index(value: bool) -> bool:

--- a/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+++ b/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
@@ -869,6 +869,8 @@ class FeishuBitableTableSink(Sink):
         self._flush_lock: asyncio.Lock | None = None
         self._uncertain_keys: set[str] = set()
         self._normal_lookup_avoided_count = 0
+        self._recovery_lookup_count = 0
+        self._insert_retry_count = 0
         self._inflight_waiter_count = 0
 
     async def open(self) -> None:
@@ -1263,6 +1265,16 @@ class FeishuBitableTableSink(Sink):
 
         round_number = recovery_round
         while unresolved and round_number <= self.ambiguous_write_max_rounds:
+            self._insert_retry_count += 1
+            logger.info(
+                "feishu insert retry",
+                extra={
+                    "event": "feishu_insert_retry",
+                    "retry_count": self._insert_retry_count,
+                    "recovery_round": round_number,
+                    "unresolved_count": len(unresolved),
+                },
+            )
             found, missing, lookup_failed = await self._lookup_pending_keys(unresolved)
             if found:
                 self._confirm_found(found)
@@ -1374,6 +1386,16 @@ class FeishuBitableTableSink(Sink):
                     )
                 else:
                     failed.append(pending)
+        self._recovery_lookup_count += len(pending_list)
+        logger.info(
+            "feishu insert lookup",
+            extra={
+                "event": "feishu_insert_lookup",
+                "normal_lookup_avoided_count": self._normal_lookup_avoided_count,
+                "recovery_lookup_count": self._recovery_lookup_count,
+                "outcome": "success" if not failed else "error",
+            },
+        )
         return found, missing, failed
 
     def _confirm_created(self, batch: list[_PendingInsert]) -> None:
@@ -1423,7 +1445,11 @@ class FeishuBitableTableSink(Sink):
         try:
             matches = await self._find_matches({self.match_fields[0]: key})
         except ConnectorOperationError:
+            self._recovery_lookup_count += 1
+            self._log_insert_lookup(outcome="error")
             raise
+        self._recovery_lookup_count += 1
+        self._log_insert_lookup(outcome="success")
         if len(matches) > 1:
             raise FeishuBitablePayloadError(
                 "insert match field resolved to multiple destination records"
@@ -1433,6 +1459,17 @@ class FeishuBitableTableSink(Sink):
                 self._insert_keys.add(key)
         # A successful exact search establishes either found or missing.
         self._uncertain_keys.discard(key)
+
+    def _log_insert_lookup(self, *, outcome: str) -> None:
+        logger.info(
+            "feishu insert lookup",
+            extra={
+                "event": "feishu_insert_lookup",
+                "normal_lookup_avoided_count": self._normal_lookup_avoided_count,
+                "recovery_lookup_count": self._recovery_lookup_count,
+                "outcome": outcome,
+            },
+        )
 
     async def _flush_indexed_insert(self, *, reason: str) -> None:
         """Seal and write an indexed insert batch under the flush lock.
@@ -1445,6 +1482,23 @@ class FeishuBitableTableSink(Sink):
                 batch = self._seal_indexed_batch(self._batch_size)
             if not batch:
                 return
+            logger.info(
+                "feishu insert buffer",
+                extra={
+                    "event": "feishu_insert_buffer",
+                    "buffered_batch_size": len(batch),
+                    "oldest_batch_age_s": round(
+                        max(
+                            0.0,
+                            time.monotonic()
+                            - min(item.buffered_at for item in batch),
+                        ),
+                        3,
+                    ),
+                    "inflight_waiter_count": self._inflight_waiter_count,
+                    "flush_reason": reason,
+                },
+            )
             await self._write_indexed_batch(batch, reason=reason)
 
     async def _send_single(self, raw_fields: dict[str, Any]) -> None:
@@ -1765,6 +1819,7 @@ class FeishuBitableTableSink(Sink):
                 raise err
             # No remaining pending keys should exist
             assert not self._pending_by_key, "close left pending entries"
+            self._log_insert_lookup(outcome="success")
             return
 
         # Legacy close path

--- a/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+++ b/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
@@ -26,6 +26,9 @@ DEFAULT_FALLBACK_SCAN_PAGE_LIMIT = 100
 _MAX_PAGE_SIZE = 500
 _TOKEN_REFRESH_MARGIN_S = 60.0
 _REDACTED = "<redacted>"
+_DEFAULT_INSERT_INDEX_PAGE_SIZE = 500
+_DEFAULT_INSERT_INDEX_MAX_PAGES = 200
+_DEFAULT_AMBIGUOUS_WRITE_MAX_ROUNDS = 3
 _AUTOMATIC_CURSOR_FIELD_ALIASES = {
     "创建时间": "created_time",
     "最后修改时间": "last_modified_time",
@@ -157,6 +160,10 @@ class FeishuBitableConnector:
         relations: Mapping[str, Mapping[str, Any]] | None = None,
         batch_size: int = 1,
         flush_interval_s: float = 1.0,
+        insert_key_index: bool = False,
+        insert_index_page_size: int = _DEFAULT_INSERT_INDEX_PAGE_SIZE,
+        insert_index_max_pages: int = _DEFAULT_INSERT_INDEX_MAX_PAGES,
+        ambiguous_write_max_rounds: int = _DEFAULT_AMBIGUOUS_WRITE_MAX_ROUNDS,
     ) -> "FeishuBitableTableSink":
         return FeishuBitableTableSink(
             connector=self,
@@ -168,6 +175,10 @@ class FeishuBitableConnector:
             relations=relations,
             batch_size=batch_size,
             flush_interval_s=flush_interval_s,
+            insert_key_index=insert_key_index,
+            insert_index_page_size=insert_index_page_size,
+            insert_index_max_pages=insert_index_max_pages,
+            ambiguous_write_max_rounds=ambiguous_write_max_rounds,
         )
 
     async def search_records(
@@ -769,6 +780,9 @@ class FeishuBitableTableSink(Sink):
 
     upsert and update modes still process records one at a time because
     each record requires a match-finding search before the write.
+
+    Opt-in insert_key_index mode preloads the destination match field into
+    memory so normal Insert processing requires zero per-key Feishu searches.
     """
 
     def __init__(
@@ -783,6 +797,10 @@ class FeishuBitableTableSink(Sink):
         relations: Mapping[str, Mapping[str, Any]] | None = None,
         batch_size: int = 1,
         flush_interval_s: float = 1.0,
+        insert_key_index: bool = False,
+        insert_index_page_size: int = _DEFAULT_INSERT_INDEX_PAGE_SIZE,
+        insert_index_max_pages: int = _DEFAULT_INSERT_INDEX_MAX_PAGES,
+        ambiguous_write_max_rounds: int = _DEFAULT_AMBIGUOUS_WRITE_MAX_ROUNDS,
     ) -> None:
         super().__init__(f"feishu_bitable.table_sink:{table_id}")
         normalized_mode = _normalize_mode(mode)
@@ -805,6 +823,17 @@ class FeishuBitableTableSink(Sink):
         self._relation_create_locks: dict[tuple[str, str, str, str], _FeishuRelationCreateLock] = {}
         self._batch_size = max(1, min(batch_size, _MAX_PAGE_SIZE))
         self._flush_interval_s = float(flush_interval_s)
+        # Insert key index configuration
+        self.insert_key_index = _normalize_insert_key_index(insert_key_index)
+        self.insert_index_page_size = _normalize_insert_index_page_size(insert_index_page_size)
+        self.insert_index_max_pages = _normalize_insert_index_max_pages(insert_index_max_pages)
+        self.ambiguous_write_max_rounds = _normalize_ambiguous_write_max_rounds(ambiguous_write_max_rounds)
+        if self.insert_key_index:
+            _validate_insert_key_index_requirements(
+                mode=self.mode,
+                match_fields=self.match_fields,
+                relations=self.relations,
+            )
         # Buffer stores raw payload fields (before relation resolution & match-finding)
         self._buffer: list[dict[str, Any]] = []
         self._buffer_lock: asyncio.Lock | None = None
@@ -1454,6 +1483,55 @@ def _normalize_mode(value: str) -> str:
     if normalized not in {"upsert", "create", "update", "insert"}:
         raise ValueError("mode must be one of 'upsert', 'create', 'update', or 'insert'")
     return normalized
+
+
+def _normalize_insert_key_index(value: bool) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError("'insert_key_index' must be a boolean")
+    return value
+
+
+def _normalize_insert_index_page_size(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("'insert_index_page_size' must be an integer")
+    if value < 1:
+        raise ValueError("'insert_index_page_size' must be >= 1")
+    return min(value, _MAX_PAGE_SIZE)
+
+
+def _normalize_insert_index_max_pages(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("'insert_index_max_pages' must be an integer")
+    if value < 1:
+        raise ValueError("'insert_index_max_pages' must be >= 1")
+    return value
+
+
+def _normalize_ambiguous_write_max_rounds(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("'ambiguous_write_max_rounds' must be an integer")
+    if value < 1:
+        raise ValueError("'ambiguous_write_max_rounds' must be >= 1")
+    return value
+
+
+def _validate_insert_key_index_requirements(
+    *,
+    mode: str,
+    match_fields: tuple[str, ...],
+    relations: tuple[_FeishuRelationConfig, ...],
+) -> None:
+    if mode != "insert":
+        raise ValueError(
+            "insert_key_index requires mode='insert', not {!r}".format(mode)
+        )
+    if len(match_fields) != 1:
+        raise ValueError(
+            "insert_key_index requires exactly one match field, "
+            "got {}: {!r}".format(len(match_fields), match_fields)
+        )
+    if relations:
+        raise ValueError("insert_key_index is not supported with relations")
 
 
 def _normalize_user_id_type(value: str | None) -> str | None:

--- a/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
+++ b/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/connector.py
@@ -9,7 +9,8 @@ import urllib.parse
 import urllib.request
 from collections import deque
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
 from types import MappingProxyType
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
@@ -773,6 +774,21 @@ class _FeishuRelationCreateLock:
     record_id: str | None = None
 
 
+class _InsertState(str, Enum):
+    BUFFERED = "buffered"
+    WRITING = "writing"
+    RECOVERING = "recovering"
+
+
+@dataclass
+class _PendingInsert:
+    key: str
+    fields: dict[str, Any]
+    waiters: list[asyncio.Future[None]] = field(default_factory=list)
+    buffered_at: float = 0.0
+    state: _InsertState = _InsertState.BUFFERED
+
+
 class FeishuBitableTableSink(Sink):
     """Feishu Bitable table sink with optional batch buffering for create mode.
 
@@ -847,6 +863,13 @@ class FeishuBitableTableSink(Sink):
         self._index_loaded = False
         self._scan_duplicate_keys = 0
         self._scan_missing_key_records = 0
+        # Indexed insert pending-key tracking
+        self._pending_by_key: dict[str, _PendingInsert] = {}
+        self._pending_order: deque[str] = deque()
+        self._flush_lock: asyncio.Lock | None = None
+        self._uncertain_keys: set[str] = set()
+        self._normal_lookup_avoided_count = 0
+        self._inflight_waiter_count = 0
 
     async def open(self) -> None:
         """Open the sink and, if insert_key_index is enabled, preload destination keys."""
@@ -978,7 +1001,11 @@ class FeishuBitableTableSink(Sink):
         """Buffer raw fields for batch processing."""
         try:
             raw_fields = _payload_fields(envelope.body)
-            await self._buffer_record(raw_fields)
+            # Indexed insert path
+            if self.insert_key_index and self._index_loaded:
+                await self._send_indexed_insert(raw_fields)
+            else:
+                await self._buffer_record(raw_fields)
         except ConnectorOperationError:
             raise
         except FeishuBitablePayloadError as exc:
@@ -993,25 +1020,432 @@ class FeishuBitableTableSink(Sink):
             ) from exc
 
     async def _buffer_record(self, raw_fields: dict[str, Any]) -> None:
-        """Buffer a record for batch write, or send immediately if batch_size <= 1."""
+        """Preserve the existing buffered behavior for non-indexed sinks."""
         if self._batch_size <= 1:
             await self._send_single(raw_fields)
             return
-
         lock = self._ensure_buffer_lock()
         async with lock:
-            # Surface any pending flush error from a background timer flush
             if self._flush_error is not None:
                 err = self._flush_error
                 self._flush_error = None
                 raise err
-
             self._buffer.append(raw_fields)
             if len(self._buffer) >= self._batch_size:
                 await self._flush_buffer()
                 return
             if self._flush_task is None and not self._closed:
-                self._flush_task = asyncio.ensure_future(self._flush_after_interval())
+                self._flush_task = asyncio.create_task(self._flush_after_interval())
+
+    async def _send_indexed_insert(self, raw_fields: dict[str, Any]) -> None:
+        """Send one record through the indexed insert path with per-key waiter.
+
+        If the key is already in the startup index, return immediately.
+        Otherwise buffer the record, join any existing waiter for the same key,
+        and await the batch outcome.
+        """
+        if self._closed:
+            raise ConnectorOperationError(
+                backend="feishu_bitable",
+                operation=ConnectorOperation.SEND,
+                kind=ConnectorErrorKind.PERMANENT,
+                source_name=self.name,
+                retry_delay_s=1.0,
+                message="feishu_bitable sink is closed",
+            )
+
+        # Parse and canonicalize the match key
+        match_value = raw_fields.get(self.match_fields[0])
+        if _empty_match_value(match_value):
+            raise FeishuBitablePayloadError(
+                f"payload must include non-empty match_fields entry {self.match_fields[0]!r}"
+            )
+        key = _canonical_insert_key(match_value)
+
+        # Key is in the startup index: confirmed pre-existing
+        if self._insert_keys is not None and key in self._insert_keys:
+            self._normal_lookup_avoided_count += 1
+            return
+
+        # Key is uncertain from a previous ambiguous write: reconcile first
+        if key in self._uncertain_keys:
+            await self._reconcile_uncertain_key(key)
+            if self._insert_keys is not None and key in self._insert_keys:
+                self._normal_lookup_avoided_count += 1
+                return
+
+        # Buffer with a waiter.  The pending entry stays in the map while its
+        # batch is being written so a concurrent duplicate joins the same
+        # outcome instead of creating a second record.
+        lock = self._ensure_buffer_lock()
+        async with lock:
+            if self._flush_error is not None:
+                err = self._flush_error
+                self._flush_error = None
+                raise err
+
+            waiter: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+            existing = self._pending_by_key.get(key)
+            if existing is not None:
+                existing.waiters.append(waiter)
+            else:
+                pending = _PendingInsert(
+                    key=key,
+                    fields=raw_fields,
+                    waiters=[waiter],
+                    buffered_at=time.monotonic(),
+                )
+                self._pending_by_key[key] = pending
+                self._pending_order.append(key)
+            self._inflight_waiter_count += 1
+            should_flush = len(self._pending_order) >= self._batch_size
+            if not should_flush and self._flush_task is None and not self._closed:
+                self._flush_task = asyncio.create_task(self._flush_after_interval())
+
+        if should_flush:
+            await self._flush_indexed_insert(reason="threshold")
+
+        # Await the waiter (may be resolved during flush above, or by timer/close)
+        try:
+            await waiter
+        except asyncio.CancelledError:
+            # Cancellation cancels this caller's Future, but the key group must
+            # remain until its batch is confirmed or failed.  Close and the
+            # elected flusher therefore still settle the group.
+            raise
+
+    def _seal_indexed_batch(self, batch_size: int) -> list[_PendingInsert]:
+        """Seal a batch from _pending_order at most batch_size unique keys."""
+        batch: list[_PendingInsert] = []
+        seen: int = 0
+        while self._pending_order and seen < batch_size:
+            key = self._pending_order[0]
+            pending = self._pending_by_key.get(key)
+            if pending is None:
+                self._pending_order.popleft()
+                continue
+            if pending.state != _InsertState.BUFFERED:
+                self._pending_order.popleft()
+                continue
+            pending.state = _InsertState.WRITING
+            batch.append(pending)
+            self._pending_order.popleft()
+            seen += 1
+        return batch
+
+    def _ensure_flush_lock(self) -> asyncio.Lock:
+        if self._flush_lock is None:
+            self._flush_lock = asyncio.Lock()
+        return self._flush_lock
+
+    async def _write_indexed_batch(
+        self,
+        batch: list[_PendingInsert],
+        *,
+        reason: str,
+        recovery_round: int = 0,
+    ) -> None:
+        """Write one indexed insert batch and settle every member."""
+        if not batch:
+            return
+
+        batch_size = len(batch)
+        start_time = time.monotonic()
+        batch_records = [dict(pending.fields) for pending in batch]
+
+        try:
+            result = await self.connector.batch_create_records(
+                app_token=self.app_token,
+                table_id=self.table_id,
+                records=batch_records,
+                user_id_type=self.user_id_type,
+                operation=ConnectorOperation.SEND,
+                source_name=self.name,
+                retry_delay_s=1.0,
+            )
+        except ConnectorOperationError as exc:
+            duration = time.monotonic() - start_time
+            if _is_definite_write_error(exc):
+                self._fail_pending(batch, exc)
+                logger.info(
+                    "feishu insert batch write",
+                    extra={
+                        "event": "feishu_insert_batch_write",
+                        "batch_size": batch_size,
+                        "duration_s": round(duration, 3),
+                        "outcome": "permanent_error",
+                        "flush_reason": reason,
+                        "recovery_round": recovery_round,
+                        "inflight_waiter_count": self._inflight_waiter_count,
+                    },
+                )
+                return
+            await self._recover_ambiguous_batch(
+                batch, reason=reason, recovery_round=recovery_round + 1, cause=exc
+            )
+            return
+        except Exception as exc:
+            # An unexpected exception after request dispatch has an unknown
+            # commit outcome.  Treat it conservatively and reconcile first.
+            await self._recover_ambiguous_batch(
+                batch,
+                reason=reason,
+                recovery_round=recovery_round + 1,
+                cause=ConnectorOperationError(
+                    backend="feishu_bitable",
+                    operation=ConnectorOperation.SEND,
+                    kind=ConnectorErrorKind.UNCERTAIN,
+                    source_name=self.name,
+                    retry_delay_s=1.0,
+                    cause=exc,
+                    message="feishu_bitable batch create outcome is uncertain",
+                ),
+            )
+            return
+
+        if not _batch_create_response_is_complete(result, expected=batch_size):
+            await self._recover_ambiguous_batch(
+                batch,
+                reason=reason,
+                recovery_round=recovery_round + 1,
+                cause=ConnectorOperationError(
+                    backend="feishu_bitable",
+                    operation=ConnectorOperation.SEND,
+                    kind=ConnectorErrorKind.UNCERTAIN,
+                    source_name=self.name,
+                    retry_delay_s=1.0,
+                    message="feishu_bitable batch create response was incomplete",
+                ),
+            )
+            return
+
+        duration = time.monotonic() - start_time
+        self._confirm_created(batch)
+        logger.info(
+            "feishu insert batch write",
+            extra={
+                "event": "feishu_insert_batch_write",
+                "batch_size": batch_size,
+                "duration_s": round(duration, 3),
+                "outcome": "success",
+                "flush_reason": reason,
+                "recovery_round": recovery_round,
+                "inflight_waiter_count": self._inflight_waiter_count,
+            },
+        )
+
+    async def _recover_ambiguous_batch(
+        self,
+        batch: list[_PendingInsert],
+        *,
+        reason: str,
+        recovery_round: int,
+        cause: ConnectorOperationError,
+    ) -> None:
+        """Reconcile only the keys whose create outcome is uncertain."""
+        unresolved = list(batch)
+        for pending in unresolved:
+            pending.state = _InsertState.RECOVERING
+            self._uncertain_keys.add(pending.key)
+
+        logger.info(
+            "feishu insert batch write",
+            extra={
+                "event": "feishu_insert_batch_write",
+                "batch_size": len(batch),
+                "duration_s": 0.0,
+                "outcome": "ambiguous",
+                "flush_reason": reason,
+                "recovery_round": recovery_round,
+                "inflight_waiter_count": self._inflight_waiter_count,
+            },
+        )
+
+        round_number = recovery_round
+        while unresolved and round_number <= self.ambiguous_write_max_rounds:
+            found, missing, lookup_failed = await self._lookup_pending_keys(unresolved)
+            if found:
+                self._confirm_found(found)
+            if not missing:
+                unresolved = lookup_failed
+                round_number += 1
+                continue
+
+            for pending in missing:
+                pending.state = _InsertState.WRITING
+            try:
+                result = await self.connector.batch_create_records(
+                    app_token=self.app_token,
+                    table_id=self.table_id,
+                    records=[dict(pending.fields) for pending in missing],
+                    user_id_type=self.user_id_type,
+                    operation=ConnectorOperation.SEND,
+                    source_name=self.name,
+                    retry_delay_s=1.0,
+                )
+            except ConnectorOperationError as exc:
+                if _is_definite_write_error(exc):
+                    self._fail_pending(missing, exc)
+                    unresolved = lookup_failed
+                else:
+                    unresolved = lookup_failed + missing
+            except Exception as exc:
+                cause = ConnectorOperationError(
+                    backend="feishu_bitable",
+                    operation=ConnectorOperation.SEND,
+                    kind=ConnectorErrorKind.UNCERTAIN,
+                    source_name=self.name,
+                    retry_delay_s=1.0,
+                    cause=exc,
+                    message="feishu_bitable recovery create outcome is uncertain",
+                )
+                unresolved = lookup_failed + missing
+            else:
+                if _batch_create_response_is_complete(result, expected=len(missing)):
+                    self._confirm_created(missing)
+                    unresolved = lookup_failed
+                else:
+                    unresolved = lookup_failed + missing
+            round_number += 1
+
+        if unresolved:
+            exhausted = ConnectorOperationError(
+                backend="feishu_bitable",
+                operation=ConnectorOperation.SEND,
+                kind=ConnectorErrorKind.UNCERTAIN,
+                source_name=self.name,
+                retry_delay_s=1.0,
+                cause=cause,
+                message=(
+                    "feishu_bitable ambiguous batch remained unresolved after "
+                    f"{self.ambiguous_write_max_rounds} recovery rounds"
+                ),
+            )
+            self._fail_pending(unresolved, exhausted)
+
+    async def _lookup_pending_keys(
+        self, pending_list: list[_PendingInsert]
+    ) -> tuple[list[_PendingInsert], list[_PendingInsert], list[_PendingInsert]]:
+        """Return found, confirmed-missing, and lookup-failed members."""
+        semaphore = asyncio.Semaphore(20)
+
+        async def lookup(
+            pending: _PendingInsert,
+        ) -> tuple[str, _PendingInsert, BaseException | None]:
+            try:
+                async with semaphore:
+                    matches = await self._find_matches(
+                        {self.match_fields[0]: pending.key}
+                    )
+            except BaseException as exc:
+                return "failed", pending, exc
+            if len(matches) > 1:
+                return (
+                    "failed",
+                    pending,
+                    FeishuBitablePayloadError(
+                        "insert match field resolved to multiple destination records"
+                    ),
+                )
+            return ("found" if matches else "missing"), pending, None
+
+        found: list[_PendingInsert] = []
+        missing: list[_PendingInsert] = []
+        failed: list[_PendingInsert] = []
+        results = await asyncio.gather(*(lookup(item) for item in pending_list))
+        for outcome, pending, exc in results:
+            if outcome == "found":
+                found.append(pending)
+            elif outcome == "missing":
+                missing.append(pending)
+            else:
+                if isinstance(exc, FeishuBitablePayloadError):
+                    self._fail_pending(
+                        [pending],
+                        ConnectorOperationError(
+                            backend="feishu_bitable",
+                            operation=ConnectorOperation.SEND,
+                            kind=ConnectorErrorKind.PERMANENT,
+                            source_name=self.name,
+                            retry_delay_s=1.0,
+                            cause=exc,
+                            message="feishu_bitable destination match is not unique",
+                        ),
+                    )
+                else:
+                    failed.append(pending)
+        return found, missing, failed
+
+    def _confirm_created(self, batch: list[_PendingInsert]) -> None:
+        """Mark batch keys as created and complete all waiters successfully."""
+        for pending in batch:
+            if self._insert_keys is not None:
+                self._insert_keys.add(pending.key)
+            self._uncertain_keys.discard(pending.key)
+        self._complete_pending(batch)
+
+    def _confirm_found(self, batch: list[_PendingInsert]) -> None:
+        """Mark batch keys as found in the destination and complete waiters."""
+        for pending in batch:
+            if self._insert_keys is not None:
+                self._insert_keys.add(pending.key)
+            self._uncertain_keys.discard(pending.key)
+        self._complete_pending(batch)
+
+    def _fail_pending(
+        self,
+        pending_list: list[_PendingInsert],
+        exc: BaseException,
+    ) -> None:
+        """Complete all waiters for the given pending items with an exception."""
+        for pending in pending_list:
+            self._pending_by_key.pop(pending.key, None)
+            self._inflight_waiter_count -= len(pending.waiters)
+            for waiter in pending.waiters:
+                if not waiter.done():
+                    waiter.set_exception(exc)
+
+    def _complete_pending(self, pending_list: list[_PendingInsert]) -> None:
+        """Complete all waiters for the given pending items successfully."""
+        for pending in pending_list:
+            self._pending_by_key.pop(pending.key, None)
+            self._inflight_waiter_count -= len(pending.waiters)
+            for waiter in pending.waiters:
+                if not waiter.done():
+                    waiter.set_result(None)
+
+    @property
+    def inflight_waiter_count(self) -> int:
+        return self._inflight_waiter_count
+
+    async def _reconcile_uncertain_key(self, key: str) -> None:
+        """Exact-search one uncertain key before a new send can proceed."""
+        try:
+            matches = await self._find_matches({self.match_fields[0]: key})
+        except ConnectorOperationError:
+            raise
+        if len(matches) > 1:
+            raise FeishuBitablePayloadError(
+                "insert match field resolved to multiple destination records"
+            )
+        if matches:
+            if self._insert_keys is not None:
+                self._insert_keys.add(key)
+        # A successful exact search establishes either found or missing.
+        self._uncertain_keys.discard(key)
+
+    async def _flush_indexed_insert(self, *, reason: str) -> None:
+        """Seal and write an indexed insert batch under the flush lock.
+
+        Timer, threshold, and close flushes share one network-write lane.
+        """
+        async with self._ensure_flush_lock():
+            lock = self._ensure_buffer_lock()
+            async with lock:
+                batch = self._seal_indexed_batch(self._batch_size)
+            if not batch:
+                return
+            await self._write_indexed_batch(batch, reason=reason)
 
     async def _send_single(self, raw_fields: dict[str, Any]) -> None:
         """Send a single record immediately (batch_size=1 path)."""
@@ -1065,10 +1499,14 @@ class FeishuBitableTableSink(Sink):
         timer_task = asyncio.current_task()
         try:
             await asyncio.sleep(self._flush_interval_s)
-            lock = self._ensure_buffer_lock()
-            async with lock:
-                if self._buffer and self._flush_error is None:
-                    await self._flush_buffer()
+            if self.insert_key_index and self._index_loaded:
+                if self._flush_error is None:
+                    await self._flush_indexed_insert(reason="timer")
+            else:
+                lock = self._ensure_buffer_lock()
+                async with lock:
+                    if self._buffer and self._flush_error is None:
+                        await self._flush_buffer()
         except asyncio.CancelledError:
             raise
         except BaseException as exc:
@@ -1303,10 +1741,34 @@ class FeishuBitableTableSink(Sink):
         """Flush remaining buffered records before closing."""
         self._closed = True
         lock = self._ensure_buffer_lock()
+        timer_task: asyncio.Task[None] | None = None
         async with lock:
             if self._flush_task is not None:
-                self._flush_task.cancel()
+                timer_task = self._flush_task
+                timer_task.cancel()
                 self._flush_task = None
+        if timer_task is not None:
+            await asyncio.gather(timer_task, return_exceptions=True)
+
+        # Indexed insert close: drain all pending keys
+        if self.insert_key_index and self._index_loaded:
+            while True:
+                await self._flush_indexed_insert(reason="close")
+                async with lock:
+                    has_buffered = bool(self._pending_order)
+                if not has_buffered:
+                    break
+            # Surface any error stored from timer flush
+            if self._flush_error is not None:
+                err = self._flush_error
+                self._flush_error = None
+                raise err
+            # No remaining pending keys should exist
+            assert not self._pending_by_key, "close left pending entries"
+            return
+
+        # Legacy close path
+        async with lock:
             if self._buffer:
                 await self._flush_buffer()
             if self._flush_error is not None:
@@ -1725,6 +2187,24 @@ def _empty_match_value(value: Any) -> bool:
     if isinstance(value, (list, tuple, set, dict)) and not value:
         return True
     return False
+
+
+def _is_definite_write_error(exc: ConnectorOperationError) -> bool:
+    """Check if a connector error is a definite (non-ambiguous) failure."""
+    return exc.kind in {
+        ConnectorErrorKind.PERMANENT,
+        ConnectorErrorKind.MISCONFIGURED,
+    }
+
+
+def _batch_create_response_is_complete(
+    result: Mapping[str, Any], *, expected: int
+) -> bool:
+    """Return whether Feishu assigned one response record per input."""
+    records = result.get("records")
+    if not isinstance(records, list) or len(records) != expected:
+        return False
+    return all(isinstance(record, Mapping) for record in records)
 
 
 def _normalize_match_fields(value: Sequence[str] | None, *, required: bool) -> tuple[str, ...]:

--- a/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/resources.py
+++ b/plugins/onestep-feishu-bitable/src/onestep_feishu_bitable/resources.py
@@ -31,7 +31,8 @@ _FEISHU_INCREMENTAL_FIELDS = frozenset(
     }
 )
 _FEISHU_TABLE_SINK_FIELDS = frozenset(
-    {"type", "connector", "app_token", "table_id", "mode", "match_fields", "user_id_type", "relations", "batch_size", "flush_interval_s"}
+    {"type", "connector", "app_token", "table_id", "mode", "match_fields", "user_id_type", "relations", "batch_size", "flush_interval_s",
+     "insert_key_index", "insert_index_page_size", "insert_index_max_pages", "ambiguous_write_max_rounds"}
 )
 _USER_ID_TYPES = frozenset({"open_id", "union_id", "user_id"})
 _RELATION_FIELDS = frozenset({"from", "app_token", "table_id", "key", "on_missing", "create_fields"})
@@ -81,6 +82,10 @@ _FEISHU_TABLE_SINK_CATALOG = ResourceCatalogEntry(
         ResourceCatalogField("relations", "mapping"),
         ResourceCatalogField("batch_size", "integer", default=1),
         ResourceCatalogField("flush_interval_s", "number", default=1.0),
+        ResourceCatalogField("insert_key_index", "boolean", default=False),
+        ResourceCatalogField("insert_index_page_size", "integer", default=500),
+        ResourceCatalogField("insert_index_max_pages", "integer", default=200),
+        ResourceCatalogField("ambiguous_write_max_rounds", "integer", default=3),
     ),
     topology_fields=("app_token", "table_id", "mode", "match_fields", "batch_size"),
 )
@@ -162,6 +167,10 @@ def _build_feishu_bitable_table_sink(ctx: ResourceBuildContext, spec: Mapping[st
         relations=spec.get("relations"),
         batch_size=spec.get("batch_size", 1),
         flush_interval_s=spec.get("flush_interval_s", 1.0),
+        insert_key_index=spec.get("insert_key_index", False),
+        insert_index_page_size=spec.get("insert_index_page_size", 500),
+        insert_index_max_pages=spec.get("insert_index_max_pages", 200),
+        ambiguous_write_max_rounds=spec.get("ambiguous_write_max_rounds", 3),
     )
 
 
@@ -214,6 +223,26 @@ def _validate_feishu_bitable_table_sink(ctx: ResourceValidationContext, spec: Ma
         )
     ctx.validate_positive_integer(spec.get("batch_size"), field=f"{ctx.field}.batch_size")
     ctx.validate_positive_number(spec.get("flush_interval_s"), field=f"{ctx.field}.flush_interval_s")
+    if "insert_key_index" in spec:
+        raw = spec["insert_key_index"]
+        if not isinstance(raw, bool):
+            raise TypeError(f"'{ctx.field}.insert_key_index' must be a boolean")
+        if raw:
+            if mode != "insert":
+                raise ValueError(
+                    f"'{ctx.field}.insert_key_index' requires '{ctx.field}.mode' to be 'insert'"
+                )
+            if len(match_fields) != 1:
+                raise ValueError(
+                    f"'{ctx.field}.insert_key_index' requires exactly one match field"
+                )
+            if "relations" in spec:
+                raise ValueError(
+                    f"'{ctx.field}.insert_key_index' is not supported with relations"
+                )
+    ctx.validate_positive_integer(spec.get("insert_index_page_size"), field=f"{ctx.field}.insert_index_page_size")
+    ctx.validate_positive_integer(spec.get("insert_index_max_pages"), field=f"{ctx.field}.insert_index_max_pages")
+    ctx.validate_positive_integer(spec.get("ambiguous_write_max_rounds"), field=f"{ctx.field}.ambiguous_write_max_rounds")
 
 
 def _validate_feishu_relations(

--- a/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_plugin.py
+++ b/plugins/onestep-feishu-bitable/tests/test_feishu_bitable_plugin.py
@@ -23,3 +23,11 @@ def test_feishu_bitable_plugin_registers_catalog_metadata() -> None:
     assert catalog["feishu_bitable_table_sink"].connector_types == ("feishu_bitable",)
     assert sink_fields["app_token"].secret is True
     assert sink_fields["relations"].type == "mapping"
+    assert sink_fields["insert_key_index"].type == "boolean"
+    assert sink_fields["insert_key_index"].default is False
+    assert sink_fields["insert_index_page_size"].type == "integer"
+    assert sink_fields["insert_index_page_size"].default == 500
+    assert sink_fields["insert_index_max_pages"].type == "integer"
+    assert sink_fields["insert_index_max_pages"].default == 200
+    assert sink_fields["ambiguous_write_max_rounds"].type == "integer"
+    assert sink_fields["ambiguous_write_max_rounds"].default == 3

--- a/plugins/onestep-feishu-bitable/tests/test_feishu_insert_incremental_chain.py
+++ b/plugins/onestep-feishu-bitable/tests/test_feishu_insert_incremental_chain.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import sqlalchemy as sa
+
+from onestep import Envelope, OneStepApp
+from onestep.runtime.executor import DeliveryExecutor
+from onestep.state import InMemoryCursorStore
+from onestep_feishu_bitable import FeishuBitableConnector
+from onestep_mysql import MySQLConnector
+
+
+class _RecordingCursorStore(InMemoryCursorStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.save_count = 0
+
+    async def save(self, key: str, value: object) -> None:
+        self.save_count += 1
+        await super().save(key, value)
+
+
+def test_indexed_insert_real_executor_holds_cursor_until_batch_confirmation(
+    tmp_path: Path,
+) -> None:
+    db_url = f"sqlite:///{tmp_path / 'follow_records.db'}"
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    rows = sa.Table(
+        "follow_records",
+        metadata,
+        sa.Column("unionKey", sa.String, primary_key=True),
+        sa.Column("dataCreateTime", sa.Integer, nullable=False),
+        sa.Column("编号", sa.String, nullable=False),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.insert(rows),
+            [
+                {
+                    "unionKey": f"K-{index:06d}",
+                    "dataCreateTime": index,
+                    "编号": f"K-{index:06d}",
+                }
+                for index in range(1, 101)
+            ],
+        )
+    engine.dispose()
+
+    async def scenario() -> None:
+        mysql = MySQLConnector(db_url)
+        state = _RecordingCursorStore()
+        source = mysql.incremental(
+            table="follow_records",
+            key="unionKey",
+            cursor=("dataCreateTime", "unionKey"),
+            batch_size=100,
+            poll_interval_s=0.01,
+            state=state,
+            state_key="follow-record-sync-v1",
+        )
+        connector = FeishuBitableConnector(app_id="id", app_secret="secret")
+        sink = connector.table_sink(
+            app_token="token",
+            table_id="table",
+            mode="insert",
+            match_fields=["编号"],
+            batch_size=100,
+            insert_key_index=True,
+        )
+        sink._insert_keys = set()
+        sink._index_loaded = True
+        write_started = asyncio.Event()
+        release_write = asyncio.Event()
+
+        async def batch_create(**kwargs: Any) -> dict[str, Any]:
+            write_started.set()
+            await release_write.wait()
+            return {
+                "records": [
+                    {"record_id": f"rec-{index}"}
+                    for index, _ in enumerate(kwargs["records"])
+                ]
+            }
+
+        connector.batch_create_records = batch_create  # type: ignore[assignment]
+        app = OneStepApp("follow-record-chain")
+
+        @app.task(source=source, emit=sink, concurrency=100)
+        async def passthrough(ctx: Any, item: dict[str, Any]) -> dict[str, Any]:
+            return {"编号": item["编号"]}
+
+        deliveries = await source.fetch(100)
+        executor = DeliveryExecutor(app, app.tasks[0])
+        executions = [
+            asyncio.create_task(executor.execute(delivery)) for delivery in deliveries
+        ]
+        await asyncio.wait_for(write_started.wait(), timeout=1.0)
+        assert await state.load("follow-record-sync-v1") is None
+        assert not any(task.done() for task in executions)
+        release_write.set()
+        outcomes = await asyncio.gather(*executions)
+        assert all(outcome.completion == "succeeded" for outcome in outcomes)
+        assert await state.load("follow-record-sync-v1") == [100, "K-000100"]
+        assert state.save_count == 1
+        await mysql.close()
+
+    asyncio.run(scenario())
+
+
+def test_indexed_insert_100k_request_count_benchmark() -> None:
+    existing_count = 50_000
+    incoming_count = 100_000
+
+    async def scenario() -> None:
+        scan_requests = 0
+        exact_search_requests = 0
+        create_requests = 0
+        create_batch_sizes: list[int] = []
+
+        async def search_records(**kwargs: Any) -> dict[str, Any]:
+            nonlocal scan_requests, exact_search_requests
+            body = kwargs["body"]
+            if "field_names" in body:
+                scan_requests += 1
+                page = scan_requests - 1
+                start = page * 500
+                stop = min(start + 500, existing_count)
+                return {
+                    "items": [
+                        {"fields": {"编号": f"K-{index:06d}"}}
+                        for index in range(start, stop)
+                    ],
+                    "has_more": stop < existing_count,
+                    "page_token": str(page + 1) if stop < existing_count else None,
+                }
+            exact_search_requests += 1
+            return {"items": [], "has_more": False}
+
+        async def batch_create(**kwargs: Any) -> dict[str, Any]:
+            nonlocal create_requests
+            create_requests += 1
+            create_batch_sizes.append(len(kwargs["records"]))
+            return {
+                "records": [
+                    {"record_id": f"rec-{index}"}
+                    for index, _ in enumerate(kwargs["records"])
+                ]
+            }
+
+        connector = FeishuBitableConnector(app_id="id", app_secret="secret")
+        connector.search_records = search_records  # type: ignore[assignment]
+        connector.batch_create_records = batch_create  # type: ignore[assignment]
+        sink = connector.table_sink(
+            app_token="token",
+            table_id="table",
+            mode="insert",
+            match_fields=["编号"],
+            batch_size=100,
+            insert_key_index=True,
+            insert_index_page_size=500,
+            insert_index_max_pages=200,
+        )
+        await sink.open()
+        for offset in range(0, incoming_count, 100):
+            await asyncio.gather(
+                *(
+                    sink.send(
+                        Envelope(body={"编号": f"K-{index:06d}"})
+                    )
+                    for index in range(offset, offset + 100)
+                )
+            )
+        await sink.close()
+        assert scan_requests == 100
+        assert exact_search_requests == 0
+        assert create_requests == 500
+        assert scan_requests + create_requests == 600
+        assert create_batch_sizes == [100] * 500
+        assert sink.inflight_waiter_count == 0
+        assert not hasattr(sink, "record_ids")
+
+    asyncio.run(scenario())

--- a/plugins/onestep-feishu-bitable/tests/test_insert_index_config.py
+++ b/plugins/onestep-feishu-bitable/tests/test_insert_index_config.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from onestep.config import load_app_config
+from onestep_feishu_bitable import FeishuBitableConnector
+
+
+def test_feishu_insert_key_index_config_normalizes_python_api() -> None:
+    connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+    sink = connector.table_sink(
+        app_token="app-token",
+        table_id="tbl",
+        mode="insert",
+        match_fields=["编号"],
+        batch_size=100,
+        insert_key_index=True,
+        insert_index_page_size=500,
+        insert_index_max_pages=200,
+        ambiguous_write_max_rounds=3,
+    )
+    assert sink.insert_key_index is True
+    assert sink.insert_index_page_size == 500
+    assert sink.insert_index_max_pages == 200
+    assert sink.ambiguous_write_max_rounds == 3
+
+
+@pytest.mark.parametrize(
+    "overrides, message",
+    [
+        ({"mode": "upsert"}, r"insert_key_index.*mode.*insert"),
+        ({"match_fields": ["编号", "来源"]}, r"exactly one match field"),
+        ({"relations": {"关联": {"table_id": "rel", "key": "编号"}}}, r"relations"),
+        ({"insert_index_page_size": 0}, r"insert_index_page_size.*[>=1]"),
+        ({"insert_index_max_pages": 0}, r"insert_index_max_pages.*[>=1]"),
+        ({"ambiguous_write_max_rounds": 0}, r"ambiguous_write_max_rounds.*[>=1]"),
+    ],
+)
+def test_feishu_insert_key_index_rejects_unsupported_config(
+    overrides: dict[str, object], message: str
+) -> None:
+    connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+    config: dict[str, object] = {
+        "app_token": "app-token",
+        "table_id": "tbl",
+        "mode": "insert",
+        "match_fields": ["编号"],
+        "insert_key_index": True,
+    }
+    config.update(overrides)
+    with pytest.raises((TypeError, ValueError), match=message):
+        connector.table_sink(**config)
+
+
+def test_yaml_builds_indexed_insert_sink_in_strict_mode() -> None:
+    app = load_app_config(
+        {
+            "apiVersion": "onestep/v1alpha1",
+            "kind": "App",
+            "app": {"name": "follow-record-sync"},
+            "resources": {
+                "feishu": {
+                    "type": "feishu_bitable",
+                    "app_id": "id",
+                    "app_secret": "secret",
+                },
+                "sink": {
+                    "type": "feishu_bitable_table_sink",
+                    "connector": "feishu",
+                    "app_token": "token",
+                    "table_id": "table",
+                    "mode": "insert",
+                    "match_fields": ["编号"],
+                    "batch_size": 100,
+                    "insert_key_index": True,
+                    "insert_index_page_size": 500,
+                    "insert_index_max_pages": 200,
+                    "ambiguous_write_max_rounds": 3,
+                },
+            },
+            "tasks": [],
+        },
+        strict=True,
+    )
+    assert app.resources["sink"].insert_key_index is True

--- a/plugins/onestep-feishu-bitable/tests/test_insert_index_scan.py
+++ b/plugins/onestep-feishu-bitable/tests/test_insert_index_scan.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from onestep.resilience import ConnectorOperationError
+from onestep_feishu_bitable.connector import _canonical_insert_key, FeishuBitablePayloadError
+from onestep_feishu_bitable import FeishuBitableConnector
+
+
+def test_feishu_insert_index_canonicalizes_source_and_destination_keys() -> None:
+    """Verify _canonical_insert_key handles all type cases."""
+    assert _canonical_insert_key("hello") == "hello"
+    assert _canonical_insert_key("  spaced  ") == "spaced"
+    assert _canonical_insert_key(42) == "42"
+    assert _canonical_insert_key(3.14) == "3.14"
+    assert _canonical_insert_key(True) == "True"
+    assert _canonical_insert_key(False) == "False"
+    # Non-finite float -> permanent error
+    with pytest.raises(FeishuBitablePayloadError):
+        _canonical_insert_key(float("nan"))
+    with pytest.raises(FeishuBitablePayloadError):
+        _canonical_insert_key(float("inf"))
+    with pytest.raises(FeishuBitablePayloadError):
+        _canonical_insert_key(float("-inf"))
+    # Empty/missing -> permanent error
+    with pytest.raises(FeishuBitablePayloadError):
+        _canonical_insert_key("")
+    with pytest.raises(FeishuBitablePayloadError):
+        _canonical_insert_key("  ")
+    with pytest.raises(FeishuBitablePayloadError):
+        _canonical_insert_key(None)
+    # Unsupported type -> permanent error
+    with pytest.raises(FeishuBitablePayloadError):
+        _canonical_insert_key({"key": "val"})
+    with pytest.raises(FeishuBitablePayloadError):
+        _canonical_insert_key([1, 2])
+
+
+def test_feishu_insert_index_open_pages_match_field_only() -> None:
+    """Startup scan pages only the match field into a bounded set."""
+    async def scenario() -> None:
+        sink_calls: list[dict[str, Any]] = []
+
+        async def fake_search_records(**kwargs: Any) -> dict[str, Any]:
+            sink_calls.append(
+                {
+                    "field_names": kwargs.get("body", {}).get("field_names"),
+                    "page_size": kwargs.get("page_size"),
+                    "page_token": kwargs.get("page_token"),
+                }
+            )
+            token = kwargs.get("page_token")
+            if token is None:
+                return {
+                    "items": [
+                        {"fields": {"编号": "A-1"}},
+                        {"fields": {"编号": "A-2"}},
+                    ],
+                    "has_more": True,
+                    "page_token": "p2",
+                }
+            return {
+                "items": [
+                    {"fields": {"编号": "A-3"}},
+                ],
+                "has_more": False,
+            }
+
+        connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+        connector.search_records = fake_search_records  # type: ignore[assignment]
+        sink = connector.table_sink(
+            app_token="app-token",
+            table_id="tbl",
+            mode="insert",
+            match_fields=["编号"],
+            batch_size=10,
+            insert_key_index=True,
+            insert_index_page_size=2,
+            insert_index_max_pages=5,
+        )
+        assert sink._insert_keys is None
+        await sink.open()
+        assert sink._insert_keys == {"A-1", "A-2", "A-3"}
+        assert sink._index_loaded is True
+        assert len(sink_calls) == 2
+        for call in sink_calls:
+            assert call["field_names"] == ["编号"]
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_index_open_rejects_truncated_scan() -> None:
+    """Startup fails if Feishu reports more pages than max_pages."""
+    async def scenario() -> None:
+        async def fake_search_records(**kwargs: Any) -> dict[str, Any]:
+            return {
+                "items": [{"fields": {"编号": "K-1"}}],
+                "has_more": True,
+                "page_token": "next",
+            }
+
+        connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+        connector.search_records = fake_search_records  # type: ignore[assignment]
+        sink = connector.table_sink(
+            app_token="app-token",
+            table_id="tbl",
+            mode="insert",
+            match_fields=["编号"],
+            batch_size=10,
+            insert_key_index=True,
+            insert_index_page_size=1,
+            insert_index_max_pages=1,
+        )
+        with pytest.raises(ConnectorOperationError) as excinfo:
+            await sink.open()
+        msg = str(excinfo.value)
+        assert "insert_index_max_pages=1" in msg
+        # Privacy: no app token in error
+        assert "app-token" not in msg
+        assert sink._insert_keys is None
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_index_open_rejects_duplicate_page_token() -> None:
+    """Startup fails if page_token does not advance."""
+    async def scenario() -> None:
+        async def fake_search_records(**kwargs: Any) -> dict[str, Any]:
+            return {
+                "items": [{"fields": {"编号": "K-1"}}],
+                "has_more": True,
+                "page_token": "stuck",
+            }
+
+        connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+        connector.search_records = fake_search_records  # type: ignore[assignment]
+        sink = connector.table_sink(
+            app_token="app-token",
+            table_id="tbl",
+            mode="insert",
+            match_fields=["编号"],
+            batch_size=10,
+            insert_key_index=True,
+            insert_index_page_size=1,
+            insert_index_max_pages=5,
+        )
+        with pytest.raises(ConnectorOperationError):
+            await sink.open()
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_index_counts_missing_and_duplicate_keys() -> None:
+    """Missing key records and duplicates are counted without logging values."""
+    async def scenario() -> None:
+        async def fake_search_records(**kwargs: Any) -> dict[str, Any]:
+            return {
+                "items": [
+                    {"fields": {"编号": "K-1"}},
+                    {"fields": {"编号": "K-1"}},  # duplicate
+                    {"fields": {}},  # missing key
+                    {"fields": None},  # missing fields
+                    {"not_fields": True},  # no fields key
+                ],
+                "has_more": False,
+            }
+
+        connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+        connector.search_records = fake_search_records  # type: ignore[assignment]
+        sink = connector.table_sink(
+            app_token="app-token",
+            table_id="tbl",
+            mode="insert",
+            match_fields=["编号"],
+            batch_size=10,
+            insert_key_index=True,
+            insert_index_page_size=10,
+            insert_index_max_pages=5,
+        )
+        await sink.open()
+        assert sink._insert_keys == {"K-1"}
+        assert sink._scan_duplicate_keys == 1
+        assert sink._scan_missing_key_records >= 1
+
+    asyncio.run(scenario())

--- a/plugins/onestep-feishu-bitable/tests/test_insert_index_waiters.py
+++ b/plugins/onestep-feishu-bitable/tests/test_insert_index_waiters.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
 from typing import Any
 
 import pytest
@@ -359,3 +361,131 @@ def test_feishu_insert_short_success_response_enters_recovery() -> None:
         assert search_calls == 2
 
     asyncio.run(scenario())
+
+
+def test_feishu_insert_logs_aggregates_without_sensitive_values(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def scenario() -> None:
+        create_calls = 0
+
+        async def fake_search(**kwargs: Any) -> dict[str, Any]:
+            body = kwargs["body"]
+            if "field_names" in body:
+                return {
+                    "items": [
+                        {
+                            "record_id": "record-id-secret",
+                            "fields": {"编号": "preexisting-key-secret"},
+                        }
+                    ],
+                    "has_more": False,
+                }
+            return {
+                "items": [
+                    {
+                        "record_id": "record-id-secret",
+                        "fields": {"编号": "union-key-secret"},
+                    }
+                ],
+                "has_more": False,
+            }
+
+        async def fake_batch_create(**kwargs: Any) -> dict[str, Any]:
+            nonlocal create_calls
+            create_calls += 1
+            raise ConnectorOperationError(
+                backend="feishu_bitable",
+                operation=ConnectorOperation.SEND,
+                kind=ConnectorErrorKind.UNCERTAIN,
+                source_name="test",
+                message="connection closed after request",
+            )
+
+        connector = FeishuBitableConnector(
+            app_id="app-id-secret", app_secret="app-secret-value"
+        )
+        connector.search_records = fake_search  # type: ignore[assignment]
+        connector.batch_create_records = fake_batch_create  # type: ignore[assignment]
+        sink = connector.table_sink(
+            app_token="app-token-secret",
+            table_id="table-id-secret",
+            mode="insert",
+            match_fields=["编号"],
+            batch_size=2,
+            insert_key_index=True,
+        )
+        await sink.open()
+        await sink.send(Envelope(body={"编号": "preexisting-key-secret"}))
+        await asyncio.gather(
+            sink.send(
+                Envelope(
+                    body={"编号": "union-key-secret", "内容": "payload-value-secret"}
+                )
+            ),
+            sink.send(
+                Envelope(
+                    body={"编号": "second-key-secret", "内容": "payload-value-secret"}
+                )
+            ),
+        )
+        await sink.close()
+        assert create_calls == 1
+
+    caplog.set_level(logging.INFO, logger="onestep_feishu_bitable.connector")
+    asyncio.run(scenario())
+
+    by_event: dict[str, list[logging.LogRecord]] = {}
+    for record in caplog.records:
+        event = getattr(record, "event", None)
+        if event is not None:
+            by_event.setdefault(event, []).append(record)
+    assert {
+        "scan_pages",
+        "scan_keys",
+        "duration_s",
+        "page_size",
+        "max_pages",
+    } <= by_event["feishu_insert_index_scan"][0].__dict__.keys()
+    assert {
+        "buffered_batch_size",
+        "oldest_batch_age_s",
+        "inflight_waiter_count",
+        "flush_reason",
+    } <= by_event["feishu_insert_buffer"][0].__dict__.keys()
+    assert {
+        "batch_size",
+        "duration_s",
+        "outcome",
+        "flush_reason",
+        "recovery_round",
+    } <= by_event["feishu_insert_batch_write"][0].__dict__.keys()
+    assert {
+        "normal_lookup_avoided_count",
+        "recovery_lookup_count",
+        "outcome",
+    } <= by_event["feishu_insert_lookup"][0].__dict__.keys()
+    assert {
+        "retry_count",
+        "recovery_round",
+        "unresolved_count",
+    } <= by_event["feishu_insert_retry"][0].__dict__.keys()
+
+    serialized = json.dumps(
+        [record.__dict__ for record in caplog.records],
+        ensure_ascii=False,
+        default=str,
+    )
+    for secret in (
+        "app-id-secret",
+        "app-secret-value",
+        "app-token-secret",
+        "table-id-secret",
+        "union-key-secret",
+        "second-key-secret",
+        "preexisting-key-secret",
+        "payload-value-secret",
+        "record-id-secret",
+        "编号",
+    ):
+        assert secret not in serialized

--- a/plugins/onestep-feishu-bitable/tests/test_insert_index_waiters.py
+++ b/plugins/onestep-feishu-bitable/tests/test_insert_index_waiters.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from onestep import Envelope
+from onestep.resilience import (
+    ConnectorErrorKind,
+    ConnectorOperation,
+    ConnectorOperationError,
+)
+from onestep_feishu_bitable import FeishuBitableConnector
+
+
+async def _make_indexed_sink(
+    *,
+    connector: FeishuBitableConnector | None = None,
+    batch_size: int = 100,
+    insert_keys: set[str] | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Create an indexed sink with preloaded keys for testing."""
+    if connector is None:
+        connector = FeishuBitableConnector(app_id="app-id", app_secret="secret")
+    sink = connector.table_sink(
+        app_token="app-token",
+        table_id="tbl",
+        mode="insert",
+        match_fields=["编号"],
+        batch_size=batch_size,
+        insert_key_index=True,
+        **kwargs,
+    )
+    if insert_keys is not None:
+        sink._insert_keys = insert_keys
+        sink._index_loaded = True
+    return sink, connector
+
+
+def test_feishu_insert_index_hit_completes_without_search_or_write() -> None:
+    """Send with a key already in the index returns immediately."""
+    async def scenario() -> None:
+        sink, _ = await _make_indexed_sink(insert_keys={"K-1"})
+        await sink.send(Envelope(body={"编号": "K-1"}))
+        # No error, no search, no write
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_send_waits_for_its_batch_write() -> None:
+    """A send does not return until the batch write completes."""
+    async def scenario() -> None:
+        write_started = asyncio.Event()
+        release_write = asyncio.Event()
+        created_batches: list[list[dict[str, Any]]] = []
+
+        async def fake_batch_create(**kwargs: Any) -> dict[str, Any]:
+            records = kwargs.get("records", [])
+            created_batches.append(list(records))
+            write_started.set()
+            await release_write.wait()
+            return {"records": [{"fields": dict(r)} for r in records]}
+
+        sink, connector = await _make_indexed_sink(insert_keys=set())
+        connector.batch_create_records = fake_batch_create  # type: ignore[assignment]
+
+        send_tasks = [
+            asyncio.create_task(sink.send(Envelope(body={"编号": f"K-{i:03d}"})))
+            for i in range(100)
+        ]
+        await asyncio.wait_for(write_started.wait(), timeout=1.0)
+        assert not any(task.done() for task in send_tasks)
+        release_write.set()
+        await asyncio.gather(*send_tasks)
+        assert len(created_batches) == 1
+        assert len(created_batches[0]) == 100
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_concurrent_duplicate_key_creates_once() -> None:
+    """Two sends for the same absent key produce one create."""
+    async def scenario() -> None:
+        created_batches: list[list[dict[str, Any]]] = []
+
+        async def fake_batch_create(**kwargs: Any) -> dict[str, Any]:
+            records = kwargs.get("records", [])
+            created_batches.append(list(records))
+            return {"records": [{"fields": dict(r)} for r in records]}
+
+        sink, connector = await _make_indexed_sink(insert_keys=set())
+        connector.batch_create_records = fake_batch_create  # type: ignore[assignment]
+
+        t1 = asyncio.create_task(sink.send(Envelope(body={"编号": "K-1"})))
+        t2 = asyncio.create_task(sink.send(Envelope(body={"编号": "K-1"})))
+        await asyncio.gather(t1, t2)
+        total_creates = sum(len(b) for b in created_batches)
+        assert total_creates == 1
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_batch_failure_completes_every_member_with_error() -> None:
+    """A batch write failure raises through every pending send."""
+    async def scenario() -> None:
+        async def fake_batch_create(**kwargs: Any) -> dict[str, Any]:
+            raise ConnectorOperationError(
+                backend="feishu_bitable",
+                operation=ConnectorOperation.SEND,
+                kind=ConnectorErrorKind.PERMANENT,
+                source_name="test",
+                retry_delay_s=1.0,
+                message="batch write failed",
+            )
+
+        sink, connector = await _make_indexed_sink(insert_keys=set(), batch_size=5)
+        connector.batch_create_records = fake_batch_create  # type: ignore[assignment]
+
+        tasks = [
+            asyncio.create_task(sink.send(Envelope(body={"编号": f"K-{i}"})))
+            for i in range(5)
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for r in results:
+            assert isinstance(r, ConnectorOperationError)
+            assert "batch write failed" in str(r)
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_timer_flush_completes_partial_batch_waiters() -> None:
+    """A timer flush completes fewer-than-batch_size sends (without NameError)."""
+    async def scenario() -> None:
+        created_batches: list[list[dict[str, Any]]] = []
+
+        async def fake_batch_create(**kwargs: Any) -> dict[str, Any]:
+            records = kwargs.get("records", [])
+            created_batches.append(list(records))
+            return {"records": [{"fields": dict(r)} for r in records]}
+
+        sink, connector = await _make_indexed_sink(
+            insert_keys=set(), batch_size=100, flush_interval_s=0.05
+        )
+        connector.batch_create_records = fake_batch_create  # type: ignore[assignment]
+
+        await asyncio.gather(
+            sink.send(Envelope(body={"编号": "K-1"})),
+            sink.send(Envelope(body={"编号": "K-2"})),
+            sink.send(Envelope(body={"编号": "K-3"})),
+        )
+        assert len(created_batches) == 1
+        assert len(created_batches[0]) == 3
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_close_drains_partial_batch_and_every_waiter() -> None:
+    """Close seals and flushes all remaining pending keys."""
+    async def scenario() -> None:
+        created_batches: list[list[dict[str, Any]]] = []
+
+        async def fake_batch_create(**kwargs: Any) -> dict[str, Any]:
+            records = kwargs.get("records", [])
+            created_batches.append(list(records))
+            return {"records": [{"fields": dict(r)} for r in records]}
+
+        sink, connector = await _make_indexed_sink(
+            insert_keys=set(), batch_size=100
+        )
+        connector.batch_create_records = fake_batch_create  # type: ignore[assignment]
+
+        t1 = asyncio.create_task(sink.send(Envelope(body={"编号": "K-1"})))
+        await asyncio.sleep(0.01)
+        await sink.close()
+        await t1
+        assert len(created_batches) == 1
+        assert len(created_batches[0]) == 1
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_close_failure_fails_every_waiter() -> None:
+    """Close that fails during flush completes remaining waiters with error."""
+    async def scenario() -> None:
+        async def fake_batch_create(**kwargs: Any) -> dict[str, Any]:
+            raise ConnectorOperationError(
+                backend="feishu_bitable",
+                operation=ConnectorOperation.SEND,
+                kind=ConnectorErrorKind.PERMANENT,
+                source_name="test",
+                retry_delay_s=1.0,
+                message="close flush failed",
+            )
+
+        sink, connector = await _make_indexed_sink(
+            insert_keys=set(), batch_size=100
+        )
+        connector.batch_create_records = fake_batch_create  # type: ignore[assignment]
+
+        t1 = asyncio.create_task(sink.send(Envelope(body={"编号": "K-1"})))
+        await asyncio.sleep(0.01)
+        await sink.close()
+        with pytest.raises(ConnectorOperationError):
+            await t1
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_cancelled_sender_leaves_no_waiter_after_close() -> None:
+    """Cancelled send coroutines do not leave leaked Futures."""
+    async def scenario() -> None:
+        sink, _ = await _make_indexed_sink(insert_keys=set(), batch_size=100)
+
+        t1 = asyncio.create_task(sink.send(Envelope(body={"编号": "K-1"})))
+        await asyncio.sleep(0.01)
+        t1.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await t1
+        await sink.close()
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_ambiguous_write_finds_committed_keys_without_recreate() -> None:
+    """An uncertain create is searched before any second create."""
+
+    async def scenario() -> None:
+        create_calls = 0
+        search_calls: list[str] = []
+
+        async def fake_batch_create(**kwargs: Any) -> dict[str, Any]:
+            nonlocal create_calls
+            create_calls += 1
+            raise ConnectorOperationError(
+                backend="feishu_bitable",
+                operation=ConnectorOperation.SEND,
+                kind=ConnectorErrorKind.UNCERTAIN,
+                source_name="test",
+                message="connection closed after request",
+            )
+
+        async def fake_search(**kwargs: Any) -> dict[str, Any]:
+            value = kwargs["body"]["filter"]["conditions"][0]["value"][0]
+            search_calls.append(value)
+            return {"items": [{"record_id": "rec"}], "has_more": False}
+
+        sink, connector = await _make_indexed_sink(insert_keys=set(), batch_size=2)
+        connector.batch_create_records = fake_batch_create  # type: ignore[assignment]
+        connector.search_records = fake_search  # type: ignore[assignment]
+
+        await asyncio.gather(
+            sink.send(Envelope(body={"编号": "K-1"})),
+            sink.send(Envelope(body={"编号": "K-2"})),
+        )
+        assert create_calls == 1
+        assert sorted(search_calls) == ["K-1", "K-2"]
+        assert sink._insert_keys == {"K-1", "K-2"}
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_ambiguous_write_recreates_only_confirmed_misses() -> None:
+    """Recovery excludes keys that the exact lookup already found."""
+
+    async def scenario() -> None:
+        creates: list[list[str]] = []
+
+        async def fake_batch_create(**kwargs: Any) -> dict[str, Any]:
+            keys = [record["编号"] for record in kwargs["records"]]
+            creates.append(keys)
+            if len(creates) == 1:
+                raise ConnectorOperationError(
+                    backend="feishu_bitable",
+                    operation=ConnectorOperation.SEND,
+                    kind=ConnectorErrorKind.UNCERTAIN,
+                    source_name="test",
+                )
+            return {"records": [{"record_id": "rec-2"}]}
+
+        async def fake_search(**kwargs: Any) -> dict[str, Any]:
+            value = kwargs["body"]["filter"]["conditions"][0]["value"][0]
+            return {
+                "items": [{"record_id": "rec-1"}] if value == "K-1" else [],
+                "has_more": False,
+            }
+
+        sink, connector = await _make_indexed_sink(insert_keys=set(), batch_size=2)
+        connector.batch_create_records = fake_batch_create  # type: ignore[assignment]
+        connector.search_records = fake_search  # type: ignore[assignment]
+        await asyncio.gather(
+            sink.send(Envelope(body={"编号": "K-1"})),
+            sink.send(Envelope(body={"编号": "K-2"})),
+        )
+        assert creates == [["K-1", "K-2"], ["K-2"]]
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_lookup_error_is_never_treated_as_missing() -> None:
+    """Recovery search errors do not trigger a blind create."""
+
+    async def scenario() -> None:
+        create_calls = 0
+
+        async def fake_batch_create(**kwargs: Any) -> dict[str, Any]:
+            nonlocal create_calls
+            create_calls += 1
+            raise ConnectorOperationError(
+                backend="feishu_bitable",
+                operation=ConnectorOperation.SEND,
+                kind=ConnectorErrorKind.UNCERTAIN,
+                source_name="test",
+            )
+
+        async def fake_search(**kwargs: Any) -> dict[str, Any]:
+            raise ConnectorOperationError(
+                backend="feishu_bitable",
+                operation=ConnectorOperation.SEND,
+                kind=ConnectorErrorKind.TRANSIENT,
+                source_name="test",
+            )
+
+        sink, connector = await _make_indexed_sink(
+            insert_keys=set(), batch_size=1, ambiguous_write_max_rounds=2
+        )
+        connector.batch_create_records = fake_batch_create  # type: ignore[assignment]
+        connector.search_records = fake_search  # type: ignore[assignment]
+        with pytest.raises(ConnectorOperationError) as excinfo:
+            await sink.send(Envelope(body={"编号": "K-1"}))
+        assert excinfo.value.kind is ConnectorErrorKind.UNCERTAIN
+        assert create_calls == 1
+
+    asyncio.run(scenario())
+
+
+def test_feishu_insert_short_success_response_enters_recovery() -> None:
+    """A short success response cannot acknowledge the whole batch."""
+
+    async def scenario() -> None:
+        search_calls = 0
+
+        async def fake_batch_create(**kwargs: Any) -> dict[str, Any]:
+            return {"records": [{"record_id": "only-one"}]}
+
+        async def fake_search(**kwargs: Any) -> dict[str, Any]:
+            nonlocal search_calls
+            search_calls += 1
+            return {"items": [{"record_id": "rec"}], "has_more": False}
+
+        sink, connector = await _make_indexed_sink(insert_keys=set(), batch_size=2)
+        connector.batch_create_records = fake_batch_create  # type: ignore[assignment]
+        connector.search_records = fake_search  # type: ignore[assignment]
+        await asyncio.gather(
+            sink.send(Envelope(body={"编号": "K-1"})),
+            sink.send(Envelope(body={"编号": "K-2"})),
+        )
+        assert search_calls == 2
+
+    asyncio.run(scenario())

--- a/plugins/onestep-mysql/README.md
+++ b/plugins/onestep-mysql/README.md
@@ -28,3 +28,9 @@ SQLAlchemy database operations use `AsyncEngine` and async drivers. Existing
 adapted to the `asyncmy` dialect. SQLite is supported in tests and local
 development through `aiosqlite`. The binlog reader remains isolated behind a
 thread boundary because `mysql-replication` is a synchronous library.
+
+Production `mysql_incremental` sources should bind a durable
+`mysql_cursor_store` with an explicit stable `state_key`. Retries redeliver the
+same logical row with incremented attempts and pause later SQL reads across the
+gap. Concurrent acknowledgements advance only a contiguous prefix and are
+coalesced into cursor-store commit waves.

--- a/plugins/onestep-mysql/pyproject.toml
+++ b/plugins/onestep-mysql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-mysql"
-version = "0.4.0"
+version = "0.5.0"
 description = "MySQL connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-mysql/src/onestep_mysql/connector.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/connector.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
+import time
 from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -10,11 +12,17 @@ from typing import Any
 
 from onestep.connectors.base import Delivery, Sink, Source
 from onestep.envelope import Envelope
-from onestep.resilience import ConnectorOperation
+from onestep.resilience import (
+    ConnectorErrorKind,
+    ConnectorOperation,
+    ConnectorOperationError,
+)
 from onestep.state import CursorStore, InMemoryCursorStore
 
 from .resilience import as_mysql_connector_operation_error, collect_sensitive_tokens
 from .state_sqlalchemy import SQLAlchemyCursorStore, SQLAlchemyStateStore, _async_dsn
+
+logger = logging.getLogger(__name__)
 
 try:
     import sqlalchemy as sa
@@ -635,6 +643,13 @@ class _CursorToken:
     value: tuple[Any, ...]
 
 
+@dataclass
+class _IncrementalRetryRow:
+    envelope: Envelope
+    ready_at: float
+    in_flight: bool = False
+
+
 class IncrementalDelivery(Delivery):
     def __init__(self, source: IncrementalTableSource, envelope: Envelope, token: _CursorToken) -> None:
         super().__init__(envelope)
@@ -645,11 +660,17 @@ class IncrementalDelivery(Delivery):
         await self._source.ack_token(self._token)
 
     async def retry(self, *, delay_s: float | None = None) -> None:
-        if delay_s:
-            await asyncio.sleep(delay_s)
+        await self._source.retry_token(
+            self._token,
+            self.envelope,
+            delay_s=delay_s,
+        )
 
     async def fail(self, exc: Exception | None = None) -> None:
-        return None
+        await self._source.fail_token(self._token, exc)
+
+    async def release_unstarted(self) -> None:
+        await self._source.release_token(self._token, self.envelope)
 
 
 class IncrementalTableSource(Source):
@@ -681,6 +702,10 @@ class IncrementalTableSource(Source):
         self._acked: set[tuple[Any, ...]] = set()
         self._commit_lock: asyncio.Lock | None = None
         self._commit_loop: asyncio.AbstractEventLoop | None = None
+        self._commit_task: asyncio.Task[None] | None = None
+        self._commit_error: BaseException | None = None
+        self._retry_rows: dict[tuple[Any, ...], _IncrementalRetryRow] = {}
+        self._terminal_error: ConnectorOperationError | None = None
         self._loaded = False
         self._committed_cursor: tuple[Any, ...] | None = None
         self._fetched_cursor: tuple[Any, ...] | None = None
@@ -695,6 +720,15 @@ class IncrementalTableSource(Source):
 
     async def fetch(self, limit: int) -> list[Delivery]:
         await self.open()
+        lock = self._runtime_commit_lock()
+        async with lock:
+            if self._terminal_error is not None:
+                raise self._terminal_error
+            retry_delivery = self._take_ready_retry_delivery()
+            if retry_delivery is not None:
+                return [retry_delivery]
+            if self._retry_rows:
+                return []
         try:
             rows = await self._fetch(max(1, min(limit, self.batch_size)))
         except Exception as exc:
@@ -709,13 +743,24 @@ class IncrementalTableSource(Source):
                 raise
             raise connector_error from exc
         deliveries: list[Delivery] = []
-        for row in rows:
-            token = _CursorToken(tuple(row[column] for column in self.cursor))
-            self._pending.append(token.value)
-            self._fetched_cursor = token.value
-            envelope = Envelope(body=row, meta={"table": self.table_name})
-            deliveries.append(IncrementalDelivery(self, envelope, token))
+        async with lock:
+            for row in rows:
+                token = _CursorToken(tuple(row[column] for column in self.cursor))
+                self._pending.append(token.value)
+                self._fetched_cursor = token.value
+                envelope = Envelope(body=row, meta={"table": self.table_name})
+                deliveries.append(IncrementalDelivery(self, envelope, token))
         return deliveries
+
+    def _take_ready_retry_delivery(self) -> Delivery | None:
+        now = time.monotonic()
+        for token_value in self._pending:
+            retry = self._retry_rows.get(token_value)
+            if retry is None or retry.in_flight or retry.ready_at > now:
+                continue
+            retry.in_flight = True
+            return IncrementalDelivery(self, retry.envelope, _CursorToken(token_value))
+        return None
 
     async def _fetch(self, limit: int) -> list[dict[str, Any]]:
         table = await self.connector._table(self.table_name)
@@ -739,15 +784,130 @@ class IncrementalTableSource(Source):
         lock = self._runtime_commit_lock()
         async with lock:
             self._acked.add(token.value)
-            advanced: tuple[Any, ...] | None = None
-            while self._pending and self._pending[0] in self._acked:
-                advanced = self._pending.popleft()
-                self._acked.remove(advanced)
-            if advanced is not None:
-                self._committed_cursor = advanced
-                if not self._pending:
-                    self._fetched_cursor = advanced
-                await self.state.save(self.state_key, list(advanced))
+            if not self._pending or self._pending[0] not in self._acked:
+                return
+            task = self._commit_task
+            if task is None or task.done():
+                self._commit_error = None
+                task = asyncio.create_task(self._flush_commits())
+                self._commit_task = task
+        await asyncio.shield(task)
+
+    async def retry_token(
+        self,
+        token: _CursorToken,
+        envelope: Envelope,
+        *,
+        delay_s: float | None,
+    ) -> None:
+        lock = self._runtime_commit_lock()
+        async with lock:
+            self._retry_rows[token.value] = _IncrementalRetryRow(
+                envelope=Envelope(
+                    body=envelope.body,
+                    meta=dict(envelope.meta),
+                    attempts=envelope.attempts + 1,
+                ),
+                ready_at=time.monotonic() + max(0.0, delay_s or 0.0),
+            )
+        logger.info(
+            "mysql incremental retry",
+            extra={
+                "event": "mysql_incremental_retry",
+                "attempt": envelope.attempts + 1,
+                "delay_s": max(0.0, delay_s or 0.0),
+                "pending_cursor_rows": len(self._pending),
+            },
+        )
+
+    async def release_token(
+        self, token: _CursorToken, envelope: Envelope
+    ) -> None:
+        lock = self._runtime_commit_lock()
+        async with lock:
+            retry = self._retry_rows.get(token.value)
+            if retry is None:
+                retry = _IncrementalRetryRow(envelope=envelope, ready_at=time.monotonic())
+                self._retry_rows[token.value] = retry
+            retry.in_flight = False
+            retry.ready_at = time.monotonic()
+
+    async def fail_token(
+        self, token: _CursorToken, exc: Exception | None
+    ) -> None:
+        lock = self._runtime_commit_lock()
+        async with lock:
+            self._terminal_error = ConnectorOperationError(
+                backend="mysql",
+                operation=ConnectorOperation.FETCH,
+                kind=ConnectorErrorKind.PERMANENT,
+                source_name=self.name,
+                retry_delay_s=self.poll_interval_s,
+                cause=exc,
+                message="mysql incremental source is blocked at a failed cursor row",
+            )
+            retry = self._retry_rows.get(token.value)
+            if retry is not None:
+                retry.in_flight = False
+
+    async def _flush_commits(self) -> None:
+        # Let acknowledgements released by the same destination batch join one
+        # durable cursor write.
+        await asyncio.sleep(0)
+        try:
+            while True:
+                lock = self._runtime_commit_lock()
+                async with lock:
+                    prefix: list[tuple[Any, ...]] = []
+                    for token_value in self._pending:
+                        if token_value not in self._acked:
+                            break
+                        prefix.append(token_value)
+                    if not prefix:
+                        return
+                    highest = prefix[-1]
+                started_at = time.monotonic()
+                await self.state.save(self.state_key, list(highest))
+                async with lock:
+                    for token_value in prefix:
+                        current = self._pending.popleft()
+                        if current != token_value:
+                            raise RuntimeError(
+                                "mysql incremental pending cursor order changed during commit"
+                            )
+                        self._acked.remove(token_value)
+                        self._retry_rows.pop(token_value, None)
+                    self._committed_cursor = highest
+                    if not self._pending:
+                        self._fetched_cursor = highest
+                    has_more = bool(
+                        self._pending and self._pending[0] in self._acked
+                    )
+                logger.info(
+                    "mysql incremental cursor commit",
+                    extra={
+                        "event": "mysql_incremental_cursor_commit",
+                        "coalesced_ack_count": len(prefix),
+                        "duration_s": round(time.monotonic() - started_at, 3),
+                        "outcome": "success",
+                        "pending_cursor_rows": len(self._pending),
+                    },
+                )
+                if not has_more:
+                    return
+        except BaseException as exc:
+            self._commit_error = exc
+            raise
+        finally:
+            lock = self._runtime_commit_lock()
+            async with lock:
+                if self._commit_task is asyncio.current_task():
+                    self._commit_task = None
+
+    async def close(self) -> None:
+        task = self._commit_task
+        if task is not None:
+            await asyncio.shield(task)
 
     def _runtime_commit_lock(self) -> asyncio.Lock:
         current_loop = asyncio.get_running_loop()

--- a/plugins/onestep-mysql/src/onestep_mysql/connector.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/connector.py
@@ -706,6 +706,9 @@ class IncrementalTableSource(Source):
         self._commit_error: BaseException | None = None
         self._retry_rows: dict[tuple[Any, ...], _IncrementalRetryRow] = {}
         self._terminal_error: ConnectorOperationError | None = None
+        self._fetch_count = 0
+        self._retry_count = 0
+        self._cursor_save_count = 0
         self._loaded = False
         self._committed_cursor: tuple[Any, ...] | None = None
         self._fetched_cursor: tuple[Any, ...] | None = None
@@ -729,8 +732,10 @@ class IncrementalTableSource(Source):
                 return [retry_delivery]
             if self._retry_rows:
                 return []
+        requested_limit = max(1, min(limit, self.batch_size))
+        started_at = time.monotonic()
         try:
-            rows = await self._fetch(max(1, min(limit, self.batch_size)))
+            rows = await self._fetch(requested_limit)
         except Exception as exc:
             connector_error = as_mysql_connector_operation_error(
                 operation=ConnectorOperation.FETCH,
@@ -750,6 +755,21 @@ class IncrementalTableSource(Source):
                 self._fetched_cursor = token.value
                 envelope = Envelope(body=row, meta={"table": self.table_name})
                 deliveries.append(IncrementalDelivery(self, envelope, token))
+            self._fetch_count += 1
+            fetch_count = self._fetch_count
+            pending_cursor_rows = len(self._pending)
+        logger.info(
+            "mysql incremental fetch",
+            extra={
+                "event": "mysql_incremental_fetch",
+                "fetch_count": fetch_count,
+                "requested_limit": requested_limit,
+                "row_count": len(rows),
+                "duration_s": round(time.monotonic() - started_at, 3),
+                "pending_cursor_rows": pending_cursor_rows,
+                "fetched_cursor_lag_rows": pending_cursor_rows,
+            },
+        )
         return deliveries
 
     def _take_ready_retry_delivery(self) -> Delivery | None:
@@ -802,6 +822,8 @@ class IncrementalTableSource(Source):
     ) -> None:
         lock = self._runtime_commit_lock()
         async with lock:
+            self._retry_count += 1
+            retry_count = self._retry_count
             self._retry_rows[token.value] = _IncrementalRetryRow(
                 envelope=Envelope(
                     body=envelope.body,
@@ -814,6 +836,7 @@ class IncrementalTableSource(Source):
             "mysql incremental retry",
             extra={
                 "event": "mysql_incremental_retry",
+                "retry_count": retry_count,
                 "attempt": envelope.attempts + 1,
                 "delay_s": max(0.0, delay_s or 0.0),
                 "pending_cursor_rows": len(self._pending),
@@ -867,7 +890,25 @@ class IncrementalTableSource(Source):
                         return
                     highest = prefix[-1]
                 started_at = time.monotonic()
-                await self.state.save(self.state_key, list(highest))
+                async with lock:
+                    self._cursor_save_count += 1
+                    cursor_save_count = self._cursor_save_count
+                try:
+                    await self.state.save(self.state_key, list(highest))
+                except BaseException:
+                    logger.info(
+                        "mysql incremental cursor commit",
+                        extra={
+                            "event": "mysql_incremental_cursor_commit",
+                            "cursor_save_count": cursor_save_count,
+                            "coalesced_ack_count": len(prefix),
+                            "duration_s": round(time.monotonic() - started_at, 3),
+                            "outcome": "error",
+                            "pending_cursor_rows": len(self._pending),
+                            "fetched_cursor_lag_rows": len(self._pending),
+                        },
+                    )
+                    raise
                 async with lock:
                     for token_value in prefix:
                         current = self._pending.popleft()
@@ -887,10 +928,12 @@ class IncrementalTableSource(Source):
                     "mysql incremental cursor commit",
                     extra={
                         "event": "mysql_incremental_cursor_commit",
+                        "cursor_save_count": cursor_save_count,
                         "coalesced_ack_count": len(prefix),
                         "duration_s": round(time.monotonic() - started_at, 3),
                         "outcome": "success",
                         "pending_cursor_rows": len(self._pending),
+                        "fetched_cursor_lag_rows": len(self._pending),
                     },
                 )
                 if not has_more:

--- a/plugins/onestep-mysql/tests/test_mysql_incremental.py
+++ b/plugins/onestep-mysql/tests/test_mysql_incremental.py
@@ -2,6 +2,9 @@ import asyncio
 from pathlib import Path
 
 import sqlalchemy as sa
+import pytest
+from onestep.resilience import ConnectorOperationError
+from onestep.state import InMemoryCursorStore
 from onestep_mysql import MySQLConnector
 
 
@@ -244,6 +247,231 @@ def test_mysql_incremental_default_state_key_separates_distinct_where_clauses(tm
         assert [item.payload["id"] for item in deleted_batch] == [3]
         await deleted_batch[0].ack()
 
+        await db.close()
+
+    asyncio.run(scenario())
+
+
+def test_mysql_incremental_retry_redelivers_same_row_with_incremented_attempts(
+    tmp_path: Path,
+) -> None:
+    db_url = f"sqlite:///{tmp_path / 'incremental_retry.db'}"
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    rows = sa.Table(
+        "rows",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("created_at", sa.Integer, nullable=False),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(sa.insert(rows), [{"id": 1, "created_at": 10}, {"id": 2, "created_at": 11}])
+    engine.dispose()
+
+    async def scenario() -> None:
+        db = MySQLConnector(db_url)
+        state = InMemoryCursorStore()
+        source = db.incremental(
+            table="rows",
+            key="id",
+            cursor=("created_at", "id"),
+            batch_size=10,
+            poll_interval_s=0.01,
+            state=state,
+            state_key="retry-test",
+        )
+        original = await source.fetch(2)
+        assert [item.payload["id"] for item in original] == [1, 2]
+
+        await original[0].retry(delay_s=0)
+        first_retry = await source.fetch(2)
+        assert len(first_retry) == 1
+        assert first_retry[0].payload["id"] == 1
+        assert first_retry[0].envelope.attempts == 1
+
+        await first_retry[0].retry(delay_s=0)
+        second_retry = await source.fetch(2)
+        assert second_retry[0].payload["id"] == 1
+        assert second_retry[0].envelope.attempts == 2
+        await second_retry[0].ack()
+        assert await state.load("retry-test") == [10, 1]
+        await original[1].ack()
+        assert await state.load("retry-test") == [11, 2]
+        await db.close()
+
+    asyncio.run(scenario())
+
+
+def test_mysql_incremental_retry_delay_and_inflight_gap_pause_sql_reads(
+    tmp_path: Path,
+) -> None:
+    db_url = f"sqlite:///{tmp_path / 'incremental_retry_gap.db'}"
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    rows = sa.Table(
+        "rows",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("created_at", sa.Integer, nullable=False),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(sa.insert(rows), [{"id": 1, "created_at": 10}])
+    engine.dispose()
+
+    async def scenario() -> None:
+        db = MySQLConnector(db_url)
+        source = db.incremental(
+            table="rows",
+            key="id",
+            cursor=("created_at", "id"),
+            batch_size=10,
+            poll_interval_s=0.01,
+        )
+        original = (await source.fetch(1))[0]
+        await original.retry(delay_s=0.05)
+        assert await source.fetch(10) == []
+        await asyncio.sleep(0.06)
+        retry = (await source.fetch(10))[0]
+        assert retry.envelope.attempts == 1
+        assert await source.fetch(10) == []
+        await retry.ack()
+        await db.close()
+
+    asyncio.run(scenario())
+
+
+def test_mysql_incremental_terminal_failure_blocks_before_failed_cursor(
+    tmp_path: Path,
+) -> None:
+    db_url = f"sqlite:///{tmp_path / 'incremental_terminal.db'}"
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    rows = sa.Table(
+        "rows",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("created_at", sa.Integer, nullable=False),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(sa.insert(rows), [{"id": 1, "created_at": 10}, {"id": 2, "created_at": 11}])
+    engine.dispose()
+
+    async def scenario() -> None:
+        db = MySQLConnector(db_url)
+        state = InMemoryCursorStore()
+        source = db.incremental(
+            table="rows",
+            key="id",
+            cursor=("created_at", "id"),
+            batch_size=10,
+            poll_interval_s=0.01,
+            state=state,
+            state_key="terminal-test",
+        )
+        batch = await source.fetch(2)
+        await batch[1].ack()
+        await batch[0].fail(RuntimeError("bad row"))
+        with pytest.raises(ConnectorOperationError, match="blocked at a failed cursor row"):
+            await source.fetch(10)
+        assert await state.load("terminal-test") is None
+        await db.close()
+
+    asyncio.run(scenario())
+
+
+class _CountingCursorStore(InMemoryCursorStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.save_calls: list[object] = []
+        self.failures_remaining = 0
+
+    async def save(self, key: str, value: object) -> None:
+        self.save_calls.append(value)
+        if self.failures_remaining:
+            self.failures_remaining -= 1
+            raise RuntimeError("cursor save failed")
+        await super().save(key, value)
+
+
+def test_mysql_incremental_coalesces_concurrent_contiguous_acks(tmp_path: Path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'incremental_coalesce.db'}"
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    rows = sa.Table(
+        "rows",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("created_at", sa.Integer, nullable=False),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.insert(rows),
+            [{"id": index, "created_at": index} for index in range(1, 101)],
+        )
+    engine.dispose()
+
+    async def scenario() -> None:
+        db = MySQLConnector(db_url)
+        state = _CountingCursorStore()
+        source = db.incremental(
+            table="rows",
+            key="id",
+            cursor=("created_at", "id"),
+            batch_size=100,
+            poll_interval_s=0.01,
+            state=state,
+            state_key="coalesce-test",
+        )
+        batch = await source.fetch(100)
+        await asyncio.gather(*(delivery.ack() for delivery in batch))
+        assert state.save_calls == [[100, 100]]
+        await db.close()
+
+    asyncio.run(scenario())
+
+
+def test_mysql_incremental_cursor_save_failure_preserves_retryable_prefix(
+    tmp_path: Path,
+) -> None:
+    db_url = f"sqlite:///{tmp_path / 'incremental_save_failure.db'}"
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    rows = sa.Table(
+        "rows",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("created_at", sa.Integer, nullable=False),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(sa.insert(rows), [{"id": 1, "created_at": 10}, {"id": 2, "created_at": 11}])
+    engine.dispose()
+
+    async def scenario() -> None:
+        db = MySQLConnector(db_url)
+        state = _CountingCursorStore()
+        state.failures_remaining = 1
+        source = db.incremental(
+            table="rows",
+            key="id",
+            cursor=("created_at", "id"),
+            batch_size=10,
+            poll_interval_s=0.01,
+            state=state,
+            state_key="save-failure-test",
+        )
+        batch = await source.fetch(2)
+        results = await asyncio.gather(
+            *(delivery.ack() for delivery in batch), return_exceptions=True
+        )
+        assert all(isinstance(result, RuntimeError) for result in results)
+        assert await state.load("save-failure-test") is None
+        await batch[0].ack()
+        assert await state.load("save-failure-test") == [11, 2]
         await db.close()
 
     asyncio.run(scenario())

--- a/plugins/onestep-mysql/tests/test_mysql_incremental.py
+++ b/plugins/onestep-mysql/tests/test_mysql_incremental.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+import logging
 from pathlib import Path
 
 import sqlalchemy as sa
@@ -475,3 +477,92 @@ def test_mysql_incremental_cursor_save_failure_preserves_retryable_prefix(
         await db.close()
 
     asyncio.run(scenario())
+
+
+def test_mysql_incremental_logs_fetch_retry_commit_without_sensitive_values(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    db_url = f"sqlite:///{tmp_path / 'mysql-dsn-secret.db'}"
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    rows = sa.Table(
+        "rows",
+        metadata,
+        sa.Column("union_key", sa.String, primary_key=True),
+        sa.Column("created_at", sa.Integer, nullable=False),
+        sa.Column("payload", sa.String, nullable=False),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.insert(rows),
+            {
+                "union_key": "union-key-secret",
+                "created_at": 8_675_309,
+                "payload": "payload-value-secret",
+            },
+        )
+    engine.dispose()
+
+    async def scenario() -> None:
+        db = MySQLConnector(db_url)
+        state = InMemoryCursorStore()
+        source = db.incremental(
+            table="rows",
+            key="union_key",
+            cursor=("created_at", "union_key"),
+            batch_size=100,
+            poll_interval_s=0.01,
+            state=state,
+            state_key="cursor-state-secret",
+        )
+        original = (await source.fetch(100))[0]
+        await original.retry(delay_s=0)
+        retry = (await source.fetch(100))[0]
+        await retry.ack()
+        await db.close()
+
+    caplog.set_level(logging.INFO, logger="onestep_mysql.connector")
+    asyncio.run(scenario())
+
+    records = {
+        record.event: record
+        for record in caplog.records
+        if hasattr(record, "event")
+    }
+    assert {
+        "fetch_count",
+        "requested_limit",
+        "row_count",
+        "duration_s",
+        "pending_cursor_rows",
+        "fetched_cursor_lag_rows",
+    } <= records["mysql_incremental_fetch"].__dict__.keys()
+    assert {
+        "retry_count",
+        "attempt",
+        "delay_s",
+        "pending_cursor_rows",
+    } <= records["mysql_incremental_retry"].__dict__.keys()
+    assert {
+        "cursor_save_count",
+        "coalesced_ack_count",
+        "duration_s",
+        "outcome",
+        "pending_cursor_rows",
+        "fetched_cursor_lag_rows",
+    } <= records["mysql_incremental_cursor_commit"].__dict__.keys()
+
+    serialized = json.dumps(
+        [record.__dict__ for record in caplog.records],
+        ensure_ascii=False,
+        default=str,
+    )
+    for secret in (
+        "mysql-dsn-secret",
+        "union-key-secret",
+        "payload-value-secret",
+        "cursor-state-secret",
+        "8675309",
+    ):
+        assert secret not in serialized

--- a/skills/onestep/references/connectors.md
+++ b/skills/onestep/references/connectors.md
@@ -124,6 +124,15 @@ resources:
     table: onestep_state
 ```
 
+For immutable MySQL rows inserted into one Feishu table, bind a durable
+`mysql_cursor_store`, use `(operation_time, unique_key)` as the incremental
+cursor, and enable the Feishu table Sink's opt-in `insert_key_index`. This
+preloads the single match field and avoids normal per-row searches. The indexed
+Sink requires one active writer, supports no relations, and stores neither
+record IDs nor a durable idempotency ledger. Source `batch_size`, Sink
+`batch_size`, and task `concurrency` are independent controls;
+`tasks[].config` is handler data only.
+
 ## PostgreSQL execution source
 
 The Python API process uses `ExecutionClient` with the backend plugin's direct DSN

--- a/uv.lock
+++ b/uv.lock
@@ -1582,7 +1582,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-feishu-bitable"
-version = "0.3.5"
+version = "0.4.0"
 source = { editable = "plugins/onestep-feishu-bitable" }
 dependencies = [
     { name = "onestep" },
@@ -1689,7 +1689,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-mysql"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "plugins/onestep-mysql" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- make Feishu Bitable `insert` mode preload the destination match-key index instead of searching once per input row
- make every sink send wait for a definitive batch outcome, with bounded reconciliation for ambiguous writes
- make MySQL incremental retries preserve the failed logical row and advance the cursor only across the contiguous acknowledged prefix
- document the production single-writer configuration and release `onestep-feishu-bitable` 0.4.0 plus `onestep-mysql` 0.5.0

## Business flow

`view_follow_record_sync` -> `mysql_incremental` -> handler/passthrough -> Feishu Bitable insert

- globally unique source key: `unionKey`
- incremental cursor: `(dataCreateTime, unionKey)`
- Feishu match field: `编号`
- insert semantics: skip an existing key; create a missing key
- one active writer per target table
- operation-record `record_id` is not persisted back to the heterogeneous source systems

Relation-table lookups are deliberately out of scope. Callers can resolve and supply related record IDs before this insert flow. This change also does not add updates, deletes, CDC, or a persistent idempotency ledger.

## Performance model

For a deterministic 100,000-row run where the target already contains 50,000 keys and the configured Feishu index page size is 500:

- destination key index scans: 100 requests
- normal per-key search calls: 0
- batch creates for 50,000 missing rows at batch size 100: 500 requests
- total Feishu data requests on the normal path: about 600

Task `concurrency: 100` bounds in-flight deliveries; it does not create 100 concurrent MySQL queries. The source performs one `fetch(available)` per runner iteration, while its own `batch_size` controls the SQL query limit.

## Reliability boundaries

- a Feishu send returns only after its batch is confirmed created or already present
- ambiguous batch writes re-query only affected keys and retry only keys confirmed missing
- a MySQL incremental failure re-delivers the same logical row and pauses later SQL reads during the gap
- the persisted cursor advances only through the contiguous acknowledged prefix
- contiguous acknowledgements coalesce into one state write
- telemetry exposes index scans, avoided searches, batch creates, ambiguous reconciliation, retry, and cursor persistence behavior

## Releases

- `onestep-feishu-bitable` 0.4.0
- `onestep-mysql` 0.5.0

Both plugin workflows test Python 3.9-3.12, build wheel/sdist distributions, check metadata, verify the required core `onestep` version is already on PyPI, and publish only after the merge to `main`.

## Validation

- core non-integration suite: 441 passed
- Feishu Bitable plugin: 91 passed
- MySQL plugin: 52 passed, 1 skipped
- official reliability/plugin matrix: passed
- end-to-end indexed insert/cursor-boundary chain: passed three consecutive runs
- production YAML strict check: passed
- Python compileall: passed
- VitePress docs build: passed (existing warnings only)
- wheel/sdist builds for both plugins: passed
- Twine metadata checks: passed
- `git diff --check`: passed

The local no-mistakes review agent was attempted again for this exact head after three earlier infrastructure-only failures. The new run reached review but produced no review output or findings and remained CPU-idle/quiet for over 17 minutes, so it was cancelled without modifying the branch. The GitHub checks on this PR remain the hard merge gate.

## Deployment scope

This PR releases the two connector plugins only. It does not deploy or start the production follow-record synchronization task.
