### PR TITLE
fix(mysql): persist datetime incremental cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 - Makes buffered sends complete only after their item is confirmed created or pre-existing.
 - Reconciles ambiguous batch writes by exact-searching only affected keys before creating confirmed misses.
 - Requires one active writer per indexed destination table and retains no record IDs or durable ledger.
+
+## onestep-mysql 0.5.1
+- Persists `datetime` components of incremental cursors as tagged ISO-8601 JSON values and restores them for keyset queries after restart.
+
 ## onestep-mysql 0.5.0
 - Retries the same incremental logical row with incremented delivery attempts.
 - Coalesces contiguous cursor acknowledgements into event-loop commit waves without crossing failed gaps.

--- a/plugins/onestep-mysql/pyproject.toml
+++ b/plugins/onestep-mysql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-mysql"
-version = "0.5.0"
+version = "0.5.1"
 description = "MySQL connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-mysql/src/onestep_mysql/state_sqlalchemy.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/state_sqlalchemy.py
@@ -132,4 +132,37 @@ class SQLAlchemyStateStore:
 
 
 class SQLAlchemyCursorStore(SQLAlchemyStateStore):
-    pass
+    _DATETIME_TYPE_KEY = "__onestep_cursor_type__"
+    _DATETIME_TYPE_VALUE = "datetime"
+    _DATETIME_VALUE_KEY = "value"
+
+    async def load(self, key: str) -> Any | None:
+        value = await super().load(key)
+        if not isinstance(value, list):
+            return value
+        return [self._decode_cursor_component(component) for component in value]
+
+    async def save(self, key: str, value: Any) -> None:
+        if isinstance(value, (list, tuple)):
+            value = [self._encode_cursor_component(component) for component in value]
+        await super().save(key, value)
+
+    @classmethod
+    def _encode_cursor_component(cls, value: Any) -> Any:
+        if isinstance(value, datetime):
+            return {
+                cls._DATETIME_TYPE_KEY: cls._DATETIME_TYPE_VALUE,
+                cls._DATETIME_VALUE_KEY: value.isoformat(),
+            }
+        return value
+
+    @classmethod
+    def _decode_cursor_component(cls, value: Any) -> Any:
+        if (
+            isinstance(value, dict)
+            and set(value) == {cls._DATETIME_TYPE_KEY, cls._DATETIME_VALUE_KEY}
+            and value[cls._DATETIME_TYPE_KEY] == cls._DATETIME_TYPE_VALUE
+            and isinstance(value[cls._DATETIME_VALUE_KEY], str)
+        ):
+            return datetime.fromisoformat(value[cls._DATETIME_VALUE_KEY])
+        return value

--- a/plugins/onestep-mysql/tests/test_mysql_incremental.py
+++ b/plugins/onestep-mysql/tests/test_mysql_incremental.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import sqlalchemy as sa
@@ -82,6 +83,76 @@ def test_mysql_incremental_cursor_advances_in_order(tmp_path: Path) -> None:
         assert [item.payload["id"] for item in next_batch] == [3]
         await next_batch[0].ack()
         assert await restarted_state.load("users-sync") == [11, 3]
+        await restarted_db.close()
+
+    asyncio.run(scenario())
+
+
+def test_mysql_incremental_restarts_from_datetime_cursor(tmp_path: Path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'incremental-datetime.db'}"
+    engine = sa.create_engine(db_url, future=True)
+    metadata = sa.MetaData()
+    rows = sa.Table(
+        "rows",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    first_created_at = datetime(2026, 8, 17, 0, 53, 55, 640000)  # noqa: DTZ001
+    second_created_at = first_created_at + timedelta(microseconds=1)
+    third_created_at = second_created_at + timedelta(microseconds=1)
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.insert(rows),
+            [
+                {"id": 1, "created_at": first_created_at},
+                {"id": 2, "created_at": second_created_at},
+            ],
+        )
+    engine.dispose()
+
+    async def scenario() -> None:
+        db = MySQLConnector(db_url)
+        state = db.cursor_store(table="onestep_cursor")
+        source = db.incremental(
+            table="rows",
+            key="id",
+            cursor=("created_at", "id"),
+            batch_size=10,
+            poll_interval_s=0.01,
+            state=state,
+            state_key="follow-records",
+        )
+
+        batch = await source.fetch(10)
+        assert [item.payload["id"] for item in batch] == [1, 2]
+        await asyncio.gather(*(item.ack() for item in batch))
+        assert await state.load("follow-records") == [second_created_at, 2]
+        await db.close()
+
+        restarted_db = MySQLConnector(db_url)
+        restarted_state = restarted_db.cursor_store(table="onestep_cursor")
+        restarted_source = restarted_db.incremental(
+            table="rows",
+            key="id",
+            cursor=("created_at", "id"),
+            batch_size=10,
+            poll_interval_s=0.01,
+            state=restarted_state,
+            state_key="follow-records",
+        )
+
+        assert await restarted_source.fetch(10) == []
+
+        verify_engine = sa.create_engine(db_url, future=True)
+        with verify_engine.begin() as conn:
+            conn.execute(sa.insert(rows), {"id": 3, "created_at": third_created_at})
+        verify_engine.dispose()
+
+        next_batch = await restarted_source.fetch(10)
+        assert [item.payload["id"] for item in next_batch] == [3]
+        await next_batch[0].ack()
         await restarted_db.close()
 
     asyncio.run(scenario())

--- a/plugins/onestep-mysql/tests/test_state_sqlalchemy.py
+++ b/plugins/onestep-mysql/tests/test_state_sqlalchemy.py
@@ -1,5 +1,6 @@
 import asyncio
 from pathlib import Path
+from datetime import datetime
 
 from onestep_mysql import MySQLConnector, SQLAlchemyStateStore
 
@@ -38,6 +39,39 @@ def test_mysql_connector_builds_shared_state_store(tmp_path: Path) -> None:
 
         assert await state.load("service:mode") == {"value": "active"}
         assert await cursor.load("users") == [10, 2]
+        await db.close()
+
+    asyncio.run(scenario())
+
+
+def test_mysql_cursor_store_round_trips_datetime_cursor_values(tmp_path: Path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'datetime-cursor.db'}"
+    cursor_value = datetime(2026, 8, 17, 0, 53, 55, 640000)  # noqa: DTZ001
+
+    async def scenario() -> None:
+        db = MySQLConnector(db_url)
+        cursor = db.cursor_store(table="onestep_cursor")
+
+        await cursor.save("follow-records", [cursor_value, "u_123"])
+
+        assert await cursor.load("follow-records") == [cursor_value, "u_123"]
+
+        raw_state = SQLAlchemyStateStore(
+            engine=db.engine,
+            table="onestep_cursor",
+            key_column="cursor_key",
+            value_column="cursor_value",
+        )
+        assert await raw_state.load("follow-records") == [
+            {
+                "__onestep_cursor_type__": "datetime",
+                "value": "2026-08-17T00:53:55.640000",
+            },
+            "u_123",
+        ]
+
+        await raw_state.save("legacy", [10, "u_456"])
+        assert await cursor.load("legacy") == [10, "u_456"]
         await db.close()
 
     asyncio.run(scenario())

--- a/uv.lock
+++ b/uv.lock
@@ -1689,7 +1689,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-mysql"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "plugins/onestep-mysql" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- persist MySQL incremental cursor datetime components as tagged ISO-8601 JSON values
- restore datetime values before keyset queries after restart
- retain compatibility with existing untagged cursor JSON
- release onestep-mysql 0.5.1

## Verification
- `uv run --package onestep-mysql pytest -q plugins/onestep-mysql/tests` (54 passed, 1 skipped)
- `uv build --package onestep-mysql`
- `uv tool run twine check` for sdist and wheel
- targeted ruff check and `git diff --check`

Fixes the `TypeError: Object of type datetime is not JSON serializable` raised while committing DATETIME incremental cursors.