### PR TITLE
feat: per-sink transform bindings in conditional emit routes (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Extends conditional `emit` routes (`when`/`then`/`otherwise`) with per-sink
+  transform bindings: `then`/`otherwise` branches accept emit-binding mappings
+  (`{sink, transform}`) alongside plain sink names, mirroring top-level emit
+  entries while string and list forms stay backward compatible.
+
 ## onestep 1.10.0
 
 - Adds declarative per-Sink emit bindings with optional Python payload transforms;

--- a/docs/yaml-task-definition.md
+++ b/docs/yaml-task-definition.md
@@ -349,8 +349,47 @@ at-least-once: a later Sink failure does not roll back earlier writes, so each
 destination must be idempotent when duplicates matter.
 
 A binding mapping may contain only sink and transform; it cannot combine with
-when, then, or otherwise in this release. Conditional routes continue to send
-the same handler result to each selected Sink.
+when, then, or otherwise on the same entry. Bindings can appear inside the
+`then` and `otherwise` branches of a conditional route, so each sink in a
+branch can receive a distinct transformed payload.
+
+```yaml
+tasks:
+  - name: extract_entities
+    source: entity_events
+    emit:
+      - sink: entity_callback
+      - when:
+          ref: worker.tasks:has_bidding_id
+        then:
+          - sink: meta_sink
+            transform:
+              ref: worker.transforms:to_meta_row
+          - sink: rows_sink
+            transform:
+              ref: worker.transforms:to_bidding_row
+        otherwise:
+          - sink: fallback_sink
+            transform:
+              ref: worker.transforms:to_fallback_row
+    handler:
+      ref: worker.tasks:extract_entities
+```
+
+The top-level `emit` list supports the same entry shapes: plain sink names, and
+binding mappings with an optional `transform`.
+
+```yaml
+emit:
+  - audit_sink
+  - when:
+      ref: worker.routing:is_active
+    then:
+      - active_sink
+      - sink: metric_sink
+        transform:
+          ref: worker.transforms:to_metric
+```
 
 ### Level 5: Add Task Config
 

--- a/skills/onestep/references/yaml-task-definition.md
+++ b/skills/onestep/references/yaml-task-definition.md
@@ -170,7 +170,32 @@ Sink dispatch remains at-least-once and non-transactional after preparation: if
 a later sink fails, an earlier successful sink can receive a duplicate on retry.
 Use stable business keys or sink idempotency when duplicates matter. A binding may
 contain only sink and transform; do not combine it with when, then, or otherwise
-in this release.
+on the same entry. Bindings can appear inside the `then` and `otherwise` branches
+of a conditional route, so each sink in a branch can receive a distinct transformed
+payload.
+
+```yaml
+tasks:
+  - name: extract_entities
+    source: entity_events
+    emit:
+      - sink: entity_callback
+      - when:
+          ref: worker.tasks:has_bidding_id
+        then:
+          - sink: meta_sink
+            transform:
+              ref: worker.transforms:to_meta_row
+          - sink: rows_sink
+            transform:
+              ref: worker.transforms:to_bidding_row
+        otherwise:
+          - sink: fallback_sink
+            transform:
+              ref: worker.transforms:to_fallback_row
+    handler:
+      ref: worker.tasks:extract_entities
+```
 
 ## Passthrough Tasks
 

--- a/src/onestep/config.py
+++ b/src/onestep/config.py
@@ -719,9 +719,7 @@ def _resolve_emit_binding(
 ) -> EmitBinding:
     _validate_unknown_fields(value, _STRICT_EMIT_BINDING_FIELDS, field=field)
     name = _require_string(value, "sink")
-    sink = _resolve_resource(resources, name)
-    if not isinstance(sink, Sink):
-        raise TypeError(f"resource {name!r} cannot be used as a sink")
+    sink = _resolve_sink_resource(resources, name)
     transform = transform_ref = None
     if "transform" in value:
         transform, transform_ref = _resolve_callable_ref(
@@ -738,31 +736,61 @@ def _resolve_emit_route(resources: Mapping[str, Any], value: Any, *, field: str)
         if "then" not in value:
             raise ValueError(f"{field}.then is required")
         predicate, predicate_ref = _resolve_callable_ref(value.get("when"), field=f"{field}.when")
-        otherwise_sinks = (
-            _resolve_emit_sinks(resources, value.get("otherwise"), field=f"{field}.otherwise")
+        otherwise_bindings = (
+            _resolve_emit_branch(resources, value.get("otherwise"), field=f"{field}.otherwise")
             if "otherwise" in value
             else ()
         )
         return EmitRoute(
             predicate=predicate,
             predicate_ref=predicate_ref,
-            then_sinks=_resolve_emit_sinks(resources, value.get("then"), field=f"{field}.then"),
-            otherwise_sinks=otherwise_sinks,
+            then_bindings=_resolve_emit_branch(resources, value.get("then"), field=f"{field}.then"),
+            otherwise_bindings=otherwise_bindings,
         )
-    return EmitRoute(then_sinks=_resolve_emit_sinks(resources, value, field=field))
+    return EmitRoute(then_bindings=_resolve_emit_branch(resources, value, field=field))
 
 
-def _resolve_emit_sinks(resources: Mapping[str, Any], value: Any, *, field: str) -> tuple[Sink, ...]:
-    names = _string_list(value, field=field)
-    if not names:
+def _resolve_emit_branch(
+    resources: Mapping[str, Any],
+    value: Any,
+    *,
+    field: str,
+) -> tuple[EmitBinding, ...]:
+    """Resolve a route branch (``then``/``otherwise``) into emit bindings.
+
+    A branch accepts a sink-name string, a list mixing sink-name strings with
+    emit-binding mappings (``{sink, transform}``), or a single emit-binding
+    mapping — the same entry shapes as top-level ``emit`` entries.
+    """
+    if value is None:
+        raise ValueError(f"'{field}' must be provided")
+    if isinstance(value, Mapping) and ("sink" in value or "transform" in value):
+        return (_resolve_emit_binding(resources, value, field=field),)
+    if isinstance(value, str):
+        _string_value(value, field=field)
+        entries, indexed = [value], False
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        entries, indexed = list(value), True
+    else:
+        raise TypeError(f"'{field}' must be a string or list of strings")
+    if not entries:
         raise ValueError(f"{field} must not be empty")
-    sinks: list[Sink] = []
-    for name in names:
-        resolved = _resolve_resource(resources, name)
-        if not isinstance(resolved, Sink):
-            raise TypeError(f"resource {name!r} cannot be used as a sink")
-        sinks.append(resolved)
-    return tuple(sinks)
+    bindings: list[EmitBinding] = []
+    for index, entry in enumerate(entries):
+        entry_field = f"{field}[{index}]" if indexed else field
+        if isinstance(entry, Mapping):
+            bindings.append(_resolve_emit_binding(resources, entry, field=entry_field))
+            continue
+        name = _string_value(entry, field=entry_field)
+        bindings.append(EmitBinding(sink=_resolve_sink_resource(resources, name)))
+    return tuple(bindings)
+
+
+def _resolve_sink_resource(resources: Mapping[str, Any], name: str) -> Sink:
+    resolved = _resolve_resource(resources, name)
+    if not isinstance(resolved, Sink):
+        raise TypeError(f"resource {name!r} cannot be used as a sink")
+    return resolved
 
 
 def _resolve_app_state(resources: Mapping[str, Any], value: Any) -> Any:
@@ -990,9 +1018,38 @@ def _validate_emit_route(raw_route: Mapping[str, Any], *, field: str) -> None:
     if "then" not in raw_route:
         raise ValueError(f"{field}.then is required")
     _validate_ref_entry(raw_route.get("when"), field=f"{field}.when")
-    _validate_emit_sink_names(raw_route.get("then"), field=f"{field}.then")
+    _validate_emit_branch(raw_route.get("then"), field=f"{field}.then")
     if "otherwise" in raw_route:
-        _validate_emit_sink_names(raw_route.get("otherwise"), field=f"{field}.otherwise")
+        _validate_emit_branch(raw_route.get("otherwise"), field=f"{field}.otherwise")
+
+
+def _validate_emit_branch(raw_value: Any, *, field: str) -> None:
+    """Validate a route branch (``then``/``otherwise").
+
+    A branch accepts a sink-name string, a list mixing sink-name strings with
+    emit-binding mappings (``{sink, transform}``), or a single emit-binding
+    mapping — mirroring top-level ``emit`` entry validation.
+    """
+    if raw_value is None:
+        raise ValueError(f"'{field}' must be provided")
+    if isinstance(raw_value, Mapping):
+        if "sink" in raw_value or "transform" in raw_value:
+            _validate_emit_binding(raw_value, field=field)
+            return
+        raise TypeError(f"'{field}' must be a string or list of strings")
+    if isinstance(raw_value, str):
+        _string_value(raw_value, field=field)
+        return
+    if not isinstance(raw_value, Sequence) or isinstance(raw_value, (str, bytes)):
+        raise TypeError(f"'{field}' must be a string or list of strings")
+    if not raw_value:
+        raise ValueError(f"{field} must not be empty")
+    for index, entry in enumerate(raw_value):
+        entry_field = f"{field}[{index}]"
+        if isinstance(entry, Mapping):
+            _validate_emit_binding(entry, field=entry_field)
+        else:
+            _string_value(entry, field=entry_field)
 
 
 def _validate_emit_sink_names(raw_value: Any, *, field: str) -> None:

--- a/src/onestep/config.py
+++ b/src/onestep/config.py
@@ -1024,7 +1024,7 @@ def _validate_emit_route(raw_route: Mapping[str, Any], *, field: str) -> None:
 
 
 def _validate_emit_branch(raw_value: Any, *, field: str) -> None:
-    """Validate a route branch (``then``/``otherwise").
+    """Validate a route branch (``then``/``otherwise``).
 
     A branch accepts a sink-name string, a list mixing sink-name strings with
     emit-binding mappings (``{sink, transform}``), or a single emit-binding

--- a/src/onestep/runtime/executor.py
+++ b/src/onestep/runtime/executor.py
@@ -244,15 +244,15 @@ class DeliveryExecutor:
                 continue
             assert isinstance(target, EmitRoute)
             if target.predicate is None:
-                bindings.extend(EmitBinding(sink=sink) for sink in target.then_sinks)
+                bindings.extend(target.then_bindings)
                 continue
             predicate_result = invoke_callback(target.predicate, ctx, payload, result)
             if inspect.isawaitable(predicate_result):
                 predicate_result = await predicate_result
             if predicate_result:
-                bindings.extend(EmitBinding(sink=sink) for sink in target.then_sinks)
+                bindings.extend(target.then_bindings)
             else:
-                bindings.extend(EmitBinding(sink=sink) for sink in target.otherwise_sinks)
+                bindings.extend(target.otherwise_bindings)
         return tuple(bindings)
 
     async def _prepare_emit_envelopes(

--- a/src/onestep/task.py
+++ b/src/onestep/task.py
@@ -23,22 +23,50 @@ class TaskHooks:
 
 
 @dataclass(frozen=True)
-class EmitRoute:
-    then_sinks: tuple[Sink, ...]
-    predicate: TaskPredicate | None = None
-    otherwise_sinks: tuple[Sink, ...] = ()
-    predicate_ref: str | None = None
-
-    @property
-    def sinks(self) -> tuple[Sink, ...]:
-        return (*self.then_sinks, *self.otherwise_sinks)
-
-
-@dataclass(frozen=True)
 class EmitBinding:
     sink: Sink
     transform: TaskTransform | None = None
     transform_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class EmitRoute:
+    then_sinks: tuple[Sink, ...] = ()
+    predicate: TaskPredicate | None = None
+    otherwise_sinks: tuple[Sink, ...] = ()
+    predicate_ref: str | None = None
+    then_bindings: tuple[EmitBinding, ...] = ()
+    otherwise_bindings: tuple[EmitBinding, ...] = ()
+
+    def __post_init__(self) -> None:
+        # Branch bindings are the canonical form: they carry the optional
+        # per-sink transform. Sinks-only construction (the original Python
+        # API) derives plain bindings, and the sink tuples are always kept in
+        # sync with the bindings so both views stay interchangeable.
+        object.__setattr__(
+            self,
+            "then_bindings",
+            _normalize_route_bindings(self.then_sinks, self.then_bindings),
+        )
+        object.__setattr__(
+            self,
+            "then_sinks",
+            tuple(binding.sink for binding in self.then_bindings),
+        )
+        object.__setattr__(
+            self,
+            "otherwise_bindings",
+            _normalize_route_bindings(self.otherwise_sinks, self.otherwise_bindings),
+        )
+        object.__setattr__(
+            self,
+            "otherwise_sinks",
+            tuple(binding.sink for binding in self.otherwise_bindings),
+        )
+
+    @property
+    def sinks(self) -> tuple[Sink, ...]:
+        return (*self.then_sinks, *self.otherwise_sinks)
 
 
 EmitTarget = Union[Sink, EmitBinding, EmitRoute]
@@ -130,6 +158,15 @@ def _normalize_emit_targets(
     return tuple(resolved)
 
 
+def _normalize_route_bindings(
+    sinks: tuple[Sink, ...],
+    bindings: tuple[EmitBinding, ...],
+) -> tuple[EmitBinding, ...]:
+    if bindings:
+        return tuple(bindings)
+    return tuple(EmitBinding(sink=sink) for sink in sinks)
+
+
 def _flatten_emit_target_bindings(
     targets: Iterable[EmitBinding | EmitRoute],
 ) -> tuple[EmitBinding, ...]:
@@ -138,7 +175,8 @@ def _flatten_emit_target_bindings(
         if isinstance(target, EmitBinding):
             bindings.append(target)
         else:
-            bindings.extend(EmitBinding(sink=sink) for sink in target.sinks)
+            bindings.extend(target.then_bindings)
+            bindings.extend(target.otherwise_bindings)
     return tuple(bindings)
 
 

--- a/tests/contract/test_runtime_contract.py
+++ b/tests/contract/test_runtime_contract.py
@@ -1529,6 +1529,7 @@ def test_conditional_emit_route_transforms_selected_branch() -> None:
         fallback_sink = MemoryQueue("fallback", poll_interval_s=0.01)
         app = OneStepApp("conditional-emit-route-transforms")
         seen: list[str] = []
+        processed = 0
 
         def is_bidding(ctx, payload, result):
             return bool(result.get("bidding_id"))
@@ -1559,7 +1560,9 @@ def test_conditional_emit_route_transforms_selected_branch() -> None:
             ],
         )
         async def consume(ctx, item):
-            if len(seen) >= 3:
+            nonlocal processed
+            processed += 1
+            if processed == 2:
                 ctx.app.request_shutdown()
             return item
 
@@ -1579,7 +1582,7 @@ def test_conditional_emit_route_transforms_selected_branch() -> None:
         assert [delivery.payload for delivery in row_batch] == [
             {"row_id": "bid-1", "value": 42}
         ]
-        assert seen == ["meta", "row"]
+        assert seen == ["fallback", "meta", "row"]
 
     asyncio.run(scenario())
 

--- a/tests/contract/test_runtime_contract.py
+++ b/tests/contract/test_runtime_contract.py
@@ -1521,6 +1521,69 @@ def test_conditional_emit_predicate_failure_uses_retry_policy() -> None:
     asyncio.run(scenario())
 
 
+def test_conditional_emit_route_transforms_selected_branch() -> None:
+    async def scenario() -> None:
+        source = MemoryQueue("incoming", poll_interval_s=0.01)
+        meta_sink = MemoryQueue("meta", poll_interval_s=0.01)
+        rows_sink = MemoryQueue("rows", poll_interval_s=0.01)
+        fallback_sink = MemoryQueue("fallback", poll_interval_s=0.01)
+        app = OneStepApp("conditional-emit-route-transforms")
+        seen: list[str] = []
+
+        def is_bidding(ctx, payload, result):
+            return bool(result.get("bidding_id"))
+
+        def to_meta(ctx, payload, result):
+            seen.append("meta")
+            return {"meta_id": result["bidding_id"], "source": payload["source"]}
+
+        def to_row(ctx, payload, result):
+            seen.append("row")
+            return {"row_id": result["bidding_id"], "value": result["value"]}
+
+        def to_fallback(ctx, payload, result):
+            seen.append("fallback")
+            return {"fallback_id": result["id"]}
+
+        @app.task(
+            source=source,
+            emit=[
+                EmitRoute(
+                    predicate=is_bidding,
+                    then_bindings=(
+                        EmitBinding(sink=meta_sink, transform=to_meta),
+                        EmitBinding(sink=rows_sink, transform=to_row),
+                    ),
+                    otherwise_bindings=(EmitBinding(sink=fallback_sink, transform=to_fallback),),
+                ),
+            ],
+        )
+        async def consume(ctx, item):
+            if len(seen) >= 3:
+                ctx.app.request_shutdown()
+            return item
+
+        await source.publish({"id": "no-bid", "source": "web"})
+        await source.publish({"bidding_id": "bid-1", "value": 42, "source": "api"})
+        await app.serve()
+
+        fallback_batch = await fallback_sink.fetch(1)
+        meta_batch = await meta_sink.fetch(1)
+        row_batch = await rows_sink.fetch(1)
+        assert [delivery.payload for delivery in fallback_batch] == [
+            {"fallback_id": "no-bid"}
+        ]
+        assert [delivery.payload for delivery in meta_batch] == [
+            {"meta_id": "bid-1", "source": "api"}
+        ]
+        assert [delivery.payload for delivery in row_batch] == [
+            {"row_id": "bid-1", "value": 42}
+        ]
+        assert seen == ["meta", "row"]
+
+    asyncio.run(scenario())
+
+
 def test_task_timeout_retries_once_then_fails() -> None:
     async def scenario() -> None:
         source = MemoryQueue("incoming", poll_interval_s=0.01)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1950,6 +1950,248 @@ def test_load_app_config_strict_rejects_emit_route_empty_then_list() -> None:
         )
 
 
+def test_load_app_config_strict_accepts_emit_route_branch_bindings() -> None:
+    def predicate(ctx, payload, result):
+        return True
+
+    def to_meta(ctx, payload, result, *, prefix: str):
+        return {"meta": result["id"], "prefix": prefix}
+
+    def to_row(ctx, payload, result):
+        return {"row": result["id"]}
+
+    def to_fallback(ctx, payload, result):
+        return {"fallback": result["id"]}
+
+    with registered_module(
+        "testsupport_yaml_route_bindings",
+        predicate=predicate,
+        to_meta=to_meta,
+        to_row=to_row,
+        to_fallback=to_fallback,
+    ):
+        app = load_app_config(
+        {
+            "apiVersion": "onestep/v1alpha1",
+            "kind": "App",
+            "app": {"name": "yaml-emit-route-bindings"},
+            "resources": {
+                "incoming": {"type": "memory", "maxsize": 100},
+                "audit": {"type": "memory", "maxsize": 100},
+                "meta": {"type": "memory", "maxsize": 100},
+                "rows": {"type": "memory", "maxsize": 100},
+                "fallback": {"type": "memory", "maxsize": 100},
+            },
+            "tasks": [
+                {
+                    "name": "route",
+                    "source": "incoming",
+                    "emit": [
+                        {
+                            "when": "testsupport_yaml_route_bindings:predicate",
+                            "then": [
+                                "audit",
+                                {
+                                    "sink": "meta",
+                                    "transform": {
+                                        "ref": "testsupport_yaml_route_bindings:to_meta",
+                                        "params": {"prefix": "bidding"},
+                                    },
+                                },
+                                {
+                                    "sink": "rows",
+                                    "transform": "testsupport_yaml_route_bindings:to_row",
+                                },
+                            ],
+                            "otherwise": [
+                                {
+                                    "sink": "fallback",
+                                    "transform": "testsupport_yaml_route_bindings:to_fallback",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        },
+        strict=True,
+    )
+
+    task = app.tasks[0]
+    route = task.emit_routes[0]
+    assert [binding.sink.name for binding in route.then_bindings] == ["audit", "meta", "rows"]
+    assert [sink.name for sink in route.then_sinks] == ["audit", "meta", "rows"]
+    assert [binding.transform_ref for binding in route.then_bindings] == [
+        None,
+        "testsupport_yaml_route_bindings:to_meta",
+        "testsupport_yaml_route_bindings:to_row",
+    ]
+    assert [sink.name for sink in route.otherwise_sinks] == ["fallback"]
+    assert [sink.name for sink in task.sinks] == ["audit", "meta", "rows", "fallback"]
+    assert [binding.transform_ref for binding in task.emit_bindings] == [
+        None,
+        "testsupport_yaml_route_bindings:to_meta",
+        "testsupport_yaml_route_bindings:to_row",
+        "testsupport_yaml_route_bindings:to_fallback",
+    ]
+
+    meta_binding = route.then_bindings[1]
+    assert asyncio.run(meta_binding.transform(None, {}, {"id": "evt-1"})) == {
+        "meta": "evt-1",
+        "prefix": "bidding",
+    }
+
+
+def test_load_app_config_accepts_single_binding_mapping_branch() -> None:
+    def predicate(ctx, payload, result):
+        return False
+
+    def to_fallback(ctx, payload, result):
+        return {"fallback": result["id"]}
+
+    with registered_module(
+        "testsupport_yaml_route_single_binding",
+        predicate=predicate,
+        to_fallback=to_fallback,
+    ):
+        app = load_app_config(
+            {
+                "name": "yaml-route-single-binding",
+                "resources": {
+                    "incoming": {"type": "memory"},
+                    "fallback": {"type": "memory"},
+                },
+                "tasks": [
+                    {
+                        "name": "route",
+                        "source": "incoming",
+                        "emit": [
+                            {
+                                "when": "testsupport_yaml_route_single_binding:predicate",
+                                "then": {
+                                    "sink": "fallback",
+                                    "transform": "testsupport_yaml_route_single_binding:to_fallback",
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+    route = app.tasks[0].emit_routes[0]
+    assert [sink.name for sink in route.then_sinks] == ["fallback"]
+    binding = route.then_bindings[0]
+    assert binding.transform_ref == "testsupport_yaml_route_single_binding:to_fallback"
+    assert binding.transform(None, {}, {"id": "evt-1"}) == {"fallback": "evt-1"}
+
+
+@pytest.mark.parametrize(
+    ("then_value", "otherwise_value", "message"),
+    [
+        (
+            [{"transform": "testsupport_yaml_route_reject:to_row"}],
+            None,
+            r"'sink' must be a non-empty string",
+        ),
+        (
+            [{"sink": "rows", "delivery": "guaranteed"}],
+            None,
+            r"unsupported fields for tasks\[0\]\.emit\[0\]\.then\[0\]: delivery",
+        ),
+        (
+            [{"sink": "rows", "transform": {"expression": "result"}}],
+            None,
+            r"unsupported fields for tasks\[0\]\.emit\[0\]\.then\[0\]\.transform: expression",
+        ),
+        (
+            [{"sink": "rows", "transform": {"params": {}}}],
+            None,
+            r"'ref' must be a non-empty string",
+        ),
+        (
+            ["rows", 5],
+            None,
+            r"tasks\[0\]\.emit\[0\]\.then\[1\]' must be a non-empty string",
+        ),
+        (
+            [{"name": "rows"}],
+            None,
+            r"unsupported fields for tasks\[0\]\.emit\[0\]\.then\[0\]: name",
+        ),
+        (
+            "rows",
+            [],
+            r"tasks\[0\]\.emit\[0\]\.otherwise must not be empty",
+        ),
+        (
+            {"name": "rows"},
+            None,
+            r"'tasks\[0\]\.emit\[0\]\.then' must be a string or list of strings",
+        ),
+    ],
+)
+def test_load_app_config_strict_rejects_invalid_emit_route_branch_entries(
+    then_value,
+    otherwise_value,
+    message,
+) -> None:
+    route: dict[str, object] = {
+        "when": "testsupport_yaml_route_reject:predicate",
+        "then": then_value,
+    }
+    if otherwise_value is not None:
+        route["otherwise"] = otherwise_value
+    with pytest.raises((TypeError, ValueError), match=message):
+        load_app_config(
+            {
+                "apiVersion": "onestep/v1alpha1",
+                "kind": "App",
+                "app": {"name": "yaml-strict-emit-branch-reject"},
+                "resources": {
+                    "incoming": {"type": "memory", "maxsize": 100},
+                    "rows": {"type": "memory", "maxsize": 100},
+                },
+                "tasks": [
+                    {
+                        "name": "route",
+                        "source": "incoming",
+                        "emit": [route],
+                    }
+                ],
+            },
+            strict=True,
+        )
+
+
+def test_load_app_config_rejects_unknown_sink_in_route_branch_binding() -> None:
+    def predicate(ctx, payload, result):
+        return True
+
+    with registered_module("testsupport_yaml_route_unknown_sink", predicate=predicate):
+        with pytest.raises(KeyError, match="unknown resource 'missing_sink'"):
+            load_app_config(
+                {
+                    "name": "yaml-route-unknown-sink",
+                    "resources": {
+                        "incoming": {"type": "memory"},
+                    },
+                    "tasks": [
+                        {
+                            "name": "route",
+                            "source": "incoming",
+                            "emit": [
+                                {
+                                    "when": "testsupport_yaml_route_unknown_sink:predicate",
+                                    "then": [{"sink": "missing_sink"}],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+
+
 def test_yaml_target_builds_webhook_auth_and_response(tmp_path) -> None:
     config_path = tmp_path / "webhook.yaml"
     config_path.write_text(


### PR DESCRIPTION
## Summary

Enable per-sink `transform` bindings inside conditional emit routes (`when`/`then`/`otherwise`). Previously only top-level emit entries could carry per-sink transforms; route branches accepted only plain sink names.

Fixes #117

## Changes

- **src/onestep/task.py**: `EmitRoute` gains `then_bindings`/`otherwise_bindings` fields, auto-derived from the classic `then_sinks`/`otherwise_sinks` for backward compatibility. `EmitBinding` dataclass promoted before `EmitRoute`.
- **src/onestep/config.py**: `_resolve_emit_branch` replaces `_resolve_emit_sinks` and accepts sink-name strings, string lists, or `{sink, transform}` mappings. Strict validation updated.
- **src/onestep/runtime/executor.py**: Route branches emit their bindings directly (3 lines changed), carrying per-sink transforms through the existing pipeline.
- **tests/test_cli.py**: 242 lines of strict validation tests (accept/reject matrix, mixed entries, error paths).
- **tests/contract/test_runtime_contract.py**: 63 lines of integration tests.
- **docs**: YAML task definition and skill references updated; CHANGELOG entry added for 1.11.0.