### PR TITLE
feat(mysql): add update mode to table sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## onestep-mysql 0.6.0
+
+- Adds `mode="update"` to `mysql_table_sink`: rows are written via
+  `UPDATE ... WHERE keys` and never inserted, avoiding
+  `Field 'xxx' doesn't have a default value` warnings on tables with `NOT NULL`
+  columns lacking defaults and removing accidental-insert risk; unmatched rows
+  are skipped with an INFO log.
+- Allows `update_columns`/`update_expr` in `update` mode with the same
+  semantics as `upsert`, and exposes `update` in the YAML resource catalog
+  `mode` options.
+
 ## onestep 1.11.0
 
 - Extends conditional `emit` routes (`when`/`then`/`otherwise`) with per-sink

--- a/docs/broker/mysql.md
+++ b/docs/broker/mysql.md
@@ -155,6 +155,12 @@ async def process(ctx, item):
     return {"id": item["id"], "data": item["data"]}
 ```
 
+> 注意：`upsert` 生成 `INSERT ... ON DUPLICATE KEY UPDATE`。即使键已存在、
+> 实际走更新分支，MySQL 仍会对 INSERT 部分做约束检查——目标表存在无默认值的
+> `NOT NULL` 列且载荷未提供这些列时，会产生
+> `Field 'xxx' doesn't have a default value` warning（更新本身仍会成功）。
+> 只需要更新已有行时，请改用 `mode="update"`。
+
 ### Insert 模式
 
 ```python
@@ -164,28 +170,46 @@ sink = db.table_sink(
 )
 ```
 
-### 更新控制（Upsert 冲突行为）
+### Update 模式
 
-`upsert` 模式下，可通过 `update_columns`、`update_expr` 精确控制冲突时的
-更新行为：
+只更新已存在的行，绝不插入新行（`UPDATE ... WHERE`）：
+
+```python
+sink = db.table_sink(
+    table="bidding",
+    mode="update",
+    keys=("id",),  # WHERE 匹配条件
+    update_columns=("deadline", "tender_deadline"),  # 只重写这些列
+)
+```
+
+- 适合"目标行由其他流程创建、本任务只回填部分字段"的场景。
+- 目标行不存在时跳过该条并记录一条 INFO 日志，不报错；MySQL 下"值未变化"
+  的重复更新同样按 0 行处理。
+- 不生成 `INSERT` 语句，目标表存在无默认值的 `NOT NULL` 列时也不会触发
+  warning，且不存在误插新行的风险。
+
+### 更新控制（Upsert / Update 行为）
+
+`upsert` 与 `update` 模式下，可通过 `update_columns`、`update_expr` 精确
+控制写入的列：
 
 ```python
 sink = db.table_sink(
     table="results",
     mode="upsert",
     keys=("id",),
-    update_columns=("data",),          # 冲突时只重写这些列
-    update_expr={"updated_at": "NOW(6)"},  # 冲突时执行的原始 SQL 表达式
+    update_columns=("data",),          # 只重写这些列
+    update_expr={"updated_at": "NOW(6)"},  # 写入时执行的原始 SQL 表达式
 )
 ```
 
-- `update_columns`：冲突时允许重写的白名单列；默认重写除 `keys` 外的所有
-  载荷列。设为空列表 `()` 表示冲突时不更新任何载荷列，只应用
-  `update_expr`。
-- `update_expr`：列名到原始 SQL 表达式的映射，在冲突时渲染执行（例如
+- `update_columns`：允许重写的白名单列；默认重写除 `keys` 外的所有载荷列。
+  设为空列表 `()` 表示不更新任何载荷列，只应用 `update_expr`。
+- `update_expr`：列名到原始 SQL 表达式的映射，写入时渲染执行（例如
   `updated_at=NOW(6)`）。
-- 两者仅适用于 `upsert` 模式；`update_columns` 为空且没有 `update_expr`
-  时配置无效。
+- 两者仅适用于 `upsert` 和 `update` 模式；`update_columns` 为空且没有
+  `update_expr` 时配置无效。
 
 ### JSON 序列化控制
 

--- a/plugins/onestep-mysql/pyproject.toml
+++ b/plugins/onestep-mysql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-mysql"
-version = "0.6.0"
+version = "0.5.2"
 description = "MySQL connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-mysql/pyproject.toml
+++ b/plugins/onestep-mysql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-mysql"
-version = "0.5.1"
+version = "0.6.0"
 description = "MySQL connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-mysql/src/onestep_mysql/connector.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/connector.py
@@ -973,19 +973,19 @@ class TableSink(Sink):
         serialize_json: str = "auto",
     ) -> None:
         super().__init__(f"mysql.table_sink:{table}")
-        if mode not in {"insert", "upsert"}:
-            raise ValueError("mode must be either 'insert' or 'upsert'")
-        if update_columns is not None and mode != "upsert":
-            raise ValueError("update_columns only applies to upsert mode")
+        if mode not in {"insert", "upsert", "update"}:
+            raise ValueError("mode must be one of 'insert', 'upsert' or 'update'")
+        if update_columns is not None and mode == "insert":
+            raise ValueError("update_columns only applies to upsert or update mode")
         update_columns_tuple = tuple(update_columns) if update_columns is not None else None
         update_expr_dict = dict(update_expr or {})
         if update_expr is not None:
-            if mode != "upsert":
-                raise ValueError("update_expr only applies to upsert mode")
+            if mode == "insert":
+                raise ValueError("update_expr only applies to upsert or update mode")
             if not all(isinstance(key, str) and isinstance(value, str) for key, value in update_expr.items()):
                 raise TypeError("update_expr keys and values must be strings")
-        if mode == "upsert" and update_columns_tuple == () and not update_expr_dict:
-            raise ValueError("upsert mode requires update_expr when update_columns is empty")
+        if mode in {"upsert", "update"} and update_columns_tuple == () and not update_expr_dict:
+            raise ValueError(f"{mode} mode requires update_expr when update_columns is empty")
         if serialize_json not in {"auto", "always", "never"}:
             raise ValueError("serialize_json must be 'auto', 'always' or 'never'")
         self.connector = connector
@@ -1017,22 +1017,29 @@ class TableSink(Sink):
         table = await self.connector._table(self.table_name)
         stmt = self._build_statement(payload, table)
         async with self.connector.engine.begin() as conn:
-            await conn.execute(stmt)
+            result = await conn.execute(stmt)
+            if self.mode == "update" and result.rowcount == 0:
+                logger.info(
+                    "mysql table sink %s update matched no rows or values unchanged (keys=%s)",
+                    self.name,
+                    {key: payload.get(key) for key in self.keys},
+                )
 
     def _build_statement(self, payload: dict[str, Any], table: sa.Table):
         payload = self._coerce_json_values(payload, table)
         if self.mode == "insert":
             return sa.insert(table).values(**payload)
         if not self.keys:
-            raise ValueError("upsert mode requires keys")
-        if self.update_columns is not None:
-            update_payload = {key: value for key, value in payload.items() if key in self.update_columns}
-        else:
-            update_payload = {key: value for key, value in payload.items() if key not in self.keys}
-        for column, expr in self.update_expr.items():
-            update_payload[column] = sa.literal_column(expr)
+            raise ValueError(f"{self.mode} mode requires keys")
+        update_payload = self._update_payload(payload)
         if not update_payload:
-            raise ValueError("upsert mode requires at least one update column or update_expr")
+            raise ValueError(f"{self.mode} mode requires at least one update column or update_expr")
+        if self.mode == "update":
+            missing_keys = [key for key in self.keys if key not in payload]
+            if missing_keys:
+                raise ValueError(f"update mode requires keys present in payload: {', '.join(missing_keys)}")
+            conditions = [table.columns[key] == payload[key] for key in self.keys]
+            return sa.update(table).where(sa.and_(*conditions)).values(**update_payload)
         sync_engine = getattr(self.connector.engine, "sync_engine", self.connector.engine)
         dialect = sync_engine.dialect.name
         if dialect == "mysql":
@@ -1046,6 +1053,15 @@ class TableSink(Sink):
             stmt = sqlite_insert(table).values(**payload)
             return stmt.on_conflict_do_update(index_elements=list(self.keys), set_=update_payload)
         return sa.insert(table).values(**payload)
+
+    def _update_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self.update_columns is not None:
+            update_payload = {key: value for key, value in payload.items() if key in self.update_columns}
+        else:
+            update_payload = {key: value for key, value in payload.items() if key not in self.keys}
+        for column, expr in self.update_expr.items():
+            update_payload[column] = sa.literal_column(expr)
+        return update_payload
 
     def _coerce_json_values(self, payload: dict[str, Any], table: sa.Table) -> dict[str, Any]:
         if self.serialize_json == "never":

--- a/plugins/onestep-mysql/src/onestep_mysql/resources.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/resources.py
@@ -151,7 +151,7 @@ _MYSQL_TABLE_SINK_CATALOG = ResourceCatalogEntry(
     fields=(
         ResourceCatalogField("connector", "ref", required=True),
         ResourceCatalogField("table", "string", required=True),
-        ResourceCatalogField("mode", "string", default="insert", options=("insert", "upsert")),
+        ResourceCatalogField("mode", "string", default="insert", options=("insert", "upsert", "update")),
         ResourceCatalogField("keys", "string_list"),
         ResourceCatalogField("update_columns", "string_list"),
         ResourceCatalogField("update_expr", "mapping"),

--- a/plugins/onestep-mysql/tests/test_mysql_plugin.py
+++ b/plugins/onestep-mysql/tests/test_mysql_plugin.py
@@ -227,6 +227,37 @@ def test_yaml_empty_update_columns_is_distinct_from_unset(tmp_path) -> None:
     assert sink.update_expr == {"updated_at": "NOW(6)"}
 
 
+def test_yaml_update_mode_builds_update_only_sink(tmp_path) -> None:
+    dsn = f"sqlite:///{tmp_path / 'mysql-plugin.db'}"
+
+    app = load_app_config(
+        {
+            "apiVersion": "onestep/v1alpha1",
+            "kind": "App",
+            "app": {"name": "mysql-plugin"},
+            "resources": {
+                "db": {"type": "mysql", "dsn": dsn},
+                "processed": {
+                    "type": "mysql_table_sink",
+                    "connector": "db",
+                    "table": "processed_users",
+                    "mode": "update",
+                    "keys": ["id"],
+                    "update_columns": ["name", "email"],
+                },
+            },
+            "tasks": [],
+        },
+        strict=True,
+    )
+
+    sink = app.resources["processed"]
+    assert isinstance(sink, TableSink)
+    assert sink.mode == "update"
+    assert sink.keys == ("id",)
+    assert sink.update_columns == ("name", "email")
+
+
 def test_yaml_rejects_empty_update_columns_without_update_expr(tmp_path) -> None:
     dsn = f"sqlite:///{tmp_path / 'mysql-plugin.db'}"
 

--- a/plugins/onestep-mysql/tests/test_mysql_table_sink.py
+++ b/plugins/onestep-mysql/tests/test_mysql_table_sink.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import logging
 from typing import Any
 
 import pytest
@@ -307,3 +309,161 @@ def test_sqlite_upsert_uses_on_conflict() -> None:
 
     sql = str(stmt.compile(dialect=sqlite_dialect.dialect()))
     assert "ON CONFLICT" in sql
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_mode_renders_update_where() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="update",
+        keys=("article_identity",),
+        update_columns=("title", "status"),
+    )
+
+    sql = _compile(sink._build_statement(_payload(), _candidate_table()))
+    set_clause = sql.split(" WHERE ", 1)[0]
+
+    assert "UPDATE v2_clean_article_candidate SET" in sql
+    assert "title=" in set_clause
+    assert "status=" in set_clause
+    assert "content=" not in set_clause
+    assert "WHERE v2_clean_article_candidate.article_identity = " in sql
+    assert "INSERT" not in sql
+    assert "ON DUPLICATE KEY" not in sql
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_mode_default_updates_all_non_key_columns() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="update",
+        keys=("article_identity",),
+    )
+
+    sql = _compile(sink._build_statement(_payload(), _candidate_table()))
+    set_clause = sql.split(" WHERE ", 1)[0]
+
+    assert "title=" in set_clause
+    assert "trace_id=" in set_clause
+    assert "article_identity" not in set_clause
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_mode_renders_update_expr_as_literal_sql() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="update",
+        keys=("article_identity",),
+        update_columns=("title",),
+        update_expr={"updated_at": "NOW(6)"},
+    )
+
+    sql = _compile(sink._build_statement(_payload(), _candidate_table()))
+
+    assert "updated_at=NOW(6)" in sql
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_mode_requires_keys() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="t",
+        mode="update",
+    )
+
+    with pytest.raises(ValueError, match="requires keys"):
+        sink._build_statement({"a": 1}, _candidate_table())
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_mode_requires_keys_present_in_payload() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="update",
+        keys=("article_identity",),
+    )
+
+    with pytest.raises(ValueError, match="keys present in payload"):
+        sink._build_statement({"title": "title"}, _candidate_table())
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_mode_rejects_empty_update_payload() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="update",
+        keys=("article_identity",),
+    )
+
+    with pytest.raises(ValueError, match="at least one update column"):
+        sink._build_statement({"article_identity": "article-1"}, _candidate_table())
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_columns_and_update_expr_valid_in_update_mode() -> None:
+    metadata = sa.MetaData()
+    table = sa.Table(
+        "t",
+        metadata,
+        sa.Column("id", sa.BigInteger, primary_key=True),
+        sa.Column("name", sa.String(64)),
+        sa.Column("updated_at", sa.DateTime),
+    )
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="t",
+        mode="update",
+        keys=("id",),
+        update_columns=("name",),
+        update_expr={"updated_at": "NOW(6)"},
+    )
+
+    sql = _compile(sink._build_statement({"id": 1, "name": "n"}, table))
+
+    assert "name=%s" in sql
+    assert "updated_at=NOW(6)" in sql
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_mode_logs_when_no_rows_matched(caplog) -> None:
+    class _Result:
+        rowcount = 0
+
+    class _Conn:
+        async def execute(self, stmt):
+            return _Result()
+
+    class _Begin:
+        async def __aenter__(self):
+            return _Conn()
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+    class _Engine:
+        def begin(self):
+            return _Begin()
+
+    class _Connector:
+        engine = _Engine()
+
+        async def _table(self, table_name):
+            return _candidate_table()
+
+    sink = TableSink(
+        connector=_Connector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="update",
+        keys=("article_identity",),
+        update_columns=("title",),
+    )
+
+    with caplog.at_level(logging.INFO, logger="onestep_mysql.connector"):
+        asyncio.run(sink._send(_payload()))
+
+    assert any("matched no rows" in record.getMessage() for record in caplog.records)

--- a/uv.lock
+++ b/uv.lock
@@ -1689,7 +1689,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-mysql"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "plugins/onestep-mysql" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Closes #120

## 问题

`mysql_table_sink` 的 `upsert` 模式生成 `INSERT ... ON DUPLICATE KEY UPDATE`，即使主键已存在、实际走更新分支，MySQL 仍会对 INSERT 部分做约束检查：目标表存在无默认值的 NOT NULL 列且载荷未提供时，每行都会产生 `Field 'xxx' doesn't have a default value` warning；在非严格 sql_mode 的实例上还可能用隐式默认值误插一条记录。

## 改动

- `TableSink` / `MySQLConnector.table_sink` 新增 `mode="update"`：通过 `UPDATE ... WHERE keys` 只更新已存在的行，绝不插入；行不存在时跳过并记录一条 INFO 日志（措辞兼容 MySQL 值未变化按 0 行计的语义），不抛错。
- `update_columns` / `update_expr` 放宽为同时适用于 `upsert` 和 `update` 模式，语义一致。
- YAML 资源目