### PR TITLE
feat: add onestep render for Mermaid worker topology diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Adds `onestep render <target>`: renders the worker topology of any Python or
+  YAML target as a Mermaid flowchart (`--format mermaid`, the only format for
+  now). Task nodes carry concurrency, retry, and timeout; edges are labeled
+  `emit` (plus transform refs), `when`/`otherwise` for conditional routes, and
+  dashed `dead_letter`; resources shared across tasks are drawn once.
+
 ## onestep-mysql 0.5.2
 
 - Adds `mode="update"` to `mysql_table_sink`: rows are written via

--- a/README.md
+++ b/README.md
@@ -140,6 +140,31 @@ Unsupported custom values produce an explicit capture error and no file rather
 than a degraded record. See
 [`docs/yaml-task-definition.md`](docs/yaml-task-definition.md) for YAML policy.
 
+## Render the worker topology
+
+`onestep render` prints the topology of any Python or YAML target as a
+[Mermaid](https://mermaid.js.org) flowchart, ready to paste into GitHub,
+Notion, or Obsidian:
+
+```bash
+onestep render worker.yaml
+```
+
+```text
+graph LR
+  %% app: billing-sync
+  n0["extract_entities<br/>concurrency=4 · retry=NoRetry · timeout=300s"]
+  n1["sqs-orders<br/>MemoryQueue"]
+  n2["mysql.meta_sink<br/>MemoryQueue"]
+  n1 --> n0
+  n0 -->|"emit"| n2
+```
+
+Each task node lists its concurrency, retry policy, and timeout. Edges are
+labeled `emit` (with the transform ref when a binding sets one), `when`/`otherwise`
+for conditional routes, and dashed `dead_letter` edges. Resources shared by
+multiple tasks appear once, so chained topologies are drawn as connected graphs.
+
 ## What it does
 
 | Capability | Where |
@@ -264,6 +289,7 @@ tasks:
 ```bash
 onestep run worker.yaml
 onestep check --strict worker.yaml   # schema validation, unknown-field detection
+onestep render worker.yaml           # worker topology as a Mermaid diagram
 onestep init billing-sync            # scaffold a minimal YAML project
 onestep build worker.yaml --out dist/worker.zip
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -130,6 +130,30 @@ Decimal、enum、tuple/namedtuple、set 和 frozenset 等常见值可无损往�
 支持的自定义值时会明确记录 capture 错误且不生成有损文件。YAML 策略见
 [`docs/yaml-task-definition.md`](docs/yaml-task-definition.md)。
 
+## 渲染 worker 拓扑
+
+`onestep render` 将任意 Python 或 YAML 目标的拓扑输出为
+[Mermaid](https://mermaid.js.org) 流程图，可直接粘贴到 GitHub、Notion 或
+Obsidian 中渲染：
+
+```bash
+onestep render worker.yaml
+```
+
+```text
+graph LR
+  %% app: billing-sync
+  n0["extract_entities<br/>concurrency=4 · retry=NoRetry · timeout=300s"]
+  n1["sqs-orders<br/>MemoryQueue"]
+  n2["mysql.meta_sink<br/>MemoryQueue"]
+  n1 --> n0
+  n0 -->|"emit"| n2
+```
+
+任务节点标注并发数、重试策略和超时。边的标签为 `emit`（绑定了 transform 时附
+带 transform 引用）、条件路由的 `when`/`otherwise`，以及虚线的 `dead_letter`。
+被多个任务共享的资源只绘制一次，链式拓扑会呈现为连通图。
+
 ## 能做什么
 
 | 能力 | 入口 |
@@ -251,6 +275,7 @@ tasks:
 ```bash
 onestep run worker.yaml
 onestep check --strict worker.yaml   # schema 校验、未知字段检测
+onestep render worker.yaml           # 以 Mermaid 图渲染 worker 拓扑
 onestep init billing-sync            # 脚手架生成最小 YAML 工程
 onestep build worker.yaml --out dist/worker.zip
 ```

--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -21,6 +21,7 @@ from .diagnostics.supervisor import supervise_diagnostic
 from .diagnostics.targets import _ensure_local_import_paths
 from .envelope import Envelope
 from .init_project import init_project
+from .render import render_mermaid
 
 _CLI_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
 
@@ -161,6 +162,31 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Emit the build report as JSON",
     )
 
+    render_parser = subparsers.add_parser(
+        "render",
+        help="Render the worker topology of a target or YAML config as a diagram",
+    )
+    render_parser.add_argument("target", help="Python target (package.module:app) or path to *.yaml")
+    render_parser.add_argument(
+        "--format",
+        choices=("mermaid",),
+        default="mermaid",
+        help="Diagram format (default: mermaid)",
+    )
+    render_parser.add_argument(
+        "--env-file",
+        dest="env_file",
+        default=None,
+        help="Path to a .env file to load environment variables from (YAML targets only)",
+    )
+    render_parser.add_argument(
+        "--strict-env",
+        action="store_true",
+        dest="strict_env",
+        default=None,
+        help="Check that all ${VAR} references resolve to environment variables (YAML targets only)",
+    )
+
     catalog_parser = subparsers.add_parser("catalog", help="Print installed source/sink resource catalog")
     catalog_parser.add_argument("--json", action="store_true", dest="as_json", help="Emit the catalog as JSON")
     catalog_parser.add_argument(
@@ -284,6 +310,10 @@ def main(argv: list[str] | None = None) -> int:
         _print_summary(args.target, app, as_json=getattr(args, "as_json", False))
         return 0
 
+    if args.command == "render":
+        print(render_mermaid(app), end="")
+        return 0
+
     cli_logging_state: tuple[logging.Handler, int] | None = None
     try:
         cli_logging_state = _configure_run_logging(explicit_level=args.log_level)
@@ -395,6 +425,7 @@ def _normalize_argv(argv: list[str] | None) -> list[str] | None:
         "init",
         "build",
         "catalog",
+        "render",
         "task",
     }:
         return argv

--- a/src/onestep/render.py
+++ b/src/onestep/render.py
@@ -1,0 +1,146 @@
+"""Render a :class:`~onestep.OneStepApp` worker topology as a Mermaid flowchart.
+
+The renderer is a read-only mapping from an app's task specs to text: it adds
+no runtime behavior and no dependencies. Resource nodes are deduplicated by
+``(name, type)``, so a resource shared by multiple tasks (for example a queue
+that one task emits to and another task consumes from) appears once and the
+chart shows the chaining for free.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .app import OneStepApp
+    from .connectors.base import Sink
+    from .task import TaskSpec
+
+__all__ = ["render_mermaid"]
+
+
+def render_mermaid(app: "OneStepApp") -> str:
+    """Render an app's worker topology as a Mermaid ``graph LR`` chart."""
+
+    lines = ["graph LR", f"  %% app: {_escape_comment(app.name)}"]
+
+    nodes = _NodeRegistry()
+    edges: list[str] = []
+
+    for task in app.tasks:
+        task_id = nodes.task(task)
+        if task.source is not None:
+            edges.append(f"  {nodes.resource(task.source)} --> {task_id}")
+
+        routed = Counter(_render_routes(task, nodes, edges, task_id))
+
+        for binding in task.emit_bindings:
+            key = _sink_key(binding.sink)
+            if routed[key] > 0:
+                routed[key] -= 1
+                continue
+            label = _edge_label("emit", binding.transform_ref)
+            edges.append(f"  {task_id} -->|{label}| {nodes.resource(binding.sink)}")
+
+        for sink in task.dead_letter_sinks:
+            label = _edge_label("dead_letter")
+            edges.append(f"  {task_id} -.->|{label}| {nodes.resource(sink)}")
+
+    lines.extend(nodes.declarations())
+    lines.extend(edges)
+    return "\n".join(lines) + "\n"
+
+
+def _render_routes(
+    task: "TaskSpec",
+    nodes: "_NodeRegistry",
+    edges: list[str],
+    task_id: str,
+) -> list[tuple[str, str]]:
+    """Render conditional emit routes and return the sink keys they covered."""
+
+    route_sink_keys: list[tuple[str, str]] = []
+    for route in task.emit_routes:
+        # A plain sink (``emit=some_sink``) is normalized into a route without
+        # a predicate; render it as an ordinary emit edge.
+        then_prefix = f"when {route.predicate_ref}" if route.predicate_ref else "emit"
+        for bindings, prefix in (
+            (route.then_bindings, then_prefix),
+            (route.otherwise_bindings, "otherwise"),
+        ):
+            for binding in bindings:
+                route_sink_keys.append(_sink_key(binding.sink))
+                label = _edge_label(prefix, binding.transform_ref)
+                edges.append(f"  {task_id} -->|{label}| {nodes.resource(binding.sink)}")
+    return route_sink_keys
+
+
+def _sink_key(sink: "Sink") -> tuple[str, str]:
+    return (str(sink.name), type(sink).__name__)
+
+
+def _edge_label(prefix: str, transform_ref: str | None = None) -> str:
+    label = prefix
+    if transform_ref:
+        label = f"{label} · {transform_ref}"
+    return f'"{_escape_text(label)}"'
+
+
+class _NodeRegistry:
+    """Allocate node ids, deduplicating resources by ``(name, type)``."""
+
+    def __init__(self) -> None:
+        self._nodes: dict[tuple[str, str, str], str] = {}
+        self._labels: dict[str, str] = {}
+
+    def resource(self, sink: "Sink") -> str:
+        name = str(sink.name)
+        type_name = type(sink).__name__
+        return self._register(
+            ("resource", name, type_name),
+            f"{_escape_text(name)}<br/>{_escape_text(type_name)}",
+        )
+
+    def task(self, task: "TaskSpec") -> str:
+        label = _escape_text(task.name)
+        meta = _task_meta(task)
+        if meta:
+            label = f"{label}<br/>{meta}"
+        return self._register(("task", task.name, ""), label)
+
+    def _register(self, key: tuple[str, str, str], label: str) -> str:
+        node_id = self._nodes.get(key)
+        if node_id is None:
+            node_id = f"n{len(self._labels)}"
+            self._nodes[key] = node_id
+            self._labels[node_id] = label
+        return node_id
+
+    def declarations(self) -> list[str]:
+        return [f'  {node_id}["{label}"]' for node_id, label in self._labels.items()]
+
+
+def _task_meta(task: "TaskSpec") -> str:
+    parts = [f"concurrency={task.concurrency}", f"retry={type(task.retry).__name__}"]
+    if task.timeout_s is not None:
+        parts.append(f"timeout={_format_seconds(task.timeout_s)}s")
+    return " · ".join(parts)
+
+
+def _format_seconds(value: float) -> str:
+    return f"{value:g}"
+
+
+def _escape_text(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("|", "&#124;")
+    )
+
+
+def _escape_comment(text: str) -> str:
+    return str(text).replace("\n", " ")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,271 @@
+import sys
+import types
+
+import pytest
+
+from onestep import MemoryQueue, OneStepApp
+from onestep.cli import main, parse_args
+from onestep.render import render_mermaid
+from onestep.task import EmitBinding, EmitRoute
+
+
+def _handler_module():
+    module = types.ModuleType("render_handlers")
+
+    async def sync(ctx, payload):
+        return payload
+
+    module.sync = sync
+    return module
+
+
+def _lines(output: str) -> list[str]:
+    return [line.strip() for line in output.splitlines()]
+
+
+def test_render_mermaid_basic_topology() -> None:
+    app = OneStepApp("render-basic")
+
+    @app.task(source=MemoryQueue("incoming"), emit=MemoryQueue("processed"))
+    async def consume(ctx, payload):
+        return payload
+
+    output = render_mermaid(app)
+    lines = _lines(output)
+
+    assert lines[0] == "graph LR"
+    assert "%% app: render-basic" in lines
+    assert 'n0["consume<br/>concurrency=1 · retry=NoRetry"]' in lines
+    assert 'n1["incoming<br/>MemoryQueue"]' in lines
+    assert 'n2["processed<br/>MemoryQueue"]' in lines
+    assert "n1 --> n0" in lines
+    assert 'n0 -->|"emit"| n2' in lines
+
+
+def test_render_mermaid_task_meta_includes_timeout_and_concurrency() -> None:
+    app = OneStepApp("render-meta")
+
+    @app.task(source=MemoryQueue("in"), emit=MemoryQueue("out"), concurrency=4, timeout_s=300.0)
+    async def consume(ctx, payload):
+        return payload
+
+    output = render_mermaid(app)
+    assert "concurrency=4 · retry=NoRetry · timeout=300s" in output
+
+
+def test_render_mermaid_shared_resource_deduplicates_across_tasks() -> None:
+    shared = MemoryQueue("shared")
+    app = OneStepApp("render-shared")
+
+    @app.task(source=MemoryQueue("in"), emit=shared)
+    async def first(ctx, payload):
+        return payload
+
+    @app.task(source=shared, emit=MemoryQueue("out"))
+    async def second(ctx, payload):
+        return payload
+
+    output = render_mermaid(app)
+    lines = _lines(output)
+
+    shared_declarations = [line for line in lines if '"shared<br/>MemoryQueue"]' in line]
+    assert len(shared_declarations) == 1
+    shared_id = shared_declarations[0].split("[", 1)[0]
+    first_id = next(line.split("[", 1)[0] for line in lines if '"first<br/>' in line)
+    second_id = next(line.split("[", 1)[0] for line in lines if '"second<br/>' in line)
+    assert f'{first_id} -->|"emit"| {shared_id}' in lines
+    assert f"{shared_id} --> {second_id}" in lines
+
+
+def test_render_mermaid_emit_transform_label() -> None:
+    app = OneStepApp("render-transform")
+
+    def project(ctx, payload, result):
+        return result
+
+    @app.task(
+        source=MemoryQueue("in"),
+        emit=EmitBinding(
+            sink=MemoryQueue("out"),
+            transform=project,
+            transform_ref="pkg.transforms:project",
+        ),
+    )
+    async def consume(ctx, payload):
+        return payload
+
+    output = render_mermaid(app)
+    assert 'n0 -->|"emit · pkg.transforms:project"| n2' in _lines(output)
+
+
+def test_render_mermaid_conditional_routes() -> None:
+    app = OneStepApp("render-route")
+
+    def is_active(ctx, payload, result):
+        return True
+
+    @app.task(
+        source=MemoryQueue("in"),
+        emit=EmitRoute(
+            predicate=is_active,
+            predicate_ref="pkg.predicates:is_active",
+            then_bindings=(
+                EmitBinding(
+                    sink=MemoryQueue("active"),
+                    transform=lambda ctx, p, r: r,
+                    transform_ref="pkg.transforms:tag",
+                ),
+            ),
+            otherwise_sinks=(MemoryQueue("fallback"),),
+        ),
+    )
+    async def consume(ctx, payload):
+        return payload
+
+    output = render_mermaid(app)
+    lines = _lines(output)
+
+    assert 'n0 -->|"when pkg.predicates:is_active · pkg.transforms:tag"| n2' in lines
+    assert 'n0 -->|"otherwise"| n3' in lines
+    # Route sinks must not be re-rendered as plain emit edges.
+    assert 'n0 -->|"emit"|' not in lines
+
+
+def test_render_mermaid_plain_sink_next_to_route() -> None:
+    app = OneStepApp("render-mixed")
+
+    def is_active(ctx, payload, result):
+        return True
+
+    @app.task(
+        source=MemoryQueue("in"),
+        emit=[
+            MemoryQueue("audit"),
+            EmitRoute(
+                predicate=is_active,
+                predicate_ref="pkg.predicates:is_active",
+                then_sinks=(MemoryQueue("active"),),
+            ),
+        ],
+    )
+    async def consume(ctx, payload):
+        return payload
+
+    output = render_mermaid(app)
+    lines = _lines(output)
+
+    audit_declarations = [line for line in lines if '"audit<br/>MemoryQueue"]' in line]
+    assert len(audit_declarations) == 1
+    audit_id = audit_declarations[0].split("[", 1)[0]
+    # The plain sink keeps its ordinary emit edge; only the route sinks are
+    # covered by the conditional branch edges.
+    assert f'n0 -->|"emit"| {audit_id}' in lines
+    assert 'n0 -->|"when pkg.predicates:is_active"| n3' in lines
+
+
+def test_render_mermaid_dead_letter_edge() -> None:
+    app = OneStepApp("render-dlq")
+
+    @app.task(source=MemoryQueue("in"), emit=MemoryQueue("out"), dead_letter=MemoryQueue("dlq"))
+    async def consume(ctx, payload):
+        return payload
+
+    output = render_mermaid(app)
+    assert 'n0 -.->|"dead_letter"| n3' in _lines(output)
+
+
+def test_render_mermaid_escapes_special_characters() -> None:
+    app = OneStepApp("render-escape")
+
+    @app.task(
+        source=MemoryQueue('weird & "name"'),
+        emit=EmitBinding(
+            sink=MemoryQueue("out"),
+            transform=lambda ctx, p, r: r,
+            transform_ref="pkg.transforms:pipe|quote",
+        ),
+    )
+    async def consume(ctx, payload):
+        return payload
+
+    output = render_mermaid(app)
+    assert "weird &amp; &quot;name&quot;" in output
+    assert "emit · pkg.transforms:pipe&#124;quote" in output
+
+
+def test_render_mermaid_empty_app() -> None:
+    output = render_mermaid(OneStepApp("empty"))
+    assert _lines(output) == ["graph LR", "%% app: empty"]
+
+
+def test_cli_render_prints_mermaid(capsys) -> None:
+    app = OneStepApp("cli-render")
+
+    @app.task(source=MemoryQueue("in"), emit=MemoryQueue("out"))
+    async def consume(ctx, payload):
+        return payload
+
+    module = types.ModuleType("testsupport_cli_render")
+    module.app = app
+    sys.modules["testsupport_cli_render"] = module
+    try:
+        exit_code = main(["render", "testsupport_cli_render:app"])
+    finally:
+        sys.modules.pop("testsupport_cli_render", None)
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.startswith("graph LR")
+    assert "%% app: cli-render" in captured.out
+    assert "consume" in captured.out
+
+
+def test_cli_render_rejects_unknown_format() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["render", "worker.yaml", "--format", "ascii"])
+
+
+def test_cli_render_is_not_swallowed_by_run_shorthand() -> None:
+    args = parse_args(["render", "worker.yaml"])
+    assert args.command == "render"
+    assert args.format == "mermaid"
+
+
+def test_cli_render_accepts_yaml_target(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    module = _handler_module()
+    sys.modules["render_handlers"] = module
+    try:
+        (tmp_path / "worker.yaml").write_text(
+            "\n".join(
+                [
+                    "apiVersion: onestep/v1alpha1",
+                    "kind: App",
+                    "app:",
+                    "  name: render-yaml",
+                    "resources:",
+                    "  incoming:",
+                    "    type: memory",
+                    "  outgoing:",
+                    "    type: memory",
+                    "tasks:",
+                    "  - name: sync",
+                    "    source: incoming",
+                    "    handler:",
+                    "      ref: render_handlers:sync",
+                    "    emit:",
+                    "      - outgoing",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        exit_code = main(["render", "worker.yaml"])
+    finally:
+        sys.modules.pop("render_handlers", None)
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.startswith("graph LR")
+    assert "%% app: render-yaml" in captured.out
+    assert "sync" in captured.out


### PR DESCRIPTION
Closes #119

## What

Adds `onestep render <target>`: prints the worker topology of any Python or YAML target as a Mermaid flowchart, ready to paste into GitHub READMEs, Notion, or Obsidian.

```bash
onestep render worker.yaml                  # default: mermaid
onestep render pkg.tasks:app --format mermaid
```

Example output:

```text
graph LR
  %% app: billing-sync
  n0["extract_entities<br/>concurrency=4 · retry=NoRetry · timeout=300s"]
  n1["sqs-orders<br/>MemoryQueue"]
  n2["audit-log<br/>MemoryQueue"]
  n3["mysql.meta_sink<br/>MemoryQueue"]
  n4["dlq<br/>MemoryQueue"]
  n1 --> n0
  n0 -->|"emit"| n2
  n0 -->|"when app.predicates:is_valid · app.transforms:to_meta"| n3
  n0 -->|"otherwise"| n4
```

## Design notes

- **Zero dependencies, no runtime changes.** The renderer is a read-only mapping from the loaded app to text, honoring the core package's empty `dependencies` constraint. `check --json` output schema is untouched (the `emit_routes` flattening contract test stays green); `render` reads the public `app.tasks` specs instead.
- **Deduplicated resource nodes.** Resources shared across tasks (e.g. a queue one task emits to and another consumes from) render once, so chained topologies appear as connected graphs without extra wiring logic.
- **Conditional routes and transforms.** Edges are labeled `emit` (plus the transform ref when a binding sets one), `when <predicate>` / `otherwise` for conditional routes, and dashed `dead_letter`. A plain `emit=sink` is normalized into a predicate-less route internally and renders as an ordinary emit edge.
- **Mermaid only for now.** Per the discussion in #119, ASCII layout (CJK width handling, branch coordinate math) is high-complexity/low-ratio and is intentionally left out; `--format` reserves the extension point.
- Escaping handles `& < > " |` in names and refs so hostile YAML strings cannot break the diagram syntax.

## Verification

- `uv run pytest -q -m "not integration"` — 479 passed (13 new tests in `tests/test_render.py` covering topology, shared-resource dedup, transform labels, conditional routes, dead-letter edges, escaping, empty apps, CLI parsing, Python and YAML targets)
- Manually exercised `onestep render` against a YAML worker with conditional routes