### PR TITLE
feat(mysql): per-column null write policies for table sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@
   `emit` (plus transform refs), `when`/`otherwise` for conditional routes, and
   dashed `dead_letter`; resources shared across tasks are drawn once.
 
+## onestep-mysql 0.6.0
+
+- Adds per-column null write policies to `mysql_table_sink`: `update_columns`
+  entries can be `{name, policy}` mappings alongside plain column names.
+  `skip_null` omits a column when the payload value is null (never clears
+  existing data), `backfill` renders `SET col = COALESCE(col, :val)` so
+  non-null stored values are preserved, and `overwrite` (the default) keeps
+  the existing unconditional behavior. Policies apply to both `update` and
+  `upsert` modes; rows whose `SET` clause becomes empty after `skip_null`
+  filtering are skipped with an INFO log.
+- Enforces policy configuration at construction time: policy entries cannot
+  target key columns, duplicate columns, or columns also configured in
+  `update_expr`.
+- Changes the `update_columns` catalog field type from `string_list` to
+  `json` to reflect the mixed entry shape.
+
 ## onestep-mysql 0.5.2
 
 - Adds `mode="update"` to `mysql_table_sink`: rows are written via

--- a/docs/broker/mysql.md
+++ b/docs/broker/mysql.md
@@ -211,6 +211,57 @@ sink = db.table_sink(
 - 两者仅适用于 `upsert` 和 `update` 模式；`update_columns` 为空且没有
   `update_expr` 时配置无效。
 
+### 按列写入策略（null 保护）
+
+`update_columns` 的条目可以是列名（默认无条件覆盖），也可以是
+`{name, policy}` 对象，按列声明载荷值与库中原值的合并方式。三种策略：
+
+| policy | 行为 | 生成 SQL |
+|---|---|---|
+| `overwrite`（默认） | 无条件用载荷值覆盖，载荷 `null` 也会写入 `NULL` | `SET col = :val` |
+| `skip_null` | 载荷值为 `null` 时该列不写，保留库中原值 | `null` → 列从 `SET` 剔除 |
+| `backfill` | 只在库中当前值为 `NULL` 时写入载荷值，原值非空则保持 | `SET col = COALESCE(col, :val)` |
+
+```yaml
+rows_sink:
+  type: mysql_table_sink
+  connector: downstream_mysql
+  table: bidding
+  mode: update
+  keys: [id]
+  update_columns:
+    - deadline              # 无条件覆盖
+    - tender_deadline       # 无条件覆盖
+    - name: tenderee
+      policy: skip_null     # 载荷 null 不写，避免清空已有值
+    - name: publish_date
+      policy: backfill      # 只回填空值，不覆盖已有值
+```
+
+Python 侧同样接受混合条目：
+
+```python
+sink = db.table_sink(
+    table="bidding",
+    mode="update",
+    keys=("id",),
+    update_columns=(
+        "deadline",
+        {"name": "tenderee", "policy": "skip_null"},
+    ),
+)
+```
+
+注意事项：
+
+- 策略对 `update` 和 `upsert` 同样生效（`ON DUPLICATE KEY UPDATE` 子句
+  应用相同规则）。
+- `skip_null` 过滤后整个 `SET` 为空时，该条载荷跳过并记录一条 INFO 日志，
+  不报错。
+- 策略列不能是 `keys` 中的列，也不能与 `update_expr` 中同列的原始 SQL
+  表达式同时配置（构造时报错）；纯列名条目与 `update_expr` 的覆盖关系
+  保持不变。
+
 ### JSON 序列化控制
 
 载荷中的 list/dict 值默认按目标列类型自动处理（`serialize_json="auto"`）：

--- a/docs/superpowers/specs/2026-08-19-mysql-table-sink-column-policy-design.md
+++ b/docs/superpowers/specs/2026-08-19-mysql-table-sink-column-policy-design.md
@@ -1,0 +1,56 @@
+# mysql_table_sink 按列写入策略（column write policies）设计
+
+日期：2026-08-19
+状态：已确认（与 issue #120 后续讨论一致）
+版本：onestep-mysql 0.6.0
+
+## 背景
+
+`mode: update` / `mode: upsert` 落库时，`update_columns` 白名单列被载荷值无条件覆盖：
+载荷值为 `null` 会生成 `SET col = NULL` 清空库里已有值；业务上需要两种相反的保护语义：
+
+1. **skip_null**：载荷值为 null 时该列不写（防止清空）；
+2. **backfill**：库里当前值为 null 时才写入新值，非 null 保持原值（只补空不覆盖）。
+
+## 核心决策
+
+- 策略与 mode 正交：mode 决定"行怎么落库"（insert/upsert/update），策略决定"列的新旧值怎么合并"。两种策略可在同一 sink 内按列混用。
+- 配置内联进 `update_columns`：字符串条目 = 默认 `overwrite`（完全向后兼容）；对象条目 `{name, policy}` 承载高级定制。避免独立的 `column_policy` 映射字段带来的键漂移校验。
+- 三种策略：`overwrite`（默认，现行为）/ `skip_null` / `backfill`。
+- update 与 upsert 共用同一份 SET 推导（`_update_payload`），`ON DUPLICATE KEY UPDATE` 子句自动获得同样能力。
+
+## 语法
+
+```yaml
+update_columns:
+  - deadline              # 覆盖（默认）
+  - name: tenderee
+    policy: skip_null     # 载荷 null → 该列不进 SET
+  - name: publish_date
+    policy: backfill      # SET col = COALESCE(col, :val)
+```
+
+Python：`update_columns=("deadline", {"name": "tenderee", "policy": "skip_null"})`。
+
+## SQL 语义
+
+| policy | 生成 | 说明 |
+|---|---|---|
+| overwrite | `SET col = :val` | 现行为，默认 |
+| skip_null | 载荷 null → 列剔除；非 null → `SET col = :val` | 按行动态 |
+| backfill | `SET col = COALESCE(col, :val)` | 原子、单往返，MySQL/SQLite 通用 |
+
+## 边界与错误处理
+
+- skip_null 过滤后 SET 为空 → 该条跳过并记 INFO 日志，不报错（update/upsert 统一；at-least-once 下属合法的"无事可做"）。非过滤导致的空 SET 维持现有构造/构建期报错。
+- 构造期校验（全部报错）：对象条目缺 `name` / 未知键 / policy 不在枚举内 / 列名重复（含字符串与对象混叠）/ 策略列命中 `keys` / 策略列与 `update_expr` 同列冲突。
+- 纯字符串条目与 `update_expr` 的现有覆盖关系不变。
+
+## Catalog / 控制面
+
+- `update_columns` 的 catalog 字段类型 `string_list` → `json`（`CATALOG_FIELD_TYPES` 已有 `json`，如实描述混合形态）。
+- `topology_fields` 含嵌套对象：plane 应按前向兼容的 JSON 容忍。发版前 verify plane 对 json 类型字段与该拓扑字段的渲染/校验（plane 源码不在本仓库，列入发版清单）。
+
+## 兼容性
+
+纯字符串配置零变化；默认策略 overwrite；无隐式行为变更。版本 0.5.2 → 0.6.0。

--- a/plugins/onestep-mysql/pyproject.toml
+++ b/plugins/onestep-mysql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-mysql"
-version = "0.5.2"
+version = "0.6.0"
 description = "MySQL connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-mysql/src/onestep_mysql/connector.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/connector.py
@@ -194,7 +194,7 @@ class MySQLConnector:
         table: str,
         mode: str = "insert",
         keys: Sequence[str] = (),
-        update_columns: Sequence[str] | None = None,
+        update_columns: Sequence[str | Mapping[str, str]] | None = None,
         update_expr: Mapping[str, str] | None = None,
         serialize_json: str = "auto",
     ) -> TableSink:
@@ -960,6 +960,47 @@ class IncrementalTableSource(Source):
         return self._commit_lock
 
 
+_UPDATE_COLUMN_POLICIES = frozenset({"overwrite", "skip_null", "backfill"})
+
+
+def _normalize_update_columns(
+    update_columns: Sequence[str | Mapping[str, str]] | None,
+    *,
+    keys: tuple[str, ...],
+) -> tuple[tuple[str, ...] | None, dict[str, str]]:
+    if update_columns is None:
+        return None, {}
+    names: list[str] = []
+    policies: dict[str, str] = {}
+    for entry in update_columns:
+        if isinstance(entry, str):
+            if not entry:
+                raise ValueError("update_columns entries must be non-empty")
+            name, policy = entry, "overwrite"
+        elif isinstance(entry, Mapping):
+            unknown_keys = set(entry) - {"name", "policy"}
+            if unknown_keys:
+                raise ValueError(f"unknown update_columns entry keys: {', '.join(sorted(unknown_keys))}")
+            name = entry.get("name")
+            policy = entry.get("policy", "overwrite")
+            if not isinstance(name, str) or not name:
+                raise ValueError("update_columns entry requires a non-empty 'name'")
+            if policy not in _UPDATE_COLUMN_POLICIES:
+                raise ValueError(
+                    "update_columns policy must be one of 'overwrite', 'skip_null' or 'backfill', "
+                    f"got {policy!r}"
+                )
+            if name in keys:
+                raise ValueError(f"update_columns policy cannot apply to key column {name!r}")
+        else:
+            raise TypeError("update_columns entries must be strings or mappings")
+        if name in policies:
+            raise ValueError(f"duplicate update column {name!r}")
+        names.append(name)
+        policies[name] = policy
+    return tuple(names), policies
+
+
 class TableSink(Sink):
     def __init__(
         self,
@@ -968,7 +1009,7 @@ class TableSink(Sink):
         table: str,
         mode: str = "insert",
         keys: tuple[str, ...] = (),
-        update_columns: tuple[str, ...] | None = None,
+        update_columns: Sequence[str | Mapping[str, str]] | None = None,
         update_expr: Mapping[str, str] | None = None,
         serialize_json: str = "auto",
     ) -> None:
@@ -977,13 +1018,16 @@ class TableSink(Sink):
             raise ValueError("mode must be one of 'insert', 'upsert' or 'update'")
         if update_columns is not None and mode == "insert":
             raise ValueError("update_columns only applies to upsert or update mode")
-        update_columns_tuple = tuple(update_columns) if update_columns is not None else None
+        update_columns_tuple, column_policies = _normalize_update_columns(update_columns, keys=keys)
         update_expr_dict = dict(update_expr or {})
         if update_expr is not None:
             if mode == "insert":
                 raise ValueError("update_expr only applies to upsert or update mode")
             if not all(isinstance(key, str) and isinstance(value, str) for key, value in update_expr.items()):
                 raise TypeError("update_expr keys and values must be strings")
+        conflicting = sorted(set(column_policies) & set(update_expr_dict))
+        if conflicting:
+            raise ValueError(f"update_columns policy conflicts with update_expr for: {', '.join(conflicting)}")
         if mode in {"upsert", "update"} and update_columns_tuple == () and not update_expr_dict:
             raise ValueError(f"{mode} mode requires update_expr when update_columns is empty")
         if serialize_json not in {"auto", "always", "never"}:
@@ -993,6 +1037,7 @@ class TableSink(Sink):
         self.mode = mode
         self.keys = keys
         self.update_columns = update_columns_tuple
+        self.column_policies = column_policies
         self.update_expr = update_expr_dict
         self.serialize_json = serialize_json
 
@@ -1016,6 +1061,13 @@ class TableSink(Sink):
     async def _send(self, payload: dict[str, Any]) -> None:
         table = await self.connector._table(self.table_name)
         stmt = self._build_statement(payload, table)
+        if stmt is None:
+            logger.info(
+                "mysql table sink %s skipped write: all update columns are null under skip_null policy (keys=%s)",
+                self.name,
+                {key: payload.get(key) for key in self.keys},
+            )
+            return
         async with self.connector.engine.begin() as conn:
             result = await conn.execute(stmt)
             if self.mode == "update" and result.rowcount == 0:
@@ -1031,8 +1083,10 @@ class TableSink(Sink):
             return sa.insert(table).values(**payload)
         if not self.keys:
             raise ValueError(f"{self.mode} mode requires keys")
-        update_payload = self._update_payload(payload)
+        update_payload, skipped_by_policy = self._update_payload(payload, table)
         if not update_payload:
+            if skipped_by_policy:
+                return None
             raise ValueError(f"{self.mode} mode requires at least one update column or update_expr")
         if self.mode == "update":
             missing_keys = [key for key in self.keys if key not in payload]
@@ -1054,14 +1108,25 @@ class TableSink(Sink):
             return stmt.on_conflict_do_update(index_elements=list(self.keys), set_=update_payload)
         return sa.insert(table).values(**payload)
 
-    def _update_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+    def _update_payload(self, payload: dict[str, Any], table: sa.Table) -> tuple[dict[str, Any], bool]:
         if self.update_columns is not None:
-            update_payload = {key: value for key, value in payload.items() if key in self.update_columns}
+            candidates = {key: value for key, value in payload.items() if key in self.update_columns}
         else:
-            update_payload = {key: value for key, value in payload.items() if key not in self.keys}
+            candidates = {key: value for key, value in payload.items() if key not in self.keys}
+        update_payload: dict[str, Any] = {}
+        skipped = False
+        for column, value in candidates.items():
+            policy = self.column_policies.get(column, "overwrite")
+            if policy == "skip_null" and value is None:
+                skipped = True
+                continue
+            if policy == "backfill":
+                update_payload[column] = sa.func.coalesce(table.columns[column], value)
+            else:
+                update_payload[column] = value
         for column, expr in self.update_expr.items():
             update_payload[column] = sa.literal_column(expr)
-        return update_payload
+        return update_payload, skipped
 
     def _coerce_json_values(self, payload: dict[str, Any], table: sa.Table) -> dict[str, Any]:
         if self.serialize_json == "never":

--- a/plugins/onestep-mysql/src/onestep_mysql/resources.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/resources.py
@@ -153,7 +153,7 @@ _MYSQL_TABLE_SINK_CATALOG = ResourceCatalogEntry(
         ResourceCatalogField("table", "string", required=True),
         ResourceCatalogField("mode", "string", default="insert", options=("insert", "upsert", "update")),
         ResourceCatalogField("keys", "string_list"),
-        ResourceCatalogField("update_columns", "string_list"),
+        ResourceCatalogField("update_columns", "json"),
         ResourceCatalogField("update_expr", "mapping"),
         ResourceCatalogField("serialize_json", "string", default="auto", options=("auto", "always", "never")),
     ),
@@ -322,6 +322,15 @@ def _build_mysql_binlog(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> A
     )
 
 
+def _update_columns_value(value: Any, *, field: str) -> list[str | Mapping[str, str]]:
+    if not isinstance(value, list):
+        raise ValueError(f"'{field}' must be a list of column names or {{name, policy}} mappings")
+    for entry in value:
+        if not isinstance(entry, (str, Mapping)):
+            raise ValueError(f"'{field}' entries must be column names or {{name, policy}} mappings")
+    return value
+
+
 def _build_mysql_table_sink(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
     connector = ctx.resolve_dependency(spec, "connector")
     if not hasattr(connector, "table_sink"):
@@ -333,7 +342,7 @@ def _build_mysql_table_sink(ctx: ResourceBuildContext, spec: Mapping[str, Any]) 
         table=ctx.require_string(spec, "table"),
         mode=spec.get("mode", "insert"),
         keys=tuple(ctx.string_list(keys, field=f"{ctx.field}.keys")) if keys is not None else (),
-        update_columns=tuple(ctx.string_list(update_columns, field=f"{ctx.field}.update_columns"))
+        update_columns=_update_columns_value(update_columns, field=f"{ctx.field}.update_columns")
         if update_columns is not None
         else None,
         update_expr=ctx.mapping_value(update_expr, field=f"{ctx.field}.update_expr")

--- a/plugins/onestep-mysql/tests/test_mysql_plugin.py
+++ b/plugins/onestep-mysql/tests/test_mysql_plugin.py
@@ -227,6 +227,66 @@ def test_yaml_empty_update_columns_is_distinct_from_unset(tmp_path) -> None:
     assert sink.update_expr == {"updated_at": "NOW(6)"}
 
 
+def test_yaml_update_columns_accepts_policy_entries(tmp_path) -> None:
+    dsn = f"sqlite:///{tmp_path / 'mysql-plugin.db'}"
+
+    app = load_app_config(
+        {
+            "apiVersion": "onestep/v1alpha1",
+            "kind": "App",
+            "app": {"name": "mysql-plugin"},
+            "resources": {
+                "db": {"type": "mysql", "dsn": dsn},
+                "processed": {
+                    "type": "mysql_table_sink",
+                    "connector": "db",
+                    "table": "processed_users",
+                    "mode": "update",
+                    "keys": ["id"],
+                    "update_columns": [
+                        "name",
+                        {"name": "email", "policy": "skip_null"},
+                        {"name": "phone", "policy": "backfill"},
+                    ],
+                },
+            },
+            "tasks": [],
+        },
+        strict=True,
+    )
+
+    sink = app.resources["processed"]
+    assert isinstance(sink, TableSink)
+    assert sink.update_columns == ("name", "email", "phone")
+    assert sink.column_policies == {"name": "overwrite", "email": "skip_null", "phone": "backfill"}
+
+
+def test_yaml_rejects_invalid_update_columns_policy(tmp_path) -> None:
+    dsn = f"sqlite:///{tmp_path / 'mysql-plugin.db'}"
+
+    with pytest.raises(ValueError, match="policy"):
+        load_app_config(
+            {
+                "apiVersion": "onestep/v1alpha1",
+                "kind": "App",
+                "app": {"name": "mysql-plugin"},
+                "resources": {
+                    "db": {"type": "mysql", "dsn": dsn},
+                    "processed": {
+                        "type": "mysql_table_sink",
+                        "connector": "db",
+                        "table": "processed_users",
+                        "mode": "update",
+                        "keys": ["id"],
+                        "update_columns": [{"name": "email", "policy": "sometimes"}],
+                    },
+                },
+                "tasks": [],
+            },
+            strict=True,
+        )
+
+
 def test_yaml_update_mode_builds_update_only_sink(tmp_path) -> None:
     dsn = f"sqlite:///{tmp_path / 'mysql-plugin.db'}"
 

--- a/plugins/onestep-mysql/tests/test_mysql_table_sink.py
+++ b/plugins/onestep-mysql/tests/test_mysql_table_sink.py
@@ -430,6 +430,211 @@ def test_update_columns_and_update_expr_valid_in_update_mode() -> None:
 
 
 @pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_skip_null_policy_omits_null_columns() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="update",
+        keys=("article_identity",),
+        update_columns=(
+            "title",
+            {"name": "content", "policy": "skip_null"},
+        ),
+    )
+    payload = dict(_payload(), title=None, content=None)
+
+    sql = _compile(sink._build_statement(payload, _candidate_table()))
+    set_clause = sql.split(" WHERE ", 1)[0]
+
+    assert "title=" in set_clause
+    assert "content=" not in set_clause
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_backfill_policy_renders_coalesce() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="update",
+        keys=("article_identity",),
+        update_columns=(
+            "title",
+            {"name": "publish_at", "policy": "backfill"},
+        ),
+    )
+
+    sql = _compile(sink._build_statement(_payload(), _candidate_table()))
+    set_clause = sql.split(" WHERE ", 1)[0]
+
+    assert "title=" in set_clause
+    assert "coalesce(v2_clean_article_candidate.publish_at," in sql.replace(" ", "").lower()
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_explicit_overwrite_policy_matches_plain_string() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="update",
+        keys=("article_identity",),
+        update_columns=({"name": "title", "policy": "overwrite"},),
+    )
+
+    sql = _compile(sink._build_statement(_payload(), _candidate_table()))
+    set_clause = sql.split(" WHERE ", 1)[0]
+
+    assert "title=" in set_clause
+    assert "coalesce" not in sql.lower()
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_all_skip_null_columns_returns_no_statement() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="update",
+        keys=("article_identity",),
+        update_columns=({"name": "title", "policy": "skip_null"},),
+    )
+    payload = dict(_payload(), title=None)
+
+    assert sink._build_statement(payload, _candidate_table()) is None
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_skipped_statement_logs_without_touching_engine(caplog) -> None:
+    class _Engine:
+        def begin(self):
+            raise AssertionError("engine must not be used when statement is skipped")
+
+    class _Connector:
+        engine = _Engine()
+
+        async def _table(self, table_name):
+            return _candidate_table()
+
+    sink = TableSink(
+        connector=_Connector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="update",
+        keys=("article_identity",),
+        update_columns=({"name": "title", "policy": "skip_null"},),
+    )
+
+    with caplog.at_level(logging.INFO, logger="onestep_mysql.connector"):
+        asyncio.run(sink._send(dict(_payload(), title=None)))
+
+    assert any("skipped write" in record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_upsert_mode_applies_policies_in_duplicate_clause() -> None:
+    sink = TableSink(
+        connector=_FakeConnector(),  # type: ignore[arg-type]
+        table="v2_clean_article_candidate",
+        mode="upsert",
+        keys=("article_identity",),
+        update_columns=(
+            "title",
+            {"name": "content", "policy": "skip_null"},
+            {"name": "publish_at", "policy": "backfill"},
+        ),
+    )
+    payload = dict(_payload(), content=None)
+
+    update = _update_clause(_compile(sink._build_statement(payload, _candidate_table())))
+
+    assert "title = " in update
+    assert "content = " not in update
+    assert "coalesce(" in update.lower()
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_columns_rejects_unknown_policy() -> None:
+    with pytest.raises(ValueError, match="policy"):
+        TableSink(
+            connector=_FakeConnector(),  # type: ignore[arg-type]
+            table="t",
+            mode="update",
+            keys=("id",),
+            update_columns=({"name": "a", "policy": "sometimes"},),
+        )
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_columns_rejects_missing_name() -> None:
+    with pytest.raises(ValueError, match="name"):
+        TableSink(
+            connector=_FakeConnector(),  # type: ignore[arg-type]
+            table="t",
+            mode="update",
+            keys=("id",),
+            update_columns=({"policy": "backfill"},),
+        )
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_columns_rejects_unknown_entry_keys() -> None:
+    with pytest.raises(ValueError, match="unknown update_columns entry keys"):
+        TableSink(
+            connector=_FakeConnector(),  # type: ignore[arg-type]
+            table="t",
+            mode="update",
+            keys=("id",),
+            update_columns=({"name": "a", "policy": "backfill", "extra": 1},),
+        )
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_columns_rejects_duplicate_columns() -> None:
+    with pytest.raises(ValueError, match="duplicate"):
+        TableSink(
+            connector=_FakeConnector(),  # type: ignore[arg-type]
+            table="t",
+            mode="update",
+            keys=("id",),
+            update_columns=("title", {"name": "title", "policy": "backfill"}),
+        )
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_columns_policy_rejects_key_column() -> None:
+    with pytest.raises(ValueError, match="key column"):
+        TableSink(
+            connector=_FakeConnector(),  # type: ignore[arg-type]
+            table="t",
+            mode="update",
+            keys=("id",),
+            update_columns=({"name": "id", "policy": "backfill"},),
+        )
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_columns_policy_conflicts_with_update_expr() -> None:
+    with pytest.raises(ValueError, match="conflicts with update_expr"):
+        TableSink(
+            connector=_FakeConnector(),  # type: ignore[arg-type]
+            table="t",
+            mode="update",
+            keys=("id",),
+            update_columns=({"name": "updated_at", "policy": "backfill"},),
+            update_expr={"updated_at": "NOW(6)"},
+        )
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
+def test_update_columns_rejects_non_string_non_mapping_entry() -> None:
+    with pytest.raises(TypeError, match="strings or mappings"):
+        TableSink(
+            connector=_FakeConnector(),  # type: ignore[arg-type]
+            table="t",
+            mode="update",
+            keys=("id",),
+            update_columns=(123,),
+        )
+
+
+@pytest.mark.skipif(sa is None, reason="sqlalchemy not installed")
 def test_update_mode_logs_when_no_rows_matched(caplog) -> None:
     class _Result:
         rowcount = 0

--- a/uv.lock
+++ b/uv.lock
@@ -1689,7 +1689,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-mysql"
-version = "0.5.2"
+version = "0.6.0"
 source = { editable = "plugins/onestep-mysql" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
延续 #121（issue #120 后续讨论）：`update_columns` 的条目支持 `{name, policy}` 对象，按列声明 null 写入策略，与 mode 正交，`update` / `upsert` 同时生效。

## 策略

| policy | 行为 | 生成 SQL |
|---|---|---|
| `overwrite`（默认） | 无条件覆盖，载荷 null 也写 NULL（现行为，完全向后兼容） | `SET col = :val` |
| `skip_null` | 载荷值为 null 时该列不写，保留库中原值 | null → 列从 SET 剔除 |
| `backfill` | 库中当前值为 NULL 才写入，非空保持原值 | `SET col = COALESCE(col, :val)` |

```yaml
update_columns:
  - deadline                              # 无条件覆盖
  - name: tenderee
    policy: skip_null                     # 载荷 null 不写，避免清空
  - name: publish_date
    policy: backfill                      # 只回填空值
```

## 边界语义

- `skip_null` 过滤后整个 SET 为空 → 该条跳过并记 INFO 日志（at-least-once 下合法的无事可做）；非过滤导致的空 SET 维持原报错。
- 构造期校验：策略列不得命中 keys、不得重复、不得与 `update_expr` 同列冲突；对象条目仅允许 name/policy 键。
- upsert 模式下策略应用于 `ON DUPLICATE KEY UPDATE` 子句（同一份 SET 推导）。

## 配套

- catalog：`update_columns` 类型 `string_list` → `json`（如实描述混合形态）；**发版前需 verify 控制面对 json 字段的渲染与 topology 中嵌套对象的容忍**（plane 源码不在本仓库）。
- 设计文档：`docs/superpowers/specs/2026-08-19-mysql-table-sink-column-policy-design.md`
- 测试：+15 用例（三种策略渲染、空集跳过+INFO、ODKU 生效、构造校验矩阵、YAML strict 加载），全套 78 passed, 1 skipped（skip 为 live 集成用例）。
- 版本 0.5.2 → 0.6.0，CHANGELOG 与 uv.lock 已更新。