### PR TITLE
test: Phase 0 SQL plugin baseline + contract tests (#133)

### DIFF
--- a/tests/contract/snapshots/sql_resource_catalog.json
+++ b/tests/contract/snapshots/sql_resource_catalog.json
@@ -1,0 +1,989 @@
+{
+  "mysql": {
+    "connector_types": [],
+    "fields": [
+      {
+        "name": "dsn",
+        "required": true,
+        "secret": true,
+        "type": "string"
+      },
+      {
+        "name": "engine_options",
+        "required": false,
+        "secret": false,
+        "type": "mapping"
+      },
+      {
+        "name": "host",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "port",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "database",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "username",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "password",
+        "required": false,
+        "secret": true,
+        "type": "string"
+      }
+    ],
+    "label": "MySQL",
+    "roles": [
+      "connector"
+    ],
+    "topology_fields": [],
+    "type": "mysql"
+  },
+  "mysql_binlog": {
+    "connector_types": [
+      "mysql"
+    ],
+    "fields": [
+      {
+        "name": "connector",
+        "required": true,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "name": "server_id",
+        "required": true,
+        "secret": false,
+        "type": "integer"
+      },
+      {
+        "name": "schemas",
+        "required": false,
+        "secret": false,
+        "type": "string_list"
+      },
+      {
+        "name": "tables",
+        "required": false,
+        "secret": false,
+        "type": "string_list"
+      },
+      {
+        "default": [
+          "insert",
+          "update",
+          "delete"
+        ],
+        "name": "events",
+        "required": false,
+        "secret": false,
+        "type": "string_list"
+      },
+      {
+        "default": 100,
+        "name": "batch_size",
+        "required": false,
+        "secret": false,
+        "type": "integer"
+      },
+      {
+        "default": 1.0,
+        "name": "poll_interval_s",
+        "required": false,
+        "secret": false,
+        "type": "number"
+      },
+      {
+        "name": "state",
+        "required": false,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "name": "state_key",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": false,
+        "name": "blocking",
+        "required": false,
+        "secret": false,
+        "type": "boolean"
+      }
+    ],
+    "label": "MySQL Binlog",
+    "roles": [
+      "source"
+    ],
+    "topology_fields": [
+      "schemas",
+      "tables",
+      "events",
+      "batch_size",
+      "poll_interval_s"
+    ],
+    "type": "mysql_binlog"
+  },
+  "mysql_cursor_store": {
+    "connector_types": [
+      "mysql"
+    ],
+    "fields": [
+      {
+        "name": "connector",
+        "required": true,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "default": "onestep_cursor",
+        "name": "table",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "cursor_key",
+        "name": "key_column",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "cursor_value",
+        "name": "value_column",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "updated_at",
+        "name": "updated_at_column",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": true,
+        "name": "auto_create",
+        "required": false,
+        "secret": false,
+        "type": "boolean"
+      }
+    ],
+    "label": "MySQL Cursor Store",
+    "roles": [
+      "cursor_store"
+    ],
+    "topology_fields": [
+      "table",
+      "key_column"
+    ],
+    "type": "mysql_cursor_store"
+  },
+  "mysql_incremental": {
+    "connector_types": [
+      "mysql"
+    ],
+    "fields": [
+      {
+        "name": "connector",
+        "required": true,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "name": "table",
+        "required": true,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "key",
+        "required": true,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "cursor",
+        "required": true,
+        "secret": false,
+        "type": "string_list"
+      },
+      {
+        "name": "where",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": 1000,
+        "name": "batch_size",
+        "required": false,
+        "secret": false,
+        "type": "integer"
+      },
+      {
+        "default": 1.0,
+        "name": "poll_interval_s",
+        "required": false,
+        "secret": false,
+        "type": "number"
+      },
+      {
+        "name": "state",
+        "required": false,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "name": "state_key",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      }
+    ],
+    "label": "MySQL Incremental",
+    "roles": [
+      "source"
+    ],
+    "topology_fields": [
+      "table",
+      "key",
+      "cursor",
+      "batch_size",
+      "poll_interval_s"
+    ],
+    "type": "mysql_incremental"
+  },
+  "mysql_state_store": {
+    "connector_types": [
+      "mysql"
+    ],
+    "fields": [
+      {
+        "name": "connector",
+        "required": true,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "default": "onestep_state",
+        "name": "table",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "state_key",
+        "name": "key_column",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "state_value",
+        "name": "value_column",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "updated_at",
+        "name": "updated_at_column",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": true,
+        "name": "auto_create",
+        "required": false,
+        "secret": false,
+        "type": "boolean"
+      }
+    ],
+    "label": "MySQL State Store",
+    "roles": [
+      "state_store"
+    ],
+    "topology_fields": [
+      "table",
+      "key_column"
+    ],
+    "type": "mysql_state_store"
+  },
+  "mysql_table_queue": {
+    "connector_types": [
+      "mysql"
+    ],
+    "fields": [
+      {
+        "name": "connector",
+        "required": true,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "name": "table",
+        "required": true,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "key",
+        "required": true,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "where",
+        "required": true,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "claim",
+        "required": true,
+        "secret": false,
+        "type": "mapping"
+      },
+      {
+        "name": "ack",
+        "required": true,
+        "secret": false,
+        "type": "mapping"
+      },
+      {
+        "name": "nack",
+        "required": false,
+        "secret": false,
+        "type": "mapping"
+      },
+      {
+        "default": 100,
+        "name": "batch_size",
+        "required": false,
+        "secret": false,
+        "type": "integer"
+      },
+      {
+        "default": 1.0,
+        "name": "poll_interval_s",
+        "required": false,
+        "secret": false,
+        "type": "number"
+      }
+    ],
+    "label": "MySQL Table Queue",
+    "roles": [
+      "source"
+    ],
+    "topology_fields": [
+      "table",
+      "key",
+      "batch_size",
+      "poll_interval_s"
+    ],
+    "type": "mysql_table_queue"
+  },
+  "mysql_table_sink": {
+    "connector_types": [
+      "mysql"
+    ],
+    "fields": [
+      {
+        "name": "connector",
+        "required": true,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "name": "table",
+        "required": true,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "insert",
+        "name": "mode",
+        "options": [
+          "insert",
+          "upsert",
+          "update"
+        ],
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "keys",
+        "required": false,
+        "secret": false,
+        "type": "string_list"
+      },
+      {
+        "name": "update_columns",
+        "required": false,
+        "secret": false,
+        "type": "json"
+      },
+      {
+        "name": "update_expr",
+        "required": false,
+        "secret": false,
+        "type": "mapping"
+      },
+      {
+        "default": "auto",
+        "name": "serialize_json",
+        "options": [
+          "auto",
+          "always",
+          "never"
+        ],
+        "required": false,
+        "secret": false,
+        "type": "string"
+      }
+    ],
+    "label": "MySQL Table Sink",
+    "roles": [
+      "sink"
+    ],
+    "topology_fields": [
+      "table",
+      "mode",
+      "keys",
+      "update_columns",
+      "update_expr",
+      "serialize_json"
+    ],
+    "type": "mysql_table_sink"
+  },
+  "postgres": {
+    "connector_types": [],
+    "fields": [
+      {
+        "name": "dsn",
+        "required": true,
+        "secret": true,
+        "type": "string"
+      },
+      {
+        "name": "engine_options",
+        "required": false,
+        "secret": false,
+        "type": "mapping"
+      },
+      {
+        "name": "host",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "port",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "database",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "username",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "password",
+        "required": false,
+        "secret": true,
+        "type": "string"
+      }
+    ],
+    "label": "Postgres",
+    "roles": [
+      "connector"
+    ],
+    "topology_fields": [],
+    "type": "postgres"
+  },
+  "postgres_cursor_store": {
+    "connector_types": [
+      "postgres"
+    ],
+    "fields": [
+      {
+        "name": "connector",
+        "required": true,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "default": "onestep_cursor",
+        "name": "table",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "cursor_key",
+        "name": "key_column",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "cursor_value",
+        "name": "value_column",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "updated_at",
+        "name": "updated_at_column",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": true,
+        "name": "auto_create",
+        "required": false,
+        "secret": false,
+        "type": "boolean"
+      }
+    ],
+    "label": "Postgres Cursor Store",
+    "roles": [
+      "cursor_store"
+    ],
+    "topology_fields": [
+      "table",
+      "key_column"
+    ],
+    "type": "postgres_cursor_store"
+  },
+  "postgres_execution_source": {
+    "connector_types": [
+      "postgres"
+    ],
+    "fields": [
+      {
+        "name": "connector",
+        "required": true,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "name": "namespace",
+        "required": true,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "task_names",
+        "required": true,
+        "secret": false,
+        "type": "string_list"
+      },
+      {
+        "default": "onestep_executions",
+        "name": "table",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "onestep_execution_attempts",
+        "name": "attempts_table",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": 100,
+        "name": "batch_size",
+        "required": false,
+        "secret": false,
+        "type": "integer"
+      },
+      {
+        "default": 1.0,
+        "name": "poll_interval_s",
+        "required": false,
+        "secret": false,
+        "type": "number"
+      },
+      {
+        "default": 90.0,
+        "name": "lease_duration_s",
+        "required": false,
+        "secret": false,
+        "type": "number"
+      },
+      {
+        "default": 30.0,
+        "name": "heartbeat_interval_s",
+        "required": false,
+        "secret": false,
+        "type": "number"
+      },
+      {
+        "default": "onestep-worker",
+        "name": "worker_id",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": true,
+        "name": "auto_create",
+        "required": false,
+        "secret": false,
+        "type": "boolean"
+      },
+      {
+        "default": 1048576,
+        "name": "max_payload_bytes",
+        "required": false,
+        "secret": false,
+        "type": "integer"
+      },
+      {
+        "default": 65536,
+        "name": "max_metadata_bytes",
+        "required": false,
+        "secret": false,
+        "type": "integer"
+      },
+      {
+        "default": 1048576,
+        "name": "max_result_bytes",
+        "required": false,
+        "secret": false,
+        "type": "integer"
+      },
+      {
+        "default": 100,
+        "name": "reclaim_batch_size",
+        "required": false,
+        "secret": false,
+        "type": "integer"
+      }
+    ],
+    "label": "Postgres Execution Source",
+    "roles": [
+      "source"
+    ],
+    "topology_fields": [
+      "namespace",
+      "task_names",
+      "batch_size",
+      "poll_interval_s"
+    ],
+    "type": "postgres_execution_source"
+  },
+  "postgres_incremental": {
+    "connector_types": [
+      "postgres"
+    ],
+    "fields": [
+      {
+        "name": "connector",
+        "required": true,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "name": "table",
+        "required": true,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "key",
+        "required": true,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "cursor",
+        "required": true,
+        "secret": false,
+        "type": "string_list"
+      },
+      {
+        "name": "where",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": 1000,
+        "name": "batch_size",
+        "required": false,
+        "secret": false,
+        "type": "integer"
+      },
+      {
+        "default": 1.0,
+        "name": "poll_interval_s",
+        "required": false,
+        "secret": false,
+        "type": "number"
+      },
+      {
+        "name": "state",
+        "required": false,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "name": "state_key",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      }
+    ],
+    "label": "Postgres Incremental",
+    "roles": [
+      "source"
+    ],
+    "topology_fields": [
+      "table",
+      "key",
+      "cursor",
+      "batch_size",
+      "poll_interval_s"
+    ],
+    "type": "postgres_incremental"
+  },
+  "postgres_state_store": {
+    "connector_types": [
+      "postgres"
+    ],
+    "fields": [
+      {
+        "name": "connector",
+        "required": true,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "default": "onestep_state",
+        "name": "table",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "state_key",
+        "name": "key_column",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "state_value",
+        "name": "value_column",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "updated_at",
+        "name": "updated_at_column",
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": true,
+        "name": "auto_create",
+        "required": false,
+        "secret": false,
+        "type": "boolean"
+      }
+    ],
+    "label": "Postgres State Store",
+    "roles": [
+      "state_store"
+    ],
+    "topology_fields": [
+      "table",
+      "key_column"
+    ],
+    "type": "postgres_state_store"
+  },
+  "postgres_table_queue": {
+    "connector_types": [
+      "postgres"
+    ],
+    "fields": [
+      {
+        "name": "connector",
+        "required": true,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "name": "table",
+        "required": true,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "key",
+        "required": true,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "where",
+        "required": true,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "claim",
+        "required": true,
+        "secret": false,
+        "type": "mapping"
+      },
+      {
+        "name": "ack",
+        "required": true,
+        "secret": false,
+        "type": "mapping"
+      },
+      {
+        "name": "nack",
+        "required": false,
+        "secret": false,
+        "type": "mapping"
+      },
+      {
+        "default": 100,
+        "name": "batch_size",
+        "required": false,
+        "secret": false,
+        "type": "integer"
+      },
+      {
+        "default": 1.0,
+        "name": "poll_interval_s",
+        "required": false,
+        "secret": false,
+        "type": "number"
+      }
+    ],
+    "label": "Postgres Table Queue",
+    "roles": [
+      "source"
+    ],
+    "topology_fields": [
+      "table",
+      "key",
+      "batch_size",
+      "poll_interval_s"
+    ],
+    "type": "postgres_table_queue"
+  },
+  "postgres_table_sink": {
+    "connector_types": [
+      "postgres"
+    ],
+    "fields": [
+      {
+        "name": "connector",
+        "required": true,
+        "secret": false,
+        "type": "ref"
+      },
+      {
+        "name": "table",
+        "required": true,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "default": "insert",
+        "name": "mode",
+        "options": [
+          "insert",
+          "upsert",
+          "update"
+        ],
+        "required": false,
+        "secret": false,
+        "type": "string"
+      },
+      {
+        "name": "keys",
+        "required": false,
+        "secret": false,
+        "type": "string_list"
+      },
+      {
+        "name": "update_columns",
+        "required": false,
+        "secret": false,
+        "type": "json"
+      },
+      {
+        "name": "update_expr",
+        "required": false,
+        "secret": false,
+        "type": "mapping"
+      },
+      {
+        "default": "auto",
+        "name": "serialize_json",
+        "options": [
+          "auto",
+          "always",
+          "never"
+        ],
+        "required": false,
+        "secret": false,
+        "type": "string"
+      }
+    ],
+    "label": "Postgres Table Sink",
+    "roles": [
+      "sink"
+    ],
+    "topology_fields": [
+      "table",
+      "mode",
+      "keys",
+      "update_columns",
+      "update_expr",
+      "serialize_json"
+    ],
+    "type": "postgres_table_sink"
+  }
+}

--- a/tests/contract/test_sql_resource_contract.py
+++ b/tests/contract/test_sql_resource_contract.py
@@ -1,0 +1,175 @@
+"""Phase 0 baseline + contract tests for the onestep SQL plugins.
+
+These tests pin the *current* public contract of ``onestep-mysql`` and
+``onestep-postgres`` so that the later consolidation into a single
+``onestep-sql`` distribution (tracking issue #133, design in
+``docs/superpowers/specs/2026-08-20-onestep-sql-consolidation-design.md``)
+cannot silently change:
+
+* the 14 YAML resource type names (7 MySQL + 7 PostgreSQL),
+* their catalog roles, fields, defaults, options and connector boundaries,
+* the public Python API surface exported from each package, and
+* the historical submodule import paths that compatibility forwarding must keep.
+
+They register handlers directly (no entry-point discovery) for
+determinism. The full install-permutation / duplicate-registration matrix
+is covered later in Phase 3 (``scripts/run-integration-tests.sh`` + CI),
+because it requires multiple installed wheels.
+
+No live database is required: every assertion here is structural.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+from onestep.resource_registry import ResourceRegistry
+
+from onestep_mysql.resources import register_resources as register_mysql
+from onestep_postgres.resources import register_resources as register_postgres
+
+SNAPSHOT_PATH = Path(__file__).parent / "snapshots" / "sql_resource_catalog.json"
+
+EXPECTED_TYPES = frozenset(
+    {
+        # MySQL (7)
+        "mysql",
+        "mysql_state_store",
+        "mysql_cursor_store",
+        "mysql_table_queue",
+        "mysql_incremental",
+        "mysql_binlog",
+        "mysql_table_sink",
+        # PostgreSQL (7)
+        "postgres",
+        "postgres_state_store",
+        "postgres_cursor_store",
+        "postgres_table_queue",
+        "postgres_incremental",
+        "postgres_execution_source",
+        "postgres_table_sink",
+    }
+)
+
+# Public API that compatibility forwarding (Phase 3) must preserve by identity.
+MYSQL_REQUIRED_PUBLIC = {
+    "MySQLConnector",
+    "TableSink",
+    "BinlogSource",
+    "SQLAlchemyStateStore",
+    "SQLAlchemyCursorStore",
+    "IncrementalTableSource",
+    "TableQueueSource",
+    "IncrementalDelivery",
+    "TableQueueDelivery",
+    "BinlogDelivery",
+    "classify_sqlalchemy_error",
+    "register",
+    "register_resources",
+}
+
+POSTGRES_REQUIRED_PUBLIC = {
+    "PostgresConnector",
+    "PostgresTableSink",
+    "PostgresExecutionBackend",
+    "PostgresExecutionSource",
+    "PostgresExecutionDelivery",
+    "PostgresIncrementalSource",
+    "PostgresTableQueueSource",
+    "PostgresTableQueueDelivery",
+    "ExecutionLease",
+    "HeartbeatResult",
+    "StaleExecutionLease",
+    "SQLAlchemyStateStore",
+    "SQLAlchemyCursorStore",
+    "IncrementalDelivery",
+    "classify_sqlalchemy_error",
+    "register",
+    "register_resources",
+}
+
+# Historical submodule import paths that must keep resolving (P0.2).
+MYSQL_SUBMODULES = ["connector", "resources", "resilience", "state_sqlalchemy"]
+POSTGRES_SUBMODULES = [
+    "connector",
+    "resources",
+    "resilience",
+    "state_sqlalchemy",
+    "execution_backend",
+    "execution_schema",
+    "execution_source",
+]
+
+
+def _normalize(value):
+    # JSON has no tuple type; normalize tuples to lists so the golden snapshot
+    # (loaded from JSON) compares equal to the runtime catalog (which may carry
+    # tuples for `default`/`options`). YAML consumers do not distinguish them.
+    if isinstance(value, dict):
+        return {key: _normalize(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalize(item) for item in value]
+    return value
+
+
+def _catalog(registry: ResourceRegistry) -> dict[str, dict]:
+    return _normalize({entry.type: entry.as_dict() for entry in registry.catalog_entries()})
+
+
+def test_fourteen_types_registered_once() -> None:
+    registry = ResourceRegistry()
+    register_mysql(registry)
+    register_postgres(registry)
+    types = set(registry.handlers().keys())
+    assert types == EXPECTED_TYPES
+    assert len(types) == 14
+
+
+def test_catalog_matches_baseline_snapshot() -> None:
+    registry = ResourceRegistry()
+    register_mysql(registry)
+    register_postgres(registry)
+    actual = _catalog(registry)
+    expected = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    assert actual == expected
+
+
+def test_idempotent_reregistration_does_not_duplicate() -> None:
+    # ResourceRegistry tolerates fully-equal duplicate handlers; re-registering
+    # both plugins must not raise and must not create duplicate types.
+    registry = ResourceRegistry()
+    register_mysql(registry)
+    register_postgres(registry)
+    register_mysql(registry)
+    register_postgres(registry)
+    assert set(registry.handlers().keys()) == EXPECTED_TYPES
+    assert len(registry.handlers()) == 14
+
+
+def test_mysql_public_api_surface() -> None:
+    import onestep_mysql
+
+    missing = MYSQL_REQUIRED_PUBLIC - set(dir(onestep_mysql))
+    assert not missing, f"onestep_mysql missing public symbols: {sorted(missing)}"
+    assert onestep_mysql.register is onestep_mysql.register_resources
+
+
+def test_postgres_public_api_surface() -> None:
+    import onestep_postgres
+
+    missing = POSTGRES_REQUIRED_PUBLIC - set(dir(onestep_postgres))
+    assert not missing, f"onestep_postgres missing public symbols: {sorted(missing)}"
+    assert onestep_postgres.register is onestep_postgres.register_resources
+
+
+def test_mysql_submodule_import_paths() -> None:
+    for submodule in MYSQL_SUBMODULES:
+        module = importlib.import_module(f"onestep_mysql.{submodule}")
+        assert module is not None
+
+
+def test_postgres_submodule_import_paths() -> None:
+    for submodule in POSTGRES_SUBMODULES:
+        module = importlib.import_module(f"onestep_postgres.{submodule}")
+        assert module is not None


### PR DESCRIPTION
## Summary

Adds Phase 0 baseline + contract tests for the `onestep-mysql` / `onestep-postgres` plugins (tracking issue #133; design in PR #134).

These pin the **current** public contract so the later `onestep-sql` consolidation cannot silently alter:
- the 14 YAML resource type names (7 MySQL + 7 PostgreSQL) and their catalog roles / fields / defaults / connector boundaries (golden snapshot `tests/contract/snapshots/sql_resource_catalog.json`),
- idempotent re-registration (no duplicate types),
- the public Python API surface exported from each package,
- the historical submodule import paths (`connector`/`resources`/`resilience`/`state_sqlalchemy`, plus postgres `execution_*`).

No live database is required — all assertions are structural. The full install-permutation / duplicate-registration matrix is intentionally left to Phase 3 (CI + `scripts/run-integration-tests.sh`).

## Validation
`pytest tests/contract/test_sql_resource_contract.py` → 7 passed.

## Acceptance (design §10 Phase 0 exit)
Two plugins have a complete baseline under the current structure; tests prove current YAML/API compatibility and the duplicate-registration failure mode.

## Next
Phase 1 (canonical `onestep-sql` package) to follow.