### PR TITLE
feat: Phase 3 — switch consumers to onestep-sql, retire legacy entry points (#133)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,11 @@ When updating this file, preserve this bar for all agents and keep entries conci
 
 ## onestep-sql consolidation (issue #133)
 
-- Authoritative design: `docs/superpowers/specs/2026-08-20-onestep-sql-consolidation-design.md` + execution tasks doc beside it. Phase 2 (shared extraction) is merged; Phase 3 (forwarding distributions, root extras, worker, CI merge) is next.
+- Authoritative design: `docs/superpowers/specs/2026-08-20-onestep-sql-consolidation-design.md` + execution tasks doc beside it. Phases 0–3 are merged; Phase 4 (docs adoption) and Phase 5 (deprecation closeout) remain.
+- `onestep-sql` is the canonical distribution for MySQL **and** PostgreSQL. Root extras `mysql`/`postgres`/`sql`/`all`/`dev`/`integration` resolve through `onestep-sql[mysql,postgres]`. New code: `pip install 'onestep-sql[mysql]'` and import from `onestep_sql.mysql` / `onestep_sql.postgres`.
+- Legacy `onestep-mysql` (0.7.0) / `onestep-postgres` (0.6.0) are thin forwarding shims: no `onestep.resources` entry point, depend on `onestep-sql[mysql,sqlite]` / `onestep-sql[postgres,sqlite]`. The single `sql` entry point on `onestep-sql` registers all 14 YAML types, so new+old install permutations never double-register. `from onestep_mysql import ...` / `from onestep_postgres import ...` keep working via `sys.modules` forwarders with object identity.
 - Shared SQL behaviour lives once in `plugins/onestep-sql/src/onestep_sql/_shared/` (`state_sqlalchemy`, `table_sink_policy`, `state_keys`, `resilience`). Backend adapters keep only driver mapping, install hints, dialect error-classification tables, `__init__` validation order, `_build_statement` SQL dialect branches, binlog (mysql) and tracked execution (postgres).
 - `scripts/check_plugin_drift.py` and its CI job are retired; the replacement guardrail is `tests/contract/test_onestep_sql_shared.py` (dual-backend identity + behaviour proofs). Extend it when moving another parallel pair into `_shared`.
+- `tests/contract/test_official_connector_conformance.py` derives the official connector set from plugins that still declare `[project.entry-points."onestep.resources"]`; the `sql` profile owns MySQL+PostgreSQL conformance since the shims dropped their entry points.
 - Plugin test dirs share basenames (e.g. `test_state_sqlalchemy.py`), so run each plugin suite in its own pytest process — see `scripts/run-reliability-checks.sh`.
-- Legacy `onestep-mysql`/`onestep-postgres` are `sys.modules` forwarders onto `onestep_sql.*`; keep object identity when refactoring canonical modules.
+- Migration guide: `docs/guide/migrate-to-onestep-sql.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,39 @@
   (`tests/contract/test_onestep_sql_shared.py`) that pin the shared behaviour
   for both backends.
 
+## onestep-sql 0.1.0
+
+- First release of the canonical, unified MySQL **and** PostgreSQL connector
+  distribution for onestep (issue #133, design PR #134). `onestep-sql` is the
+  single package that registers all 14 existing YAML resource types
+  (`mysql_*`, `postgres_*`) through one `sql` entry point, with `mysql`,
+  `postgres`, `sqlite`, and `all` extras. New code should install
+  `onestep-sql[mysql]` / `onestep-sql[postgres]` and import from
+  `onestep_sql.mysql` / `onestep_sql.postgres`. Runtime behaviour, YAML names,
+  catalog roles, fields, defaults, and connector boundaries are unchanged; the
+  previously separate `onestep-mysql` / `onestep-postgres` distributions remain
+  available as thin forwarding shims without their own resource entry points.
+
+## onestep-mysql 0.7.0
+
+- Converts `onestep-mysql` into a thin forwarding distribution that delegates to
+  the canonical `onestep-sql` package (issue #133, Phase 3). The package no
+  longer declares its own `onestep.resources` entry point; installing it pulls
+  `onestep-sql[mysql,sqlite]` and re-exports the public API from
+  `onestep_sql.mysql` with object identity preserved. Existing
+  `from onestep_mysql import ...` imports and YAML configurations keep working
+  unchanged. Prefer `onestep-sql[mysql]` for new deployments.
+
+## onestep-postgres 0.6.0
+
+- Converts `onestep-postgres` into a thin forwarding distribution that delegates
+  to the canonical `onestep-sql` package (issue #133, Phase 3). The package no
+  longer declares its own `onestep.resources` entry point; installing it pulls
+  `onestep-sql[postgres,sqlite]` and re-exports the public API from
+  `onestep_sql.postgres` with object identity preserved. Existing
+  `from onestep_postgres import ...` imports and YAML configurations keep
+  working unchanged. Prefer `onestep-sql[postgres]` for new deployments.
+
 ## onestep-postgres 0.5.0
 
 - Ports incremental source commit-waves, retry rows, and failure fencing from

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ Each backend ships as its own package so you only install what you use:
 | --- | --- | --- |
 | **core** | `MemoryQueue`, `IntervalSource`, `CronSource`, `WebhookSource`, `http_sink`, runtime | `pip install onestep` |
 | **Control plane** | reporter telemetry and remote commands | `pip install 'onestep[control-plane]'` |
-| **MySQL** | `table_queue`, `incremental`, binlog CDC, `table_sink`, state/cursor stores | `pip install onestep-mysql` |
-| **PostgreSQL** | same primitives as MySQL, backed by PostgreSQL | `pip install onestep-postgres` |
+| **MySQL** | `table_queue`, `incremental`, binlog CDC, `table_sink`, state/cursor stores | `pip install 'onestep-sql[mysql]'` (`onestep-mysql` shim available) |
+| **PostgreSQL** | same primitives as MySQL, backed by PostgreSQL | `pip install 'onestep-sql[postgres]'` (`onestep-postgres` shim available) |
 | **RabbitMQ** | `queue` with exchange/routing-key binding and prefetch | `pip install onestep-mq` |
 | **Redis** | `stream` with consumer groups, `XACK`, `XCLAIM`, `maxlen` | `pip install onestep-redis` |
 | **SQS** | `queue` with batched deletes and heartbeat visibility | `pip install onestep-sqs` |
@@ -242,6 +242,15 @@ Or install everything at once:
 ```bash
 pip install 'onestep[all]'
 ```
+
+> **MySQL/PostgreSQL consolidation (issue #133):** `onestep-sql` is now the
+> canonical distribution for both MySQL and PostgreSQL. New deployments should
+> install `onestep-sql[mysql]` / `onestep-sql[postgres]` (or `onestep[mysql]` /
+> `onestep[postgres]`). The legacy `onestep-mysql` / `onestep-postgres` packages
+> remain available as thin forwarding shims — existing `pip install
+> onestep-mysql` and `from onestep_mysql import ...` imports keep working
+> unchanged. All 14 YAML resource type names are unchanged. See
+> [the migration guide](docs/guide/migrate-to-onestep-sql.md) for details.
 
 ## Configuration styles
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -201,8 +201,8 @@ async def main():
 | 包 | 提供 | 安装 |
 | --- | --- | --- |
 | **核心** | `MemoryQueue`、`IntervalSource`、`CronSource`、`WebhookSource`、`http_sink`、运行时、Reporter | `pip install onestep` |
-| **MySQL** | `table_queue`、`incremental`、binlog CDC、`table_sink`、state/cursor store | `pip install onestep-mysql` |
-| **PostgreSQL** | 与 MySQL 对等的原语，后端为 PostgreSQL | `pip install onestep-postgres` |
+| **MySQL** | `table_queue`、`incremental`、binlog CDC、`table_sink`、state/cursor store | `pip install 'onestep-sql[mysql]'`（`onestep-mysql` shim 仍可用） |
+| **PostgreSQL** | 与 MySQL 对等的原语，后端为 PostgreSQL | `pip install 'onestep-sql[postgres]'`（`onestep-postgres` shim 仍可用） |
 | **RabbitMQ** | `queue`，支持 exchange/routing-key 绑定与 prefetch | `pip install onestep-mq` |
 | **Redis** | `stream`，支持消费组、`XACK`、`XCLAIM`、`maxlen` | `pip install onestep-redis` |
 | **SQS** | `queue`，支持批量删除与心跳可见性续期 | `pip install onestep-sqs` |

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -74,6 +74,7 @@ export default defineConfig({
           { text: '功能特性', link: '/guide/features' },
           { text: '生产部署', link: '/guide/deploy' },
           { text: 'Worker Runtime Image', link: '/guide/worker-runtime-image' },
+          { text: '迁移到 onestep-sql', link: '/guide/migrate-to-onestep-sql' },
         ],
       },
       {

--- a/docs/broker/index.md
+++ b/docs/broker/index.md
@@ -35,8 +35,8 @@ onestep 1.x 使用 `Source` 表示输入，使用 `Sink` 表示输出。很多�
 
 | 连接器 | Source | Sink | 描述 |
 |--------|--------|------|------|
-| [MySQL](/broker/mysql) | 支持 | 支持 | 表队列/增量同步/binlog CDC/表输出，安装 `onestep-mysql` |
-| [PostgreSQL](/broker/postgres) | 支持 | 支持 | 表队列/增量同步/表输出，安装 `onestep-postgres` |
+| [MySQL](/broker/mysql) | 支持 | 支持 | 表队列/增量同步/binlog CDC/表输出，安装 `onestep-sql[mysql]` |
+| [PostgreSQL](/broker/postgres) | 支持 | 支持 | 表队列/增量同步/表输出，安装 `onestep-sql[postgres]` |
 | [Feishu Bitable](/broker/feishu-bitable) | 支持 | 支持 | 飞书多维表格增量同步/表输出，安装 `onestep-feishu-bitable` |
 
 ### Web

--- a/docs/broker/mysql.md
+++ b/docs/broker/mysql.md
@@ -13,8 +13,12 @@ MySQL Connector 提供三种模式：
 ## 安装
 
 ```bash
-pip install onestep-mysql
+pip install 'onestep-sql[mysql]'
+# 或使用 core extra
+# pip install 'onestep[mysql]'
 ```
+
+> `onestep-sql` 是 MySQL 与 PostgreSQL 的规范发行包（issue #133）。旧的 `pip install onestep-mysql` 仍可用作转发 shim，但新部署建议使用 `onestep-sql[mysql]`。所有 YAML 资源类型名不变。
 
 ## 表队列 (Table Queue)
 

--- a/docs/broker/postgres-execution.md
+++ b/docs/broker/postgres-execution.md
@@ -5,7 +5,7 @@ outline: deep
 
 # PostgreSQL Tracked Execution
 
-本文说明 `onestep==1.9.0` 和 `onestep-postgres==0.2.0` 都发布后，业务系统如何把 PostgreSQL 用作长任务的提交、状态、结果、取消和租约存储。
+本文说明 `onestep==1.9.0` 和 `onestep-sql[postgres]==0.1.0` 都发布后，业务系统如何把 PostgreSQL 用作长任务的提交、状态、结果、取消和租约存储。
 
 适用场景：HTTP 请求提交一个可能运行数秒、数分钟甚至更久的任务，API 需要返回任务 ID，业务端再查询状态或结果。典型例子包括 Agent、报表生成、文件处理、异步导入和批量同步。
 
@@ -17,9 +17,9 @@ outline: deep
 | --- | --- | --- |
 | 继续使用普通 queue、schedule、webhook | `onestep==1.9.0` | 不需要 |
 | 继续使用旧 PostgreSQL table queue、incremental、state 或 sink | `onestep==1.9.0` + 兼容的 PostgreSQL plugin | 通常不需要 |
-| 使用本页的提交、查询、结果和取消能力 | `onestep==1.9.0` + `onestep-postgres==0.2.0` | 需要按本文部署 API 和 worker |
+| 使用本页的提交、查询、结果和取消能力 | `onestep==1.9.0` + `onestep-sql[postgres]==0.1.0` | 需要按本文部署 API 和 worker |
 
-`onestep-postgres==0.2.0` 依赖 `onestep>=1.9.0`，不能与 `onestep==1.8.1` 组合。反过来，只发布或安装 `onestep==1.9.0` 不会自动启用 tracked execution；没有安装 PostgreSQL plugin 的普通 worker 可以照常运行。
+`onestep-sql[postgres]==0.1.0` 依赖 `onestep>=1.9.0`，不能与 `onestep==1.8.1` 组合。反过来，只发布或安装 `onestep==1.9.0` 不会自动启用 tracked execution；没有安装 PostgreSQL plugin 的普通 worker 可以照常运行。
 
 ## 1. 运行架构
 
@@ -51,10 +51,10 @@ POST /executions/{id}/cancel         heartbeat + lease completion
 两个包都发布后，参与同一条 execution 链路的 API 和 worker 使用同一组锁定版本：
 
 ```bash
-pip install "onestep==1.9.0" "onestep-postgres==0.2.0"
+pip install "onestep==1.9.0" "onestep-sql[postgres]==0.1.0"
 ```
 
-也可以使用 core 的 extra。注意 extra 声明的是 `onestep-postgres>=0.2.0`；生产环境仍建议通过 lockfile 固定最终解析版本：
+也可以使用 core 的 extra。注意 extra 声明的是 `onestep-sql[postgres]>=0.1.0`；生产环境仍建议通过 lockfile 固定最终解析版本：
 
 ```bash
 pip install "onestep[postgres]==1.9.0"
@@ -63,16 +63,18 @@ pip install "onestep[postgres]==1.9.0"
 项目使用 uv 时：
 
 ```bash
-uv add "onestep==1.9.0" "onestep-postgres==0.2.0"
-uv run python -c "import onestep, onestep_postgres; print(onestep.__version__, onestep_postgres.__version__)"
+uv add "onestep==1.9.0" "onestep-sql[postgres]==0.1.0"
+uv run python -c "import onestep, onestep_sql.postgres; print(onestep.__version__, onestep_sql.postgres.__version__)"
 uv run pip check
 ```
+
+> `onestep-sql` 是 MySQL 与 PostgreSQL 的规范发行包（issue #133）。旧的 `onestep-postgres` 仍可用作转发 shim，但新部署建议使用 `onestep-sql[postgres]`。Python 导入路径 `from onestep_postgres import ...` 保持兼容。
 
 发布顺序必须是：
 
 1. 发布 `onestep==1.9.0`。
 2. 确认 `onestep==1.9.0` 已经可以从 PyPI 安装。
-3. 发布 `onestep-postgres==0.2.0`。
+3. 发布 `onestep-sql==0.1.0`（含 PostgreSQL 后端）。
 4. 锁定依赖，完成数据库初始化。
 5. 先部署 worker 并确认能连接数据库，再开放 API 提交入口。
 6. 避免同一业务链路长期运行混合版本。
@@ -690,9 +692,9 @@ ORDER BY attempt_no;
 
 上线前按顺序确认：
 
-- [ ] PyPI 中同时存在 `onestep==1.9.0` 和 `onestep-postgres==0.2.0`。
+- [ ] PyPI 中同时存在 `onestep==1.9.0` 和 `onestep-sql==0.1.0`（含 PostgreSQL 后端）。
 - [ ] API 和 worker 的 `pip check` 通过，两个进程使用相同版本组合。
-- [ ] API 和 worker 都打印并核对过 `onestep`、`onestep-postgres` 的实际版本。
+- [ ] API 和 worker 都打印并核对过 `onestep`、`onestep_sql.postgres` 的实际版本。
 - [ ] 以 migration 身份完成 execution 两张表的初始化。
 - [ ] API 和 worker 都使用 `auto_create=False`。
 - [ ] API 和 worker 的 DSN、namespace、表名一致。
@@ -719,7 +721,7 @@ ORDER BY attempt_no;
 
 1. 先停止 API 继续提交新的 tracked execution。
 2. 等待或人工处理当前 `running`、`cancel_requested` 和 `retrying` 记录。
-3. API 和 worker 一起回滚到兼容的 core/plugin 版本，例如 `onestep==1.8.1` 与 `onestep-postgres==0.1.3`。
+3. API 和 worker 一起回滚到兼容的 core/plugin 版本，例如 `onestep==1.8.1` 与 `onestep-postgres==0.1.3`（旧转发 shim 仍可安装）。
 4. 保留 `onestep_executions` 和 `onestep_execution_attempts` 表，不要直接 drop。它们包含审计和恢复信息。
 5. 如果恢复到新版本，先执行 smoke test，再重新放开业务提交。
 

--- a/docs/broker/postgres.md
+++ b/docs/broker/postgres.md
@@ -12,8 +12,12 @@ outline: deep
 ## 安装
 
 ```bash
-pip install onestep-postgres
+pip install 'onestep-sql[postgres]'
+# 或使用 core extra
+# pip install 'onestep[postgres]'
 ```
+
+> `onestep-sql` 是 MySQL 与 PostgreSQL 的规范发行包（issue #133）。旧的 `pip install onestep-postgres` 仍可用作转发 shim，但新部署建议使用 `onestep-sql[postgres]`。所有 YAML 资源类型名不变。
 
 ## 基本用法
 

--- a/docs/guide/migrate-to-onestep-sql.md
+++ b/docs/guide/migrate-to-onestep-sql.md
@@ -1,0 +1,117 @@
+---
+title: 迁移到 onestep-sql
+outline: deep
+---
+
+# 迁移到 onestep-sql
+
+`onestep-sql` 是 MySQL 与 PostgreSQL 的规范发行包（tracking issue #133，
+[设计文档](../superpowers/specs/2026-08-20-onestep-sql-consolidation-design.md)）。
+它把原先分开的 `onestep-mysql` 与 `onestep-postgres` 收敛为一个包、一个
+namespace（`onestep_sql`）和一套共用 SQL 行为实现。
+
+本页说明如何从旧发行包迁移到 `onestep-sql`，以及旧安装在新版本下如何继续工作。
+
+## 是否需要立即迁移
+
+不需要。旧发行包 `onestep-mysql` / `onestep-postgres` 仍以薄转发 shim 的形式
+发布，并保持至少「六个月或两个 feature releases，以较晚者为准」的兼容窗口：
+
+- `pip install onestep-mysql` 仍可安装，并自动拉取 `onestep-sql[mysql,sqlite]`。
+- `from onestep_mysql import MySQLConnector` 等导入路径保持对象 identity 兼容。
+- 所有 14 个 YAML 资源类型名（`mysql_*`、`postgres_*`）不变。
+- 旧 shim 不再声明自己的 `onestep.resources` entry point；资源注册由
+  `onestep-sql` 的单一 `sql` entry point 统一完成，因此新旧同装不会重复注册。
+
+新部署和新文档示例建议直接使用 `onestep-sql`。
+
+## 安装
+
+| 场景 | 旧命令 | 新命令（推荐） |
+| --- | --- | --- |
+| MySQL | `pip install onestep-mysql` | `pip install 'onestep-sql[mysql]'` |
+| PostgreSQL | `pip install onestep-postgres` | `pip install 'onestep-sql[postgres]'` |
+| 两者 | 分别安装两个旧包 | `pip install 'onestep-sql[mysql,postgres]'` |
+| 通过 core extra | `pip install 'onestep[mysql]'` | 不变（extra 现在解析到 `onestep-sql`） |
+| 全部连接器 | `pip install 'onestep[all]'` | 不变 |
+
+`onestep[mysql]`、`onestep[postgres]`、`onestep[sql]`、`onestep[all]`、
+`onestep[dev]`、`onestep[integration]` 这些 core extra 现在都解析到
+`onestep-sql`，无需修改 `pyproject.toml` 中的 `pip install 'onestep[...]'`。
+
+## Python 导入
+
+新代码应从规范 namespace 导入：
+
+```python
+# MySQL
+from onestep_sql.mysql import MySQLConnector, BinlogSource, TableSink
+
+# PostgreSQL
+from onestep_sql.postgres import PostgresConnector, PostgresExecutionSource
+```
+
+旧导入路径保持兼容（转发 shim 保证对象 identity）：
+
+```python
+# 仍可用，等价于上面的导入
+from onestep_mysql import MySQLConnector, BinlogSource, TableSink
+from onestep_postgres import PostgresConnector, PostgresExecutionSource
+```
+
+## YAML 配置
+
+**无需改动。** 所有 YAML 资源类型名、字段、默认值、catalog role 和 connector
+boundary 全部不变。`onestep-sql` 通过单一 `sql` entry point 注册全部 14 个类型，
+YAML loader 自动发现。
+
+```yaml
+resources:
+  db:
+    type: mysql          # 名字不变
+    dsn: "${MYSQL_DSN}"
+  cursor:
+    type: mysql_cursor_store
+    connector: db
+  users:
+    type: mysql_incremental
+    connector: db
+    table: users
+    key: id
+    cursor: [updated_at, id]
+    state: cursor
+```
+
+## 后端专属能力边界
+
+合并不是把 MySQL 与 PostgreSQL 当作可互换后端：
+
+- `mysql_binlog` 始终是 MySQL 专属（依赖同步 `mysql-replication`）。
+- `postgres_execution_source` / tracked execution 始终是 PostgreSQL 专属
+  （依赖 PostgreSQL 事务/锁/lease 语义）。
+
+这两项不会出现在另一后端的 namespace 中。
+
+## Worker 镜像
+
+`onestep-worker` 镜像已经包含 `onestep-sql`、`onestep-mysql`、`onestep-postgres`
+三个包。`onestep[all]` 现在通过 `onestep-sql` 解析 MySQL/PostgreSQL 依赖，无需
+修改 worker YAML 或挂载的 `requirements.txt`。
+
+## 迁移检查清单
+
+- [ ] 新部署使用 `pip install 'onestep-sql[mysql]'` / `'onestep-sql[postgres]'`。
+- [ ] 新代码从 `onestep_sql.mysql` / `onestep_sql.postgres` 导入。
+- [ ] 现有 `pip install onestep-mysql` / `onestep-postgres` 仍可安装。
+- [ ] 现有 `from onestep_mysql import ...` / `from onestep_postgres import ...` 仍可导入。
+- [ ] YAML 资源类型名、字段、默认值未变。
+- [ ] `pip check` 通过，没有版本冲突。
+- [ ] 同一环境安装新旧包时不会重复注册资源类型（由 `onestep-sql` 单一 entry point 保证）。
+
+## 参考
+
+- [设计文档](../superpowers/specs/2026-08-20-onestep-sql-consolidation-design.md)
+- [MySQL 连接器](/broker/mysql)
+- [PostgreSQL 连接器](/broker/postgres)
+- [PostgreSQL Tracked Execution](/broker/postgres-execution)
+- [CHANGELOG](https://github.com/mic1on/onestep/blob/main/CHANGELOG.md)

--- a/docs/yaml-task-definition.md
+++ b/docs/yaml-task-definition.md
@@ -682,7 +682,7 @@ Plugin resource types:
 
 - `onestep-elasticsearch`: `elasticsearch`, `elasticsearch_bulk_sink`
 - `onestep-clickhouse`: `clickhouse`, `clickhouse_table_sink`
-- `onestep-mysql`: `mysql`, `mysql_state_store`, `mysql_cursor_store`, `mysql_table_queue`, `mysql_incremental`, `mysql_table_sink`
+- `onestep-sql`: `mysql`, `mysql_state_store`, `mysql_cursor_store`, `mysql_table_queue`, `mysql_incremental`, `mysql_table_sink`, `mysql_binlog`, `postgres`, `postgres_state_store`, `postgres_cursor_store`, `postgres_table_queue`, `postgres_incremental`, `postgres_table_sink`, `postgres_execution_source` (legacy `onestep-mysql` / `onestep-postgres` shims still register the same types via `onestep-sql`)
 - `onestep-mq`: `rabbitmq`, `rabbitmq_queue`
 - `onestep-redis`: `redis`, `redis_stream`
 - `onestep-sqs`: `sqs`, `sqs_queue`

--- a/plugins/onestep-mysql/README.md
+++ b/plugins/onestep-mysql/README.md
@@ -1,9 +1,20 @@
 # onestep-mysql
 
+> **Deprecation notice (issue #133):** `onestep-mysql` is now a thin forwarding
+> shim that delegates to the canonical [`onestep-sql`](https://pypi.org/project/onestep-sql/)
+> package. New deployments should install `onestep-sql[mysql]` (or `onestep[mysql]`)
+> and import from `onestep_sql.mysql`. This package remains available so existing
+> `pip install onestep-mysql` and `from onestep_mysql import ...` keep working
+> unchanged; it no longer declares its own resource entry point. All 14 YAML
+> resource type names are unchanged. See the
+> [migration guide](../../docs/guide/migrate-to-onestep-sql.md) for details.
+
 MySQL connector plugin for `onestep`.
 
 ```bash
 pip install onestep-mysql
+# or the canonical package
+# pip install 'onestep-sql[mysql]'
 ```
 
 The package registers these YAML resource types through the `onestep.resources`

--- a/plugins/onestep-mysql/pyproject.toml
+++ b/plugins/onestep-mysql/pyproject.toml
@@ -1,17 +1,13 @@
 [project]
 name = "onestep-mysql"
-version = "0.6.1"
+version = "0.7.0"
 description = "MySQL connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }
 dependencies = [
     "onestep>=1.7.3",
-    "onestep-sql>=0.1.0",
-    "SQLAlchemy[asyncio]>=2.0.0",
-    "asyncmy>=0.2.10",
-    "aiosqlite>=0.20.0",
-    "mysql-replication>=1.0.15",
+    "onestep-sql[mysql,sqlite]>=0.1.0",
 ]
 
 [project.optional-dependencies]
@@ -23,9 +19,6 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
 ]
-
-[project.entry-points."onestep.resources"]
-mysql = "onestep_mysql:register"
 
 [build-system]
 requires = ["hatchling"]

--- a/plugins/onestep-mysql/src/onestep_mysql/__init__.py
+++ b/plugins/onestep-mysql/src/onestep_mysql/__init__.py
@@ -4,4 +4,4 @@
 # replacement while the MySQL+PostgreSQL consolidation lands.
 from onestep_sql.mysql import *  # noqa: F401,F403
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"

--- a/plugins/onestep-mysql/tests/test_mysql_plugin.py
+++ b/plugins/onestep-mysql/tests/test_mysql_plugin.py
@@ -29,12 +29,20 @@ from onestep.resilience import (
 from onestep.resource_registry import ResourceRegistry
 
 
-def test_package_exposes_onestep_resource_entry_point() -> None:
+def test_package_does_not_declare_its_own_resource_entry_point() -> None:
+    """Phase 3 (issue #133): onestep-mysql is a thin forwarding shim and must
+    not auto-register resource types. The canonical onestep-sql package owns
+    the single `sql` entry point that registers all 14 MySQL + PostgreSQL
+    types."""
     entry_points = _entry_points_for_group("onestep.resources")
 
+    assert not any(
+        entry_point.value.startswith("onestep_mysql:")
+        for entry_point in entry_points
+    )
     assert any(
-        entry_point.name == "mysql"
-        and entry_point.value == "onestep_mysql:register"
+        entry_point.name == "sql"
+        and entry_point.value == "onestep_sql:register_resources"
         for entry_point in entry_points
     )
 

--- a/plugins/onestep-postgres/README.md
+++ b/plugins/onestep-postgres/README.md
@@ -1,11 +1,23 @@
 # onestep-postgres
 
+> **Deprecation notice (issue #133):** `onestep-postgres` is now a thin
+> forwarding shim that delegates to the canonical
+> [`onestep-sql`](https://pypi.org/project/onestep-sql/) package. New deployments
+> should install `onestep-sql[postgres]` (or `onestep[postgres]`) and import from
+> `onestep_sql.postgres`. This package remains available so existing
+> `pip install onestep-postgres` and `from onestep_postgres import ...` keep
+> working unchanged; it no longer declares its own resource entry point. All 14
+> YAML resource type names are unchanged. See the
+> [migration guide](../../docs/guide/migrate-to-onestep-sql.md) for details.
+
 PostgreSQL connector plugin for onestep.
 
 Install it with:
 
 ```bash
 pip install onestep-postgres
+# or the canonical package
+# pip install 'onestep-sql[postgres]'
 ```
 
 YAML resources are available after the plugin is installed:

--- a/plugins/onestep-postgres/pyproject.toml
+++ b/plugins/onestep-postgres/pyproject.toml
@@ -1,16 +1,13 @@
 [project]
 name = "onestep-postgres"
-version = "0.5.0"
+version = "0.6.0"
 description = "PostgreSQL connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }
 dependencies = [
     "onestep>=1.9.0",
-    "onestep-sql>=0.1.0",
-    "SQLAlchemy[asyncio]>=2.0.0",
-    "psycopg[binary]>=3.2.0",
-    "aiosqlite>=0.20.0",
+    "onestep-sql[postgres,sqlite]>=0.1.0",
 ]
 
 [project.optional-dependencies]
@@ -22,9 +19,6 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
 ]
-
-[project.entry-points."onestep.resources"]
-postgres = "onestep_postgres:register"
 
 [build-system]
 requires = ["hatchling"]

--- a/plugins/onestep-postgres/src/onestep_postgres/__init__.py
+++ b/plugins/onestep-postgres/src/onestep_postgres/__init__.py
@@ -4,4 +4,4 @@
 # replacement while the MySQL+PostgreSQL consolidation lands.
 from onestep_sql.postgres import *  # noqa: F401,F403
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/plugins/onestep-postgres/tests/test_postgres_plugin.py
+++ b/plugins/onestep-postgres/tests/test_postgres_plugin.py
@@ -27,12 +27,20 @@ from onestep_postgres.resilience import (
 )
 
 
-def test_package_exposes_onestep_resource_entry_point() -> None:
+def test_package_does_not_declare_its_own_resource_entry_point() -> None:
+    """Phase 3 (issue #133): onestep-postgres is a thin forwarding shim and
+    must not auto-register resource types. The canonical onestep-sql package
+    owns the single `sql` entry point that registers all 14 MySQL + PostgreSQL
+    types."""
     entry_points = _entry_points_for_group("onestep.resources")
 
+    assert not any(
+        entry_point.value.startswith("onestep_postgres:")
+        for entry_point in entry_points
+    )
     assert any(
-        entry_point.name == "postgres"
-        and entry_point.value == "onestep_postgres:register"
+        entry_point.name == "sql"
+        and entry_point.value == "onestep_sql:register_resources"
         for entry_point in entry_points
     )
 

--- a/plugins/onestep-sql/README.md
+++ b/plugins/onestep-sql/README.md
@@ -11,15 +11,20 @@ namespace (`onestep_sql`). It is introduced incrementally per
 
 ## Status
 
-**Phase 1 — canonical package without changing consumers.**
+**Phase 3 — canonical distribution; legacy packages are thin forwarding shims.**
 
-* `onestep-sql[mysql]`, `[postgres]`, and `[all]` build, discover their
-  resources, and pass their suites.
-* `onestep_sql.mysql` and `onestep_sql.postgres` carry the copied, unchanged
-  implementations of the legacy packages.
-* The legacy `onestep-mysql` / `onestep-postgres` distributions still exist and
-  remain the recommended install until the later phases switch first-party
-  consumers over (Phase 3) and update the docs (Phase 4).
+* `onestep-sql[mysql]`, `[postgres]`, `[sqlite]`, and `[all]` build, discover
+  their resources, and pass their suites.
+* `onestep_sql.mysql` and `onestep_sql.postgres` carry the canonical
+  implementations; shared SQL behaviour lives once in `onestep_sql._shared`.
+* The root `onestep` extras (`mysql`, `postgres`, `sql`, `all`, `dev`,
+  `integration`) resolve through `onestep-sql`.
+* The legacy `onestep-mysql` / `onestep-postgres` distributions remain
+  available as thin forwarding shims without their own resource entry points;
+  existing `pip install onestep-mysql` and `from onestep_mysql import ...`
+  imports keep working unchanged.
+* All 14 YAML resource type names, catalog roles, fields, defaults, and
+  connector boundaries are unchanged.
 
 ## Install
 

--- a/plugins/onestep-sql/pyproject.toml
+++ b/plugins/onestep-sql/pyproject.toml
@@ -19,10 +19,14 @@ mysql = [
 postgres = [
     "psycopg[binary]>=3.2.0",
 ]
+sqlite = [
+    "aiosqlite>=0.20.0",
+]
 all = [
     "asyncmy>=0.2.10",
     "mysql-replication>=1.0.15",
     "psycopg[binary]>=3.2.0",
+    "aiosqlite>=0.20.0",
 ]
 test = [
     "pytest>=8.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,13 @@ yaml = [
     "PyYAML>=6.0",
 ]
 mysql = [
-    "onestep-mysql>=0.3.3",
+    "onestep-sql[mysql]>=0.1.0",
 ]
 postgres = [
-    "onestep-postgres>=0.2.0",
+    "onestep-sql[postgres]>=0.1.0",
+]
+sql = [
+    "onestep-sql[mysql,postgres]>=0.1.0",
 ]
 rabbitmq = [
     "onestep-mq>=0.2.1",
@@ -68,8 +71,7 @@ integration = [
     "PyYAML>=6.0",
     "onestep-mq>=0.2.1",
     "onestep-redis>=0.2.1",
-    "onestep-mysql>=0.3.3",
-    "onestep-postgres>=0.2.0",
+    "onestep-sql[mysql,postgres]>=0.1.0",
     "onestep-sqs>=0.2.2",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
@@ -81,8 +83,7 @@ all = [
     "PyYAML>=6.0",
     "onestep-mq>=0.2.1",
     "onestep-redis>=0.2.1",
-    "onestep-mysql>=0.3.3",
-    "onestep-postgres>=0.2.0",
+    "onestep-sql[mysql,postgres]>=0.1.0",
     "onestep-sqs>=0.2.2",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
@@ -96,8 +97,7 @@ dev = [
     "PyYAML>=6.0",
     "onestep-mq>=0.2.1",
     "onestep-redis>=0.2.1",
-    "onestep-mysql>=0.3.3",
-    "onestep-postgres>=0.2.0",
+    "onestep-sql[mysql,postgres]>=0.1.0",
     "onestep-sqs>=0.2.2",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
@@ -126,8 +126,6 @@ members = [
 [tool.uv.sources]
 onestep-mq = { workspace = true }
 onestep-redis = { workspace = true }
-onestep-mysql = { workspace = true }
-onestep-postgres = { workspace = true }
 onestep-sqs = { workspace = true }
 onestep-control-plane = { workspace = true }
 onestep-kafka = { path = "plugins/onestep-kafka" }

--- a/skills/onestep/references/connectors.md
+++ b/skills/onestep/references/connectors.md
@@ -4,10 +4,11 @@ Use this reference when wiring onestep resources to queues, polling backends, sc
 
 ## General Rules
 
-- Install only the needed package: `onestep-mysql`, `onestep-postgres`,
-  `onestep-mq`, `onestep-redis`, `onestep-sqs`, `onestep-kafka`,
-  `onestep-elasticsearch`, `onestep-clickhouse`, `onestep-mongodb`, or
-  `onestep[yaml]`.
+- Install only the needed package: `onestep-sql[mysql]`,
+  `onestep-sql[postgres]`, `onestep-mq`, `onestep-redis`, `onestep-sqs`,
+  `onestep-kafka`, `onestep-elasticsearch`, `onestep-clickhouse`,
+  `onestep-mongodb`, or `onestep[yaml]`. Legacy `onestep-mysql` /
+  `onestep-postgres` shims still work (issue #133).
 - Prefer environment variables for DSNs, tokens, and queue URLs in YAML.
 - In YAML, define shared connection resources first, then sources/sinks that reference them by name.
 - Keep connector options minimal until the deployment requires tuning.

--- a/skills/onestep/references/quickstart.md
+++ b/skills/onestep/references/quickstart.md
@@ -14,7 +14,7 @@ Common extras and connector plugins:
 
 ```bash
 pip install 'onestep[yaml]'
-pip install onestep-mysql
+pip install 'onestep-sql[mysql]'
 pip install onestep-mq
 pip install onestep-redis
 pip install onestep-sqs

--- a/skills/onestep/references/yaml-task-definition.md
+++ b/skills/onestep/references/yaml-task-definition.md
@@ -301,7 +301,7 @@ Plugin resource types:
 
 - `onestep-elasticsearch`: `elasticsearch`, `elasticsearch_bulk_sink`
 - `onestep-clickhouse`: `clickhouse`, `clickhouse_table_sink`
-- `onestep-mysql`: `mysql`, `mysql_state_store`, `mysql_cursor_store`, `mysql_table_queue`, `mysql_incremental`, `mysql_table_sink`
+- `onestep-sql`: `mysql`, `mysql_state_store`, `mysql_cursor_store`, `mysql_table_queue`, `mysql_incremental`, `mysql_table_sink`, `mysql_binlog`, `postgres`, `postgres_state_store`, `postgres_cursor_store`, `postgres_table_queue`, `postgres_incremental`, `postgres_table_sink`, `postgres_execution_source` (legacy `onestep-mysql` / `onestep-postgres` shims register the same types via `onestep-sql`)
 - `onestep-mq`: `rabbitmq`, `rabbitmq_queue`
 - `onestep-redis`: `redis`, `redis_stream`
 - `onestep-sqs`: `sqs`, `sqs_queue`

--- a/tests/contract/test_official_connector_conformance.py
+++ b/tests/contract/test_official_connector_conformance.py
@@ -104,52 +104,14 @@ PROFILES = (
         },
     ),
     ConnectorConformanceProfile(
-        name="mysql",
-        contracts={
-            Capability.BASIC_SOURCE: (
-                "plugins/onestep-mysql/tests/test_mysql_table_queue.py::test_mysql_table_queue_round_trip",
-            ),
-            Capability.CHECKPOINT_SOURCE: (
-                "plugins/onestep-mysql/tests/test_mysql_incremental.py::test_mysql_incremental_cursor_advances_in_order",
-                "plugins/onestep-mysql/tests/test_mysql_binlog.py::test_mysql_binlog_cursor_advances_in_order",
-            ),
-            Capability.CLAIMED_SOURCE: (
-                "plugins/onestep-mysql/tests/test_mysql_runtime_contract.py::test_table_queue_stop_controls_release_claimed_rows",
-            ),
-            Capability.ACKNOWLEDGED_SINK: (
-                "plugins/onestep-mysql/tests/test_mysql_table_queue.py::test_mysql_table_queue_round_trip",
-            ),
-            Capability.PUBLIC_ERRORS: (
-                "plugins/onestep-mysql/tests/test_mysql_plugin.py::test_mysql_connector_error_does_not_leak_dsn_credentials",
-            ),
-        },
-    ),
-    ConnectorConformanceProfile(
-        name="postgres",
-        contracts={
-            Capability.BASIC_SOURCE: (
-                "plugins/onestep-postgres/tests/test_postgres_table_queue.py::test_postgres_table_queue_round_trip",
-            ),
-            Capability.CHECKPOINT_SOURCE: (
-                "plugins/onestep-postgres/tests/test_postgres_incremental.py::test_postgres_incremental_cursor_advances_in_order",
-            ),
-            Capability.CLAIMED_SOURCE: (
-                "plugins/onestep-postgres/tests/test_postgres_runtime_contract.py::test_table_queue_stop_controls_release_claimed_rows",
-            ),
-            Capability.ACKNOWLEDGED_SINK: (
-                "plugins/onestep-postgres/tests/test_postgres_table_queue.py::test_postgres_table_queue_round_trip",
-            ),
-            Capability.PUBLIC_ERRORS: (
-                "plugins/onestep-postgres/tests/test_postgres_plugin.py::test_postgres_connector_error_does_not_leak_dsn_credentials",
-            ),
-        },
-    ),
-    ConnectorConformanceProfile(
         name="sql",
         contracts={
             # The canonical onestep-sql package is the Phase 1 consolidation of
             # onestep-mysql + onestep-postgres; its conformance is the union of
-            # both backends (issue #133, design PR #134).
+            # both backends (issue #133, design PR #134). The legacy
+            # onestep-mysql / onestep-postgres distributions became thin
+            # forwarding shims in Phase 3 and no longer declare their own
+            # resource entry points, so their conformance is owned here.
             Capability.BASIC_SOURCE: (
                 "plugins/onestep-mysql/tests/test_mysql_table_queue.py::test_mysql_table_queue_round_trip",
                 "plugins/onestep-postgres/tests/test_postgres_table_queue.py::test_postgres_table_queue_round_trip",

--- a/uv.lock
+++ b/uv.lock
@@ -1342,9 +1342,8 @@ all = [
     { name = "onestep-kafka", marker = "python_full_version >= '3.10'" },
     { name = "onestep-mongodb" },
     { name = "onestep-mq" },
-    { name = "onestep-mysql" },
-    { name = "onestep-postgres" },
     { name = "onestep-redis" },
+    { name = "onestep-sql", extra = ["mysql", "postgres"] },
     { name = "onestep-sqs" },
     { name = "pyyaml" },
 ]
@@ -1361,9 +1360,8 @@ dev = [
     { name = "onestep-kafka", marker = "python_full_version >= '3.10'" },
     { name = "onestep-mongodb" },
     { name = "onestep-mq" },
-    { name = "onestep-mysql" },
-    { name = "onestep-postgres" },
     { name = "onestep-redis" },
+    { name = "onestep-sql", extra = ["mysql", "postgres"] },
     { name = "onestep-sqs" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -1380,9 +1378,8 @@ integration = [
     { name = "onestep-kafka", marker = "python_full_version >= '3.10'" },
     { name = "onestep-mongodb" },
     { name = "onestep-mq" },
-    { name = "onestep-mysql" },
-    { name = "onestep-postgres" },
     { name = "onestep-redis" },
+    { name = "onestep-sql", extra = ["mysql", "postgres"] },
     { name = "onestep-sqs" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -1397,16 +1394,19 @@ mongodb = [
     { name = "onestep-mongodb" },
 ]
 mysql = [
-    { name = "onestep-mysql" },
+    { name = "onestep-sql", extra = ["mysql"] },
 ]
 postgres = [
-    { name = "onestep-postgres" },
+    { name = "onestep-sql", extra = ["postgres"] },
 ]
 rabbitmq = [
     { name = "onestep-mq" },
 ]
 redis = [
     { name = "onestep-redis" },
+]
+sql = [
+    { name = "onestep-sql", extra = ["mysql", "postgres"] },
 ]
 sqs = [
     { name = "onestep-sqs" },
@@ -1447,18 +1447,16 @@ requires-dist = [
     { name = "onestep-mq", marker = "extra == 'dev'", editable = "plugins/onestep-rabbitmq" },
     { name = "onestep-mq", marker = "extra == 'integration'", editable = "plugins/onestep-rabbitmq" },
     { name = "onestep-mq", marker = "extra == 'rabbitmq'", editable = "plugins/onestep-rabbitmq" },
-    { name = "onestep-mysql", marker = "extra == 'all'", editable = "plugins/onestep-mysql" },
-    { name = "onestep-mysql", marker = "extra == 'dev'", editable = "plugins/onestep-mysql" },
-    { name = "onestep-mysql", marker = "extra == 'integration'", editable = "plugins/onestep-mysql" },
-    { name = "onestep-mysql", marker = "extra == 'mysql'", editable = "plugins/onestep-mysql" },
-    { name = "onestep-postgres", marker = "extra == 'all'", editable = "plugins/onestep-postgres" },
-    { name = "onestep-postgres", marker = "extra == 'dev'", editable = "plugins/onestep-postgres" },
-    { name = "onestep-postgres", marker = "extra == 'integration'", editable = "plugins/onestep-postgres" },
-    { name = "onestep-postgres", marker = "extra == 'postgres'", editable = "plugins/onestep-postgres" },
     { name = "onestep-redis", marker = "extra == 'all'", editable = "plugins/onestep-redis" },
     { name = "onestep-redis", marker = "extra == 'dev'", editable = "plugins/onestep-redis" },
     { name = "onestep-redis", marker = "extra == 'integration'", editable = "plugins/onestep-redis" },
     { name = "onestep-redis", marker = "extra == 'redis'", editable = "plugins/onestep-redis" },
+    { name = "onestep-sql", extras = ["mysql"], marker = "extra == 'mysql'", editable = "plugins/onestep-sql" },
+    { name = "onestep-sql", extras = ["mysql", "postgres"], marker = "extra == 'all'", editable = "plugins/onestep-sql" },
+    { name = "onestep-sql", extras = ["mysql", "postgres"], marker = "extra == 'dev'", editable = "plugins/onestep-sql" },
+    { name = "onestep-sql", extras = ["mysql", "postgres"], marker = "extra == 'integration'", editable = "plugins/onestep-sql" },
+    { name = "onestep-sql", extras = ["mysql", "postgres"], marker = "extra == 'sql'", editable = "plugins/onestep-sql" },
+    { name = "onestep-sql", extras = ["postgres"], marker = "extra == 'postgres'", editable = "plugins/onestep-sql" },
     { name = "onestep-sqs", marker = "extra == 'all'", editable = "plugins/onestep-sqs" },
     { name = "onestep-sqs", marker = "extra == 'dev'", editable = "plugins/onestep-sqs" },
     { name = "onestep-sqs", marker = "extra == 'integration'", editable = "plugins/onestep-sqs" },
@@ -1475,7 +1473,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'test'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0" },
 ]
-provides-extras = ["control-plane", "yaml", "mysql", "postgres", "rabbitmq", "redis", "sqs", "kafka", "elasticsearch", "clickhouse", "mongodb", "test", "integration", "all", "dev"]
+provides-extras = ["control-plane", "yaml", "mysql", "postgres", "sql", "rabbitmq", "redis", "sqs", "kafka", "elasticsearch", "clickhouse", "mongodb", "test", "integration", "all", "dev"]
 
 [[package]]
 name = "onestep-clickhouse"
@@ -1690,15 +1688,11 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-mysql"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "plugins/onestep-mysql" }
 dependencies = [
-    { name = "aiosqlite" },
-    { name = "asyncmy" },
-    { name = "mysql-replication" },
     { name = "onestep" },
-    { name = "onestep-sql" },
-    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "onestep-sql", extra = ["mysql", "sqlite"] },
 ]
 
 [package.optional-dependencies]
@@ -1717,30 +1711,22 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiosqlite", specifier = ">=0.20.0" },
-    { name = "asyncmy", specifier = ">=0.2.10" },
-    { name = "mysql-replication", specifier = ">=1.0.15" },
     { name = "onestep", editable = "." },
-    { name = "onestep-sql", editable = "plugins/onestep-sql" },
+    { name = "onestep-sql", extras = ["mysql", "sqlite"], editable = "plugins/onestep-sql" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
-    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
 ]
 provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-postgres"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "plugins/onestep-postgres" }
 dependencies = [
-    { name = "aiosqlite" },
     { name = "onestep" },
-    { name = "onestep-sql" },
-    { name = "psycopg", version = "3.2.13", source = { registry = "https://pypi.org/simple" }, extra = ["binary"], marker = "python_full_version < '3.10'" },
-    { name = "psycopg", version = "3.3.4", source = { registry = "https://pypi.org/simple" }, extra = ["binary"], marker = "python_full_version >= '3.10'" },
-    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "onestep-sql", extra = ["postgres", "sqlite"] },
 ]
 
 [package.optional-dependencies]
@@ -1759,15 +1745,12 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "onestep", editable = "." },
-    { name = "onestep-sql", editable = "plugins/onestep-sql" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
+    { name = "onestep-sql", extras = ["postgres", "sqlite"], editable = "plugins/onestep-sql" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
-    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
 ]
 provides-extras = ["test", "dev"]
 
@@ -1822,6 +1805,7 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "aiosqlite" },
     { name = "asyncmy" },
     { name = "mysql-replication" },
     { name = "psycopg", version = "3.2.13", source = { registry = "https://pypi.org/simple" }, extra = ["binary"], marker = "python_full_version < '3.10'" },
@@ -1841,6 +1825,9 @@ postgres = [
     { name = "psycopg", version = "3.2.13", source = { registry = "https://pypi.org/simple" }, extra = ["binary"], marker = "python_full_version < '3.10'" },
     { name = "psycopg", version = "3.3.4", source = { registry = "https://pypi.org/simple" }, extra = ["binary"], marker = "python_full_version >= '3.10'" },
 ]
+sqlite = [
+    { name = "aiosqlite" },
+]
 test = [
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -1851,6 +1838,8 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "aiosqlite", marker = "extra == 'all'", specifier = ">=0.20.0" },
+    { name = "aiosqlite", marker = "extra == 'sqlite'", specifier = ">=0.20.0" },
     { name = "asyncmy", marker = "extra == 'all'", specifier = ">=0.2.10" },
     { name = "asyncmy", marker = "extra == 'mysql'", specifier = ">=0.2.10" },
     { name = "mysql-replication", marker = "extra == 'all'", specifier = ">=1.0.15" },
@@ -1864,7 +1853,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
 ]
-provides-extras = ["mysql", "postgres", "all", "test", "dev"]
+provides-extras = ["mysql", "postgres", "sqlite", "all", "test", "dev"]
 
 [[package]]
 name = "onestep-sqs"


### PR DESCRIPTION
## Summary

Phase 3 of the onestep-sql consolidation (tracking issue #133, [design doc](../docs/superpowers/specs/2026-08-20-onestep-sql-consolidation-design.md), execution plan PR #135). Phases 0–2 are already merged to main. Phase 3 switches first-party consumers and infrastructure to the canonical `onestep-sql` package and converts the legacy distributions into pure forwarding shims.

## Changes

### Packaging
- **Root `pyproject.toml`**: the `mysql`, `postgres`, `all`, `dev`, and `integration` extras now resolve through `onestep-sql[mysql,postgres]`; add a new `sql` extra (`onestep-sql[mysql,postgres]>=0.1.0`). Remove `onestep-mysql` / `onestep-postgres` from `[tool.uv.sources]` — nothing depends on those package names anymore.
- **`onestep-sql` 0.1.0**: gains a `sqlite` extra (`aiosqlite>=0.20.0`) so the shims can declare `onestep-sql[mysql,sqlite]` / `onestep-sql[postgres,sqlite]`.
- **`onestep-mysql` 0.7.0** and **`onestep-postgres` 0.6.0**: become thin forwarding shims. They drop their `[project.entry-points."onestep.resources"]` section and depend on `onestep-sql[mysql,sqlite]` / `onestep-sql[postgres,sqlite]` only. Installing a shim pulls the canonical package, which owns the single `sql` entry point that registers all 14 YAML resource types. New + old install permutations no longer double-register handlers.
- Regenerate `uv.lock`.

### Tests
- Update `plugins/onestep-mysql/tests/test_mysql_plugin.py` and `plugins/onestep-postgres/tests/test_postgres_plugin.py` to assert the shim no longer declares its own resource entry point and that the canonical `sql` entry point (`onestep_sql:register_resources`) is present.
- Drop the standalone `mysql` / `postgres` conformance profiles from `tests/contract/test_official_connector_conformance.py`: those distributions no longer declare entry points, so their conformance is owned by the single `sql` profile (which already references the same unit contracts).

### Docs
- `README.md` / `README.zh-CN.md`: present `onestep-sql` as the preferred distribution with a backward-compat note for legacy installs.
- `docs/broker/{mysql,postgres,postgres-execution,index}.md`: update install/import references to `onestep-sql`.
- `docs/yaml-task-definition.md`: list `onestep-sql` as the SQL plugin.
- New `docs/guide/migrate-to-onestep-sql.md` migration guide, wired into the VitePress sidebar.
- Plugin READMEs: add deprecation notices pointing to `onestep-sql`.
- `onestep-sql` README: bump status to Phase 3.
- `skills/onestep` references: update install/type listings.

### Worker image
- `docker/worker/Dockerfile` is unchanged from Phase 1 (it already copies and installs `onestep-sql`, `onestep-mysql`, `onestep-postgres`). The root `[all]` extra now pulls `onestep-sql` via the new extras, and the explicit pip install of the shim packages still works for forwarding.

## Hard constraints (unchanged)
- All 14 YAML resource type names, catalog roles, fields, defaults — unchanged (Phase 0 contract tests enforce this).
- Public API and legacy import paths remain functional (forwarders preserve object identity).
- No runtime behavior changes to MySQL/PostgreSQL sources/sinks.
- `mysql_binlog` stays mysql-only; PostgreSQL tracked execution stays postgres-only.

## Validation
- Root + contract tests: `uv run --all-packages python -m pytest tests/ -q -x -m "not integration"` → 561 passed
- MySQL plugin tests: 78 passed, 1 skipped
- PostgreSQL plugin tests: 142 passed, 2 skipped
- Contract suites (`tests/contract/`): 192 passed
- Wheel builds for `onestep-sql`, `onestep-mysql`, `onestep-postgres` + `twine check`: all PASSED
- `uv lock --check`: passes
- VitePress docs build: passes

## Note on no-mistakes pipeline
The no-mistakes pipeline could not complete: the review and test steps both failed because the agent binaries (codex, claude) cannot connect to their APIs (`ConnectionRefused` / `stream disconnected`). This is a daemon-level infrastructure issue (the daemon process inherited stale `http_proxy`/`https_proxy` env vars pointing at a down proxy on `127.0.0.1:7890`), not a code issue. Per the task brief, the remaining steps (test, build, push, PR) were run manually with the full validation suite above.

Closes #133 (Phase 3).
