### PR TITLE
ci: add onestep-sql PyPI release workflow

### DIFF
--- a/.github/workflows/plugin-sql.yml
+++ b/.github/workflows/plugin-sql.yml
@@ -1,0 +1,235 @@
+name: SQL Plugin
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/plugin-sql.yml"
+      - "plugins/onestep-sql/**"
+      - "src/**"
+      - "pyproject.toml"
+  pull_request:
+    paths:
+      - ".github/workflows/plugin-sql.yml"
+      - "plugins/onestep-sql/**"
+      - "src/**"
+      - "pyproject.toml"
+  workflow_dispatch:
+    inputs:
+      publish_pypi:
+        description: "Publish the current onestep-sql version to PyPI"
+        required: false
+        default: false
+        type: boolean
+      version:
+        description: "Optional expected plugin version, for example 0.1.0"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sql-plugin-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PLUGIN_PACKAGE: onestep-sql
+  PLUGIN_PATH: plugins/onestep-sql
+  PLUGIN_PYPROJECT: plugins/onestep-sql/pyproject.toml
+
+jobs:
+  test:
+    name: Test plugin (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install plugin test dependencies
+        run: uv sync --frozen --all-packages --extra test
+
+      - name: Run plugin tests
+        run: uv run --all-packages python -m pytest -q tests/contract/test_onestep_sql_canonical.py tests/contract/test_onestep_sql_shared.py
+
+      - name: Build plugin distribution
+        run: uv build --package "$PLUGIN_PACKAGE" --out-dir dist/plugin --sdist --wheel --clear
+
+      - name: Check plugin metadata
+        run: uvx twine check dist/plugin/*
+
+  detect-version:
+    name: Detect plugin version change
+    runs-on: ubuntu-latest
+    outputs:
+      current_version: ${{ steps.detect.outputs.current_version }}
+      previous_version: ${{ steps.detect.outputs.previous_version }}
+      should_publish: ${{ steps.detect.outputs.should_publish }}
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Detect version change
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          INPUT_PUBLISH_PYPI: ${{ github.event.inputs.publish_pypi || 'false' }}
+          INPUT_VERSION: ${{ github.event.inputs.version || '' }}
+        run: |
+          set -euo pipefail
+
+          read_version() {
+            python3 -c 'import pathlib, re, sys; text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"); match = re.search(r"(?m)^version\s*=\s*\"([^\"]+)\"", text); print(match.group(1) if match else sys.exit(f"project.version not found in {sys.argv[1]}"))' "$1"
+          }
+
+          CURRENT_VERSION="$(read_version "$PLUGIN_PYPROJECT")"
+          PREVIOUS_VERSION=""
+          SHOULD_PUBLISH=false
+          PROJECT_EXISTS_ON_PYPI=false
+          VERSION_EXISTS_ON_PYPI=false
+          PYPI_STATUS=unknown
+
+          PYPI_STATUS="$(python3 - "$CURRENT_VERSION" "$PLUGIN_PACKAGE" <<'PY'
+          import json
+          import socket
+          import sys
+          import urllib.error
+          import urllib.request
+
+          version = sys.argv[1]
+          package = sys.argv[2]
+          try:
+              with urllib.request.urlopen(f"https://pypi.org/pypi/{package}/json", timeout=20) as response:
+                  releases = json.load(response).get("releases", {})
+          except urllib.error.HTTPError as exc:
+              if exc.code == 404:
+                  print("missing-project")
+                  raise SystemExit(0)
+              print("unknown")
+              raise SystemExit(0)
+          except (TimeoutError, socket.timeout, urllib.error.URLError):
+              print("unknown")
+              raise SystemExit(0)
+          print("version-exists" if releases.get(version) else "missing-version")
+          PY
+          )"
+
+          if [ "$PYPI_STATUS" = "version-exists" ]; then
+            PROJECT_EXISTS_ON_PYPI=true
+            VERSION_EXISTS_ON_PYPI=true
+          elif [ "$PYPI_STATUS" = "missing-version" ]; then
+            PROJECT_EXISTS_ON_PYPI=true
+          fi
+
+          if [ "$EVENT_NAME" = "push" ]; then
+            if [ "$PYPI_STATUS" = "unknown" ]; then
+              echo "::notice::Could not determine PyPI status for $PLUGIN_PACKAGE. Skipping automatic publish on push; use workflow_dispatch with publish_pypi=true when PyPI is healthy."
+            fi
+
+            if [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+              if git cat-file -e "$BEFORE_SHA:$PLUGIN_PYPROJECT" 2>/dev/null; then
+                git show "$BEFORE_SHA:$PLUGIN_PYPROJECT" > /tmp/previous-plugin-pyproject.toml
+                PREVIOUS_VERSION="$(read_version /tmp/previous-plugin-pyproject.toml)"
+              fi
+            fi
+
+            if [ "$PYPI_STATUS" = "unknown" ]; then
+              SHOULD_PUBLISH=false
+            elif [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
+              SHOULD_PUBLISH=true
+            elif [ "$VERSION_EXISTS_ON_PYPI" != "true" ]; then
+              SHOULD_PUBLISH=true
+            fi
+          elif [ "$INPUT_PUBLISH_PYPI" = "true" ]; then
+            if [ -n "$INPUT_VERSION" ] && [ "$INPUT_VERSION" != "$CURRENT_VERSION" ]; then
+              echo "Requested plugin version '$INPUT_VERSION' does not match current version '$CURRENT_VERSION'." >&2
+              exit 1
+            fi
+            SHOULD_PUBLISH=true
+          fi
+
+          {
+            echo "current_version=$CURRENT_VERSION"
+            echo "previous_version=$PREVIOUS_VERSION"
+            echo "should_publish=$SHOULD_PUBLISH"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Current plugin version: $CURRENT_VERSION"
+          echo "Previous plugin version: ${PREVIOUS_VERSION:-<none>}"
+          echo "PyPI status: $PYPI_STATUS"
+          echo "Project exists on PyPI: $PROJECT_EXISTS_ON_PYPI"
+          echo "Version exists on PyPI: $VERSION_EXISTS_ON_PYPI"
+          echo "Publish plugin: $SHOULD_PUBLISH"
+
+  publish-pypi:
+    name: Publish plugin to PyPI
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - detect-version
+    if: >-
+      ${{
+        needs.test.result == 'success' &&
+        needs.detect-version.outputs.should_publish == 'true'
+      }}
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build plugin distribution
+        run: uv build --package "$PLUGIN_PACKAGE" --out-dir dist/plugin --sdist --wheel --clear
+
+      - name: Check plugin metadata
+        run: uvx twine check dist/plugin/*
+
+      - name: Verify onestep dependency is published
+        run: |
+          set -euo pipefail
+
+          REQUIRED_ONESTEP_VERSION="$(
+            python3 -c 'import pathlib, re, sys; text = pathlib.Path("plugins/onestep-sql/pyproject.toml").read_text(encoding="utf-8"); match = re.search(r"onestep\s*>=\s*([0-9]+(?:\.[0-9]+)*(?:[A-Za-z0-9._+-]*)?)", text); print(match.group(1) if match else sys.exit("onestep dependency must be pinned as onestep>=<version>"))'
+          )"
+
+          python3 -c 'import json, sys, urllib.request; version = sys.argv[1]; releases = json.load(urllib.request.urlopen("https://pypi.org/pypi/onestep/json", timeout=20)).get("releases", {}); sys.exit(f"onestep=={version} is not published on PyPI yet; publish the core package before publishing the plugin.") if not releases.get(version) else print(f"onestep=={version} is available on PyPI.")' "$REQUIRED_ONESTEP_VERSION"
+
+      - name: Publish plugin to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/plugin
+          skip-existing: true


### PR DESCRIPTION
## Intent

Add a dedicated GitHub Actions workflow at .github/workflows/plugin-sql.yml for the canonical onestep-sql plugin, following existing plugin release workflow conventions. Trigger on pushes and pull requests affecting the workflow, plugins/onestep-sql/**, src/**, or pyproject.toml. Provide workflow_dispatch inputs for publish_pypi and an optional expected version. Test the plugin on Python 3.9 through 3.12, build the distribution, and run metadata checks. Detect the current package version and whether the project/version exists on PyPI, publishing on a main push when the package/version is missing or the version changed, and publishing when manually requested. Publish onestep-sql with trusted publishing after successful tests and dependency verification. Use PLUGIN_PACKAGE=onestep-sql, PLUGIN_PATH=plugins/onestep-sql, and PLUGIN_PYPROJECT=plugins/onestep-sql/pyproject.toml. Do not modify application/runtime code or unrelated workflows. The package is version 0.1.0 and is not yet present on PyPI; the workflow must safely handle a missing project and must depend only on the already-published core onestep package, not on an already-published onestep-sql package.

## What Changed

- Added a dedicated GitHub Actions workflow for testing and building the canonical `onestep-sql` plugin across Python3.9–3.12, with distribution and metadata checks.
- Added push, pull request, and manual dispatch controls for version-aware release decisions, including safe handling when the package is not yet on PyPI.
- Added conditional trusted publishing for `onestep-sql` after successful tests and dependency verification.

## Risk Assessment

🚨 High: Source risk is unknown because the review phase could not inspect the branch diff or validate the workflow against the required acceptance criteria.

## Testing

No baseline, automated, manual, build, metadata, or evidence-producing validation could be completed because the command runner aborted every attempted execution immediately; no evidence artifacts were produced.

- Outcome: ⚠️ 1 warning across 1 run (2m55s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ Review could not be completed because the command execution tool repeatedly returned `aborted` before any repository diff, workflow file, or skill instruction could be read. No source-verifiable defect was established.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ I could not complete the assigned test phase because every command-execution attempt in this environment was aborted immediately, including a no-op probe. That prevented repository inspection, targeted test execution, build/metadata verification, and creation of reviewer-visible evidence for the GitHub Actions workflow behavior.
- <code>Attempted to read required OneStep skill guidance with `sed -n &#39;1,240p&#39; /Users/miclon/.agents/skills/onestep/SKILL.md`; execution was aborted before output.</code>
- <code>Attempted repository/environment probe with `pwd`; execution was aborted before output.</code>
- <code>Attempted no-op command runner probe via `text(&#39;hello&#39;)`; execution was aborted before output.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ Unable to inspect or lint the workflow because every exec attempt was aborted by the tool harness; no documentation or lint changes could be verified in this phase.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
