### PR TITLE
feat(sql): add public SQLite backend to onestep-sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,26 @@
   (`tests/contract/test_onestep_sql_shared.py`) that pin the shared behaviour
   for both backends.
 
+## onestep-sql 0.2.0
+
+- Publicly exposes the SQLite backend of the canonical `onestep-sql` package
+  (issue #141). `onestep-sql[sqlite]` now installs the `sqlite` asyncio extra
+  and registers six new YAML resource types through the single `sql` entry
+  point: `sqlite`, `sqlite_state_store`, `sqlite_cursor_store`,
+  `sqlite_table_queue`, `sqlite_incremental`, and `sqlite_table_sink`. SQLite is
+  embedded (no server): it reuses the shared SQLAlchemy state/cursor stores,
+  table-sink policy, and incremental commit-coalescing logic, and adds no
+  binlog CDC or tracked-execution capability.
+- Fixes a `sqlite_table_queue` claim race. MySQL/PostgreSQL claim rows with
+  `SELECT ... FOR UPDATE SKIP LOCKED`; SQLite now claims and reads in one atomic
+  `UPDATE ... RETURNING` statement so the write lock is held for the whole claim
+  and two consumers can never deliver the same rows (previously a concurrent
+  poll could double-claim). The returned delivery body is the post-claim row,
+  matching the MySQL/PostgreSQL envelope contract.
+- Maps `sqlite` / `sqlite+pysqlite` DSNs (and a bare file path or `:memory:`)
+  onto the `sqlite+aiosqlite` dialect, with a 30s busy timeout and no
+  `pool_pre_ping`, so a bare path no longer silently skips the engine tuning.
+
 ## onestep-sql 0.1.0
 
 - First release of the canonical, unified MySQL **and** PostgreSQL connector

--- a/plugins/onestep-sql/pyproject.toml
+++ b/plugins/onestep-sql/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "onestep-sql"
-version = "0.1.0"
-description = "Unified MySQL and PostgreSQL connector plugin for onestep."
+version = "0.2.0"
+description = "Unified MySQL, PostgreSQL, and SQLite connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }

--- a/plugins/onestep-sql/src/onestep_sql/__init__.py
+++ b/plugins/onestep-sql/src/onestep_sql/__init__.py
@@ -2,20 +2,22 @@ from __future__ import annotations
 
 from onestep.resource_registry import ResourceRegistry
 
-from . import mysql, postgres
+from . import mysql, postgres, sqlite
 from .mysql import register_resources as _register_mysql
 from .postgres import register_resources as _register_postgres
+from .sqlite import register_resources as _register_sqlite
 
-__all__ = ["register_resources", "mysql", "postgres"]
+__all__ = ["register_resources", "mysql", "postgres", "sqlite"]
 
 
 def register_resources(registry: ResourceRegistry) -> None:
-    """Register every onestep-sql resource type (MySQL + PostgreSQL).
+    """Register every onestep-sql resource type (MySQL + PostgreSQL + SQLite).
 
     This is the single entry point for the canonical ``onestep-sql``
     distribution (declared as ``sql`` in the ``onestep.resources`` group).
     It delegates to the per-backend registrars without changing any of the
-    14 existing YAML type names, their catalog roles, or their fields.
+    existing YAML type names, their catalog roles, or their fields.
     """
     _register_mysql(registry)
     _register_postgres(registry)
+    _register_sqlite(registry)

--- a/plugins/onestep-sql/src/onestep_sql/sqlite/__init__.py
+++ b/plugins/onestep-sql/src/onestep_sql/sqlite/__init__.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _package_version
+
+from .connector import (
+    IncrementalDelivery,
+    IncrementalTableSource,
+    SQLiteConnector,
+    TableQueueDelivery,
+    TableQueueSource,
+    TableSink,
+)
+from .resilience import classify_sqlalchemy_error
+from .resources import register_resources
+from .state_sqlalchemy import SQLAlchemyCursorStore, SQLAlchemyStateStore
+
+try:
+    __version__ = _package_version("onestep-sql")
+except PackageNotFoundError:  # pragma: no cover - local source tree before install
+    __version__ = "dev"
+
+register = register_resources
+
+__all__ = [
+    "IncrementalDelivery",
+    "IncrementalTableSource",
+    "SQLAlchemyCursorStore",
+    "SQLAlchemyStateStore",
+    "SQLiteConnector",
+    "TableQueueDelivery",
+    "TableQueueSource",
+    "TableSink",
+    "__version__",
+    "classify_sqlalchemy_error",
+    "register",
+    "register_resources",
+]

--- a/plugins/onestep-sql/src/onestep_sql/sqlite/connector.py
+++ b/plugins/onestep-sql/src/onestep_sql/sqlite/connector.py
@@ -1,0 +1,755 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import deque
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from onestep.connectors.base import Delivery, Sink, Source
+from onestep.envelope import Envelope
+from onestep.resilience import (
+    ConnectorErrorKind,
+    ConnectorOperation,
+    ConnectorOperationError,
+)
+from onestep.state import CursorStore, InMemoryCursorStore
+from onestep_sql._shared.state_keys import _default_incremental_state_key
+from onestep_sql._shared.table_sink_policy import (
+    TableSinkUpdatePolicy,
+    _normalize_update_columns,
+)
+
+from .resilience import as_sqlite_connector_operation_error, collect_sensitive_tokens
+from .state_sqlalchemy import SQLAlchemyCursorStore, SQLAlchemyStateStore, _async_dsn
+
+logger = logging.getLogger(__name__)
+
+try:
+    import sqlalchemy as sa
+    from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+except ImportError:  # pragma: no cover - exercised when optional deps are missing
+    sa = None
+    AsyncEngine = None
+    create_async_engine = None
+
+
+def _normalize_dsn(dsn: str) -> str:
+    """Accept a bare file path or a ``sqlite://`` URL and return an async URL."""
+    if "://" not in dsn:
+        from pathlib import Path
+
+        return f"sqlite+aiosqlite:///{Path(dsn).resolve()}"
+    return _async_dsn(dsn)
+
+
+class SQLiteConnector:
+    def __init__(self, dsn: str, **engine_options: Any) -> None:
+        if create_async_engine is None:
+            raise RuntimeError("SQLiteConnector requires SQLAlchemy. Install onestep-sql with the 'sqlite' extra.")
+        self.dsn = dsn
+        self._sensitive_tokens = collect_sensitive_tokens(dsn, engine_options)
+        parsed = urlparse(dsn)
+        if parsed.scheme.startswith("sqlite"):
+            # File-based single-writer backend: tolerate busy writers and do not
+            # ping (sqlite has no server).
+            engine_options.setdefault("connect_args", {})
+            engine_options["connect_args"].setdefault("timeout", 30)
+            engine_options.pop("pool_pre_ping", None)
+            if parsed.path in ("", "/:memory:", ":memory:"):
+                from sqlalchemy.pool import StaticPool
+
+                engine_options.setdefault("poolclass", StaticPool)
+        self.engine: AsyncEngine = create_async_engine(_normalize_dsn(dsn), **engine_options)
+        self._tables: dict[str, Any] = {}
+        self._table_lock: asyncio.Lock | None = None
+
+    def _secret_tokens(self) -> list[str]:
+        """Secret-bearing config tokens used to scrub error messages."""
+        return list(self._sensitive_tokens)
+
+    async def close(self) -> None:
+        await self.engine.dispose()
+
+    def state_store(
+        self,
+        *,
+        table: str = "onestep_state",
+        key_column: str = "state_key",
+        value_column: str = "state_value",
+        updated_at_column: str = "updated_at",
+        auto_create: bool = True,
+    ) -> SQLAlchemyStateStore:
+        return SQLAlchemyStateStore(
+            engine=self.engine,
+            table=table,
+            key_column=key_column,
+            value_column=value_column,
+            updated_at_column=updated_at_column,
+            auto_create=auto_create,
+        )
+
+    def cursor_store(
+        self,
+        *,
+        table: str = "onestep_cursor",
+        key_column: str = "cursor_key",
+        value_column: str = "cursor_value",
+        updated_at_column: str = "updated_at",
+        auto_create: bool = True,
+    ) -> SQLAlchemyCursorStore:
+        return SQLAlchemyCursorStore(
+            engine=self.engine,
+            table=table,
+            key_column=key_column,
+            value_column=value_column,
+            updated_at_column=updated_at_column,
+            auto_create=auto_create,
+        )
+
+    def table_queue(
+        self,
+        *,
+        table: str,
+        key: str,
+        where: str,
+        claim: Mapping[str, Any],
+        ack: Mapping[str, Any],
+        nack: Mapping[str, Any] | None = None,
+        batch_size: int = 100,
+        poll_interval_s: float = 1.0,
+    ) -> TableQueueSource:
+        return TableQueueSource(
+            connector=self,
+            table=table,
+            key=key,
+            where=where,
+            claim=dict(claim),
+            ack=dict(ack),
+            nack=dict(nack or {}),
+            batch_size=batch_size,
+            poll_interval_s=poll_interval_s,
+        )
+
+    def incremental(
+        self,
+        *,
+        table: str,
+        key: str,
+        cursor: Sequence[str],
+        where: str | None = None,
+        batch_size: int = 1000,
+        poll_interval_s: float = 1.0,
+        state: CursorStore | None = None,
+        state_key: str | None = None,
+    ) -> IncrementalTableSource:
+        if len(cursor) < 1:
+            raise ValueError("cursor must contain at least one column")
+        effective_cursor = tuple(cursor) if key in cursor else (*tuple(cursor), key)
+        return IncrementalTableSource(
+            connector=self,
+            table=table,
+            key=key,
+            cursor=effective_cursor,
+            where=where,
+            batch_size=batch_size,
+            poll_interval_s=poll_interval_s,
+            state=state or InMemoryCursorStore(),
+            state_key=state_key or _default_incremental_state_key(
+                table=table,
+                cursor=effective_cursor,
+                key=key,
+                where=where,
+            ),
+        )
+
+    def table_sink(
+        self,
+        *,
+        table: str,
+        mode: str = "insert",
+        keys: Sequence[str] = (),
+        update_columns: Sequence[str | Mapping[str, str]] | None = None,
+        update_expr: Mapping[str, str] | None = None,
+        serialize_json: str = "auto",
+    ) -> TableSink:
+        return TableSink(
+            connector=self,
+            table=table,
+            mode=mode,
+            keys=tuple(keys),
+            update_columns=tuple(update_columns) if update_columns is not None else None,
+            update_expr=update_expr,
+            serialize_json=serialize_json,
+        )
+
+    async def _table(self, table_name: str):
+        table = self._tables.get(table_name)
+        if table is None:
+            lock = self._table_lock
+            if lock is None:
+                lock = asyncio.Lock()
+                self._table_lock = lock
+            async with lock:
+                table = self._tables.get(table_name)
+                if table is None:
+                    metadata = sa.MetaData()
+                    async with self.engine.connect() as conn:
+                        table = await conn.run_sync(
+                            lambda sync_conn: sa.Table(
+                                table_name, metadata, autoload_with=sync_conn
+                            )
+                        )
+                    self._tables[table_name] = table
+        return table
+
+
+@dataclass
+class _TableRowRef:
+    table: str
+    key: str
+    key_value: Any
+
+
+class TableQueueDelivery(Delivery):
+    def __init__(self, source: TableQueueSource, envelope: Envelope, row_ref: _TableRowRef) -> None:
+        super().__init__(envelope)
+        self._source = source
+        self._row_ref = row_ref
+
+    async def update_current_row(self, values: Mapping[str, Any]) -> None:
+        payload = dict(values)
+        await self._source.update_row(self._row_ref, payload)
+        if isinstance(self.envelope.body, dict):
+            self.envelope.body.update(payload)
+
+    async def ack(self) -> None:
+        await self._source.ack_row(self._row_ref)
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        await self._source.retry_row(self._row_ref, delay_s=delay_s)
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        await self._source.fail_row(self._row_ref, exc=exc)
+
+    async def release_unstarted(self) -> None:
+        await self._source.release_row(self._row_ref)
+
+
+class TableQueueSource(Source):
+    fetch_is_cancel_safe = False
+
+    def __init__(
+        self,
+        *,
+        connector: SQLiteConnector,
+        table: str,
+        key: str,
+        where: str,
+        claim: dict[str, Any],
+        ack: dict[str, Any],
+        nack: dict[str, Any],
+        batch_size: int,
+        poll_interval_s: float,
+    ) -> None:
+        super().__init__(f"sqlite.table_queue:{table}")
+        self.connector = connector
+        self.table_name = table
+        self.key = key
+        self.where = where
+        self.claim = claim
+        self.ack = ack
+        self.nack = nack
+        self.batch_size = batch_size
+        self.poll_interval_s = poll_interval_s
+
+    async def fetch(self, limit: int) -> list[Delivery]:
+        try:
+            rows = await self._fetch(max(1, min(limit, self.batch_size)))
+        except Exception as exc:
+            connector_error = as_sqlite_connector_operation_error(
+                operation=ConnectorOperation.FETCH,
+                exc=exc,
+                source_name=self.name,
+                retry_delay_s=self.poll_interval_s,
+                secrets=self.connector._secret_tokens(),
+            )
+            if connector_error is None:
+                raise
+            raise connector_error from exc
+        deliveries: list[Delivery] = []
+        for row in rows:
+            key_value = row[self.key]
+            envelope = Envelope(body=row, meta={"table": self.table_name})
+            row_ref = _TableRowRef(self.table_name, self.key, key_value)
+            deliveries.append(TableQueueDelivery(self, envelope, row_ref))
+        return deliveries
+
+    async def _fetch(self, limit: int) -> list[dict[str, Any]]:
+        table = await self.connector._table(self.table_name)
+        async with self.connector.engine.begin() as conn:
+            stmt = sa.select(table).where(sa.text(self.where)).order_by(table.c[self.key]).limit(limit)
+            rows = (await conn.execute(stmt)).mappings().all()
+            if not rows:
+                return []
+            ids = [row[self.key] for row in rows]
+            await conn.execute(sa.update(table).where(table.c[self.key].in_(ids)).values(**self.claim))
+        return [dict(row) for row in rows]
+
+    async def ack_row(self, row_ref: _TableRowRef) -> None:
+        await self.update_row(row_ref, self.ack)
+
+    async def retry_row(self, row_ref: _TableRowRef, *, delay_s: float | None = None) -> None:
+        if delay_s:
+            await asyncio.sleep(delay_s)
+        await self.update_row(row_ref, self.nack)
+
+    async def fail_row(self, row_ref: _TableRowRef, exc: Exception | None = None) -> None:
+        await self.update_row(row_ref, self.nack)
+
+    async def release_row(self, row_ref: _TableRowRef) -> None:
+        await self.update_row(row_ref, self.nack)
+
+    async def update_row(self, row_ref: _TableRowRef, values: Mapping[str, Any]) -> None:
+        await self._update_row(row_ref, dict(values))
+
+    async def _update_row(self, row_ref: _TableRowRef, values: Mapping[str, Any]) -> None:
+        if not values:
+            return
+        table = await self.connector._table(row_ref.table)
+        async with self.connector.engine.begin() as conn:
+            await conn.execute(
+                sa.update(table)
+                .where(table.c[row_ref.key] == row_ref.key_value)
+                .values(**dict(values))
+            )
+
+
+@dataclass
+class _CursorToken:
+    value: tuple[Any, ...]
+
+
+@dataclass
+class _IncrementalRetryRow:
+    envelope: Envelope
+    ready_at: float
+    in_flight: bool = False
+
+
+class IncrementalDelivery(Delivery):
+    def __init__(self, source: IncrementalTableSource, envelope: Envelope, token: _CursorToken) -> None:
+        super().__init__(envelope)
+        self._source = source
+        self._token = token
+
+    async def ack(self) -> None:
+        await self._source.ack_token(self._token)
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        await self._source.retry_token(
+            self._token,
+            self.envelope,
+            delay_s=delay_s,
+        )
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        await self._source.fail_token(self._token, exc)
+
+    async def release_unstarted(self) -> None:
+        await self._source.release_token(self._token, self.envelope)
+
+
+class IncrementalTableSource(Source):
+    def __init__(
+        self,
+        *,
+        connector: SQLiteConnector,
+        table: str,
+        key: str,
+        cursor: tuple[str, ...],
+        where: str | None,
+        batch_size: int,
+        poll_interval_s: float,
+        state: CursorStore,
+        state_key: str,
+    ) -> None:
+        super().__init__(f"sqlite.incremental:{table}")
+        self.connector = connector
+        self.table_name = table
+        self.key = key
+        self.configured_cursor = cursor
+        self.cursor = cursor if key in cursor else (*cursor, key)
+        self.where = where
+        self.batch_size = batch_size
+        self.poll_interval_s = poll_interval_s
+        self.state = state
+        self.state_key = state_key
+        self._pending: deque[tuple[Any, ...]] = deque()
+        self._acked: set[tuple[Any, ...]] = set()
+        self._commit_lock: asyncio.Lock | None = None
+        self._commit_loop: asyncio.AbstractEventLoop | None = None
+        self._commit_task: asyncio.Task[None] | None = None
+        self._commit_error: BaseException | None = None
+        self._retry_rows: dict[tuple[Any, ...], _IncrementalRetryRow] = {}
+        self._terminal_error: ConnectorOperationError | None = None
+        self._fetch_count = 0
+        self._retry_count = 0
+        self._cursor_save_count = 0
+        self._loaded = False
+        self._committed_cursor: tuple[Any, ...] | None = None
+        self._fetched_cursor: tuple[Any, ...] | None = None
+
+    async def open(self) -> None:
+        if not self._loaded:
+            loaded = await self.state.load(self.state_key)
+            if loaded is not None and len(loaded) == len(self.cursor):
+                self._committed_cursor = tuple(loaded)
+                self._fetched_cursor = self._committed_cursor
+            self._loaded = True
+
+    async def fetch(self, limit: int) -> list[Delivery]:
+        await self.open()
+        lock = self._runtime_commit_lock()
+        async with lock:
+            if self._terminal_error is not None:
+                raise self._terminal_error
+            retry_delivery = self._take_ready_retry_delivery()
+            if retry_delivery is not None:
+                return [retry_delivery]
+            if self._retry_rows:
+                return []
+        requested_limit = max(1, min(limit, self.batch_size))
+        started_at = time.monotonic()
+        try:
+            rows = await self._fetch(requested_limit)
+        except Exception as exc:
+            connector_error = as_sqlite_connector_operation_error(
+                operation=ConnectorOperation.FETCH,
+                exc=exc,
+                source_name=self.name,
+                retry_delay_s=self.poll_interval_s,
+                secrets=self.connector._secret_tokens(),
+            )
+            if connector_error is None:
+                raise
+            raise connector_error from exc
+        deliveries: list[Delivery] = []
+        async with lock:
+            for row in rows:
+                token = _CursorToken(tuple(row[column] for column in self.cursor))
+                self._pending.append(token.value)
+                self._fetched_cursor = token.value
+                envelope = Envelope(body=row, meta={"table": self.table_name})
+                deliveries.append(IncrementalDelivery(self, envelope, token))
+            self._fetch_count += 1
+            fetch_count = self._fetch_count
+            pending_cursor_rows = len(self._pending)
+        logger.info(
+            "sqlite incremental fetch",
+            extra={
+                "event": "sqlite_incremental_fetch",
+                "fetch_count": fetch_count,
+                "requested_limit": requested_limit,
+                "row_count": len(rows),
+                "duration_s": round(time.monotonic() - started_at, 3),
+                "pending_cursor_rows": pending_cursor_rows,
+                "fetched_cursor_lag_rows": pending_cursor_rows,
+            },
+        )
+        return deliveries
+
+    def _take_ready_retry_delivery(self) -> Delivery | None:
+        now = time.monotonic()
+        for token_value in self._pending:
+            retry = self._retry_rows.get(token_value)
+            if retry is None or retry.in_flight or retry.ready_at > now:
+                continue
+            retry.in_flight = True
+            return IncrementalDelivery(self, retry.envelope, _CursorToken(token_value))
+        return None
+
+    async def _fetch(self, limit: int) -> list[dict[str, Any]]:
+        table = await self.connector._table(self.table_name)
+        stmt = sa.select(table)
+        predicates = []
+        if self.where:
+            predicates.append(sa.text(self.where))
+        read_cursor = self._fetched_cursor or self._committed_cursor
+        if read_cursor is not None:
+            cursor_columns = [table.c[name] for name in self.cursor]
+            predicates.append(sa.tuple_(*cursor_columns) > tuple(read_cursor))
+        if predicates:
+            stmt = stmt.where(*predicates)
+        order_columns = [table.c[name] for name in self.cursor]
+        stmt = stmt.order_by(*order_columns).limit(limit)
+        async with self.connector.engine.begin() as conn:
+            rows = (await conn.execute(stmt)).mappings().all()
+        return [dict(row) for row in rows]
+
+    async def ack_token(self, token: _CursorToken) -> None:
+        lock = self._runtime_commit_lock()
+        async with lock:
+            self._acked.add(token.value)
+            if not self._pending or self._pending[0] not in self._acked:
+                return
+            task = self._commit_task
+            if task is None or task.done():
+                self._commit_error = None
+                task = asyncio.create_task(self._flush_commits())
+                self._commit_task = task
+        await asyncio.shield(task)
+
+    async def retry_token(
+        self,
+        token: _CursorToken,
+        envelope: Envelope,
+        *,
+        delay_s: float | None,
+    ) -> None:
+        lock = self._runtime_commit_lock()
+        async with lock:
+            self._retry_count += 1
+            retry_count = self._retry_count
+            self._retry_rows[token.value] = _IncrementalRetryRow(
+                envelope=Envelope(
+                    body=envelope.body,
+                    meta=dict(envelope.meta),
+                    attempts=envelope.attempts + 1,
+                ),
+                ready_at=time.monotonic() + max(0.0, delay_s or 0.0),
+            )
+        logger.info(
+            "sqlite incremental retry",
+            extra={
+                "event": "sqlite_incremental_retry",
+                "retry_count": retry_count,
+                "attempt": envelope.attempts + 1,
+                "delay_s": max(0.0, delay_s or 0.0),
+                "pending_cursor_rows": len(self._pending),
+            },
+        )
+
+    async def release_token(
+        self, token: _CursorToken, envelope: Envelope
+    ) -> None:
+        lock = self._runtime_commit_lock()
+        async with lock:
+            retry = self._retry_rows.get(token.value)
+            if retry is None:
+                retry = _IncrementalRetryRow(envelope=envelope, ready_at=time.monotonic())
+                self._retry_rows[token.value] = retry
+            retry.in_flight = False
+            retry.ready_at = time.monotonic()
+
+    async def fail_token(
+        self, token: _CursorToken, exc: Exception | None
+    ) -> None:
+        lock = self._runtime_commit_lock()
+        async with lock:
+            self._terminal_error = ConnectorOperationError(
+                backend="sqlite",
+                operation=ConnectorOperation.FETCH,
+                kind=ConnectorErrorKind.PERMANENT,
+                source_name=self.name,
+                retry_delay_s=self.poll_interval_s,
+                cause=exc,
+                message="sqlite incremental source is blocked at a failed cursor row",
+            )
+            retry = self._retry_rows.get(token.value)
+            if retry is not None:
+                retry.in_flight = False
+
+    async def _flush_commits(self) -> None:
+        await asyncio.sleep(0)
+        try:
+            while True:
+                lock = self._runtime_commit_lock()
+                async with lock:
+                    prefix: list[tuple[Any, ...]] = []
+                    for token_value in self._pending:
+                        if token_value not in self._acked:
+                            break
+                        prefix.append(token_value)
+                    if not prefix:
+                        return
+                    highest = prefix[-1]
+                started_at = time.monotonic()
+                async with lock:
+                    self._cursor_save_count += 1
+                    cursor_save_count = self._cursor_save_count
+                try:
+                    await self.state.save(self.state_key, list(highest))
+                except BaseException:
+                    logger.info(
+                        "sqlite incremental cursor commit",
+                        extra={
+                            "event": "sqlite_incremental_cursor_commit",
+                            "cursor_save_count": cursor_save_count,
+                            "coalesced_ack_count": len(prefix),
+                            "duration_s": round(time.monotonic() - started_at, 3),
+                            "outcome": "error",
+                            "pending_cursor_rows": len(self._pending),
+                            "fetched_cursor_lag_rows": len(self._pending),
+                        },
+                    )
+                    raise
+                async with lock:
+                    for token_value in prefix:
+                        current = self._pending.popleft()
+                        if current != token_value:
+                            raise RuntimeError(
+                                "sqlite incremental pending cursor order changed during commit"
+                            )
+                        self._acked.remove(token_value)
+                        self._retry_rows.pop(token_value, None)
+                    self._committed_cursor = highest
+                    if not self._pending:
+                        self._fetched_cursor = highest
+                    has_more = bool(
+                        self._pending and self._pending[0] in self._acked
+                    )
+                logger.info(
+                    "sqlite incremental cursor commit",
+                    extra={
+                        "event": "sqlite_incremental_cursor_commit",
+                        "cursor_save_count": cursor_save_count,
+                        "coalesced_ack_count": len(prefix),
+                        "duration_s": round(time.monotonic() - started_at, 3),
+                        "outcome": "success",
+                        "pending_cursor_rows": len(self._pending),
+                        "fetched_cursor_lag_rows": len(self._pending),
+                    },
+                )
+                if not has_more:
+                    return
+        except BaseException as exc:
+            self._commit_error = exc
+            raise
+        finally:
+            lock = self._runtime_commit_lock()
+            async with lock:
+                if self._commit_task is asyncio.current_task():
+                    self._commit_task = None
+
+    async def close(self) -> None:
+        task = self._commit_task
+        if task is not None:
+            await asyncio.shield(task)
+
+    def _runtime_commit_lock(self) -> asyncio.Lock:
+        current_loop = asyncio.get_running_loop()
+        if self._commit_lock is None or self._commit_loop is not current_loop:
+            self._commit_lock = asyncio.Lock()
+            self._commit_loop = current_loop
+        return self._commit_lock
+
+
+class TableSink(TableSinkUpdatePolicy, Sink):
+    def __init__(
+        self,
+        *,
+        connector: SQLiteConnector,
+        table: str,
+        mode: str = "insert",
+        keys: tuple[str, ...] = (),
+        update_columns: Sequence[str | Mapping[str, str]] | None = None,
+        update_expr: Mapping[str, str] | None = None,
+        serialize_json: str = "auto",
+    ) -> None:
+        super().__init__(f"sqlite.table_sink:{table}")
+        if mode not in {"insert", "upsert", "update"}:
+            raise ValueError("mode must be one of 'insert', 'upsert' or 'update'")
+        if update_columns is not None and mode == "insert":
+            raise ValueError("update_columns only applies to upsert or update mode")
+        update_expr_dict = dict(update_expr or {})
+        update_columns_tuple, column_policies = _normalize_update_columns(
+            update_columns, keys=keys, update_expr=update_expr_dict
+        )
+        if update_expr is not None:
+            if mode == "insert":
+                raise ValueError("update_expr only applies to upsert or update mode")
+            if not all(isinstance(key, str) and isinstance(value, str) for key, value in update_expr.items()):
+                raise TypeError("update_expr keys and values must be strings")
+        if mode in {"upsert", "update"} and update_columns_tuple == () and not update_expr_dict:
+            raise ValueError(f"{mode} mode requires update_expr when update_columns is empty")
+        if serialize_json not in {"auto", "always", "never"}:
+            raise ValueError("serialize_json must be 'auto', 'always' or 'never'")
+        self.connector = connector
+        self.table_name = table
+        self.mode = mode
+        self.keys = keys
+        self.update_columns = update_columns_tuple
+        self.column_policies = column_policies
+        self.update_expr = update_expr_dict
+        self.serialize_json = serialize_json
+
+    async def send(self, envelope: Envelope) -> None:
+        if not isinstance(envelope.body, Mapping):
+            raise TypeError("TableSink only accepts mapping payloads")
+        try:
+            await self._send(dict(envelope.body))
+        except Exception as exc:
+            connector_error = as_sqlite_connector_operation_error(
+                operation=ConnectorOperation.SEND,
+                exc=exc,
+                source_name=self.name,
+                retry_delay_s=1.0,
+                secrets=self.connector._secret_tokens(),
+            )
+            if connector_error is None:
+                raise
+            raise connector_error from exc
+
+    async def _send(self, payload: dict[str, Any]) -> None:
+        table = await self.connector._table(self.table_name)
+        stmt = self._build_statement(payload, table)
+        if stmt is None:
+            logger.info(
+                "sqlite table sink %s skipped write: all update columns are null under skip_null policy (keys=%s)",
+                self.name,
+                {key: payload.get(key) for key in self.keys},
+            )
+            return
+        async with self.connector.engine.begin() as conn:
+            result = await conn.execute(stmt)
+            if self.mode == "update" and result.rowcount == 0:
+                logger.info(
+                    "sqlite table sink %s update matched no rows or values unchanged (keys=%s)",
+                    self.name,
+                    {key: payload.get(key) for key in self.keys},
+                )
+
+    def _build_statement(self, payload: dict[str, Any], table: sa.Table):
+        payload = self._coerce_json_values(payload, table)
+        if self.mode == "insert":
+            return sa.insert(table).values(**payload)
+        if not self.keys:
+            raise ValueError(f"{self.mode} mode requires keys")
+        update_payload, skipped_by_policy = self._update_payload(payload, table)
+        if not update_payload:
+            if skipped_by_policy:
+                return None
+            raise ValueError(f"{self.mode} mode requires at least one update column or update_expr")
+        if self.mode == "update":
+            missing_keys = [key for key in self.keys if key not in payload]
+            if missing_keys:
+                raise ValueError(f"update mode requires keys present in payload: {', '.join(missing_keys)}")
+            conditions = [table.columns[key] == payload[key] for key in self.keys]
+            return sa.update(table).where(sa.and_(*conditions)).values(**update_payload)
+        sync_engine = getattr(self.connector.engine, "sync_engine", self.connector.engine)
+        dialect = sync_engine.dialect.name
+        if dialect == "sqlite":
+            from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+            stmt = sqlite_insert(table).values(**payload)
+            return stmt.on_conflict_do_update(index_elements=list(self.keys), set_=update_payload)
+        if dialect == "mysql":
+            from sqlalchemy.dialects.mysql import insert as mysql_insert
+
+            stmt = mysql_insert(table).values(**payload)
+            return stmt.on_duplicate_key_update(**update_payload)
+        return sa.insert(table).values(**payload)

--- a/plugins/onestep-sql/src/onestep_sql/sqlite/connector.py
+++ b/plugins/onestep-sql/src/onestep_sql/sqlite/connector.py
@@ -38,7 +38,14 @@ except ImportError:  # pragma: no cover - exercised when optional deps are missi
 
 
 def _normalize_dsn(dsn: str) -> str:
-    """Accept a bare file path or a ``sqlite://`` URL and return an async URL."""
+    """Accept a bare file path or a ``sqlite://`` URL and return an async URL.
+
+    A bare ``":memory:"`` is kept as an in-memory database (StaticPool); any
+    other bare token is treated as a filesystem path so it gets the same engine
+    tuning (busy timeout, no ``pool_pre_ping``) as an explicit ``sqlite://`` URL.
+    """
+    if dsn == ":memory:":
+        return "sqlite+aiosqlite:///:memory:"
     if "://" not in dsn:
         from pathlib import Path
 
@@ -52,7 +59,10 @@ class SQLiteConnector:
             raise RuntimeError("SQLiteConnector requires SQLAlchemy. Install onestep-sql with the 'sqlite' extra.")
         self.dsn = dsn
         self._sensitive_tokens = collect_sensitive_tokens(dsn, engine_options)
-        parsed = urlparse(dsn)
+        # Normalize first (bare path / ":memory:" -> async URL) so the SQLite
+        # engine tuning below applies uniformly regardless of DSN spelling.
+        normalized_dsn = _normalize_dsn(dsn)
+        parsed = urlparse(normalized_dsn)
         if parsed.scheme.startswith("sqlite"):
             # File-based single-writer backend: tolerate busy writers and do not
             # ping (sqlite has no server).
@@ -63,7 +73,7 @@ class SQLiteConnector:
                 from sqlalchemy.pool import StaticPool
 
                 engine_options.setdefault("poolclass", StaticPool)
-        self.engine: AsyncEngine = create_async_engine(_normalize_dsn(dsn), **engine_options)
+        self.engine: AsyncEngine = create_async_engine(normalized_dsn, **engine_options)
         self._tables: dict[str, Any] = {}
         self._table_lock: asyncio.Lock | None = None
 
@@ -290,14 +300,29 @@ class TableQueueSource(Source):
 
     async def _fetch(self, limit: int) -> list[dict[str, Any]]:
         table = await self.connector._table(self.table_name)
+        # SQLite has no ``SELECT ... FOR UPDATE SKIP LOCKED`` (mysql/connector.py
+        # uses it to claim). Instead we claim and read in one atomic statement:
+        # the write lock is held for the whole UPDATE, so two consumers can never
+        # both select the same candidate rows before either commits. The
+        # subquery re-applies the user ``where`` predicate and ``limit`` under the
+        # lock, and ``RETURNING`` hands back the post-claim rows (matching the
+        # mysql connector's post-claim re-read, see issue #4 of the PR review).
+        claim_stmt = (
+            sa.update(table)
+            .where(
+                table.c[self.key].in_(
+                    sa.select(table.c[self.key])
+                    .where(sa.text(self.where))
+                    .order_by(table.c[self.key])
+                    .limit(limit)
+                )
+            )
+            .values(**self.claim)
+            .returning(*table.c)
+        )
         async with self.connector.engine.begin() as conn:
-            stmt = sa.select(table).where(sa.text(self.where)).order_by(table.c[self.key]).limit(limit)
-            rows = (await conn.execute(stmt)).mappings().all()
-            if not rows:
-                return []
-            ids = [row[self.key] for row in rows]
-            await conn.execute(sa.update(table).where(table.c[self.key].in_(ids)).values(**self.claim))
-        return [dict(row) for row in rows]
+            claimed = (await conn.execute(claim_stmt)).mappings().all()
+        return [dict(row) for row in claimed]
 
     async def ack_row(self, row_ref: _TableRowRef) -> None:
         await self.update_row(row_ref, self.ack)

--- a/plugins/onestep-sql/src/onestep_sql/sqlite/resilience.py
+++ b/plugins/onestep-sql/src/onestep_sql/sqlite/resilience.py
@@ -1,0 +1,96 @@
+"""SQLite resilience helpers.
+
+The secret-redaction scaffolding is shared in ``onestep_sql._shared.resilience``.
+Only the genuinely SQLite-specific part stays here: the SQLAlchemy error
+classification table keyed to SQLite error messages (mostly "database is
+locked" and integrity/syntax errors).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from onestep.resilience import (
+    ConnectorErrorKind,
+    ConnectorOperation,
+    ConnectorOperationError,
+)
+from onestep_sql._shared.resilience import (
+    SQLErrorCause,
+    as_connector_operation_error,
+    collect_sensitive_tokens,
+    redact_message,
+)
+
+__all__ = [
+    "SQLiteErrorCause",
+    "as_sqlite_connector_operation_error",
+    "classify_sqlalchemy_error",
+    "collect_sensitive_tokens",
+    "redacted_sqlite_cause",
+]
+
+try:  # pragma: no cover - optional dependency
+    import sqlalchemy as sa
+except ImportError:  # pragma: no cover - optional dependency
+    sa = None
+
+
+@dataclass(frozen=True)
+class SQLiteErrorCause(SQLErrorCause):
+    backend = "sqlite"
+
+
+def redacted_sqlite_cause(
+    exc: BaseException, *, secrets: list[str] | None = None
+) -> SQLiteErrorCause:
+    return SQLiteErrorCause(redact_message(str(exc), secrets or []))
+
+
+def classify_sqlalchemy_error(exc: BaseException) -> ConnectorErrorKind | None:
+    if sa is None:
+        return None
+    sql_exc = sa.exc
+    if isinstance(exc, getattr(sql_exc, "TimeoutError", ())):
+        return ConnectorErrorKind.TRANSIENT
+    if isinstance(exc, getattr(sql_exc, "InterfaceError", ())):
+        return ConnectorErrorKind.DISCONNECTED
+    if isinstance(exc, getattr(sql_exc, "ProgrammingError", ())):
+        return ConnectorErrorKind.PERMANENT
+    if isinstance(exc, getattr(sql_exc, "IntegrityError", ())):
+        return ConnectorErrorKind.PERMANENT
+    if isinstance(exc, getattr(sql_exc, "DBAPIError", ())):
+        if getattr(exc, "connection_invalidated", False):
+            return ConnectorErrorKind.DISCONNECTED
+        message = " ".join(
+            str(part).lower()
+            for part in (getattr(exc, "orig", None), exc)
+            if part is not None
+        )
+        if "database is locked" in message:
+            return ConnectorErrorKind.TRANSIENT
+        if any(token in message for token in ("no such table", "no such column", "syntax error")):
+            return ConnectorErrorKind.PERMANENT
+        if isinstance(exc, getattr(sql_exc, "OperationalError", ())):
+            return ConnectorErrorKind.TRANSIENT
+    return None
+
+
+def as_sqlite_connector_operation_error(
+    *,
+    operation: ConnectorOperation,
+    exc: BaseException,
+    source_name: str | None = None,
+    retry_delay_s: float | None = None,
+    secrets: list[str] | None = None,
+) -> ConnectorOperationError | None:
+    return as_connector_operation_error(
+        backend="sqlite",
+        operation=operation,
+        exc=exc,
+        classify=classify_sqlalchemy_error,
+        redacted_cause=redacted_sqlite_cause,
+        source_name=source_name,
+        retry_delay_s=retry_delay_s,
+        secrets=secrets,
+    )

--- a/plugins/onestep-sql/src/onestep_sql/sqlite/resources.py
+++ b/plugins/onestep-sql/src/onestep_sql/sqlite/resources.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from onestep.resource_registry import (
+    ResourceBuildContext,
+    ResourceCatalogEntry,
+    ResourceCatalogField,
+    ResourceRegistry,
+    ResourceSpecHandler,
+)
+
+from .connector import SQLiteConnector
+
+_SQLITE_FIELDS = frozenset({"type", "dsn", "engine_options"})
+_SQLITE_STATE_STORE_FIELDS = frozenset(
+    {"type", "connector", "table", "key_column", "value_column", "updated_at_column", "auto_create"}
+)
+_SQLITE_CURSOR_STORE_FIELDS = frozenset(
+    {"type", "connector", "table", "key_column", "value_column", "updated_at_column", "auto_create"}
+)
+_SQLITE_TABLE_QUEUE_FIELDS = frozenset(
+    {"type", "connector", "table", "key", "where", "claim", "ack", "nack", "batch_size", "poll_interval_s"}
+)
+_SQLITE_INCREMENTAL_FIELDS = frozenset(
+    {"type", "connector", "table", "key", "cursor", "where", "batch_size", "poll_interval_s", "state", "state_key"}
+)
+_SQLITE_TABLE_SINK_FIELDS = frozenset(
+    {"type", "connector", "table", "mode", "keys", "update_columns", "update_expr", "serialize_json"}
+)
+_SQLITE_CATALOG = ResourceCatalogEntry(
+    type="sqlite",
+    roles=("connector",),
+    label="SQLite",
+    fields=(
+        ResourceCatalogField("dsn", "string", required=True, secret=True),
+        ResourceCatalogField("engine_options", "mapping"),
+    ),
+)
+_SQLITE_STATE_STORE_CATALOG = ResourceCatalogEntry(
+    type="sqlite_state_store",
+    roles=("state_store",),
+    label="SQLite State Store",
+    connector_types=("sqlite",),
+    fields=(
+        ResourceCatalogField("connector", "ref", required=True),
+        ResourceCatalogField("table", "string", default="onestep_state"),
+        ResourceCatalogField("key_column", "string", default="state_key"),
+        ResourceCatalogField("value_column", "string", default="state_value"),
+        ResourceCatalogField("updated_at_column", "string", default="updated_at"),
+        ResourceCatalogField("auto_create", "boolean", default=True),
+    ),
+    topology_fields=("table", "key_column"),
+)
+_SQLITE_CURSOR_STORE_CATALOG = ResourceCatalogEntry(
+    type="sqlite_cursor_store",
+    roles=("cursor_store",),
+    label="SQLite Cursor Store",
+    connector_types=("sqlite",),
+    fields=(
+        ResourceCatalogField("connector", "ref", required=True),
+        ResourceCatalogField("table", "string", default="onestep_cursor"),
+        ResourceCatalogField("key_column", "string", default="cursor_key"),
+        ResourceCatalogField("value_column", "string", default="cursor_value"),
+        ResourceCatalogField("updated_at_column", "string", default="updated_at"),
+        ResourceCatalogField("auto_create", "boolean", default=True),
+    ),
+    topology_fields=("table", "key_column"),
+)
+_SQLITE_TABLE_QUEUE_CATALOG = ResourceCatalogEntry(
+    type="sqlite_table_queue",
+    roles=("source",),
+    label="SQLite Table Queue",
+    connector_types=("sqlite",),
+    fields=(
+        ResourceCatalogField("connector", "ref", required=True),
+        ResourceCatalogField("table", "string", required=True),
+        ResourceCatalogField("key", "string", required=True),
+        ResourceCatalogField("where", "string", required=True),
+        ResourceCatalogField("claim", "mapping", required=True),
+        ResourceCatalogField("ack", "mapping", required=True),
+        ResourceCatalogField("nack", "mapping"),
+        ResourceCatalogField("batch_size", "integer", default=100),
+        ResourceCatalogField("poll_interval_s", "number", default=1.0),
+    ),
+    topology_fields=("table", "key", "batch_size", "poll_interval_s"),
+)
+_SQLITE_INCREMENTAL_CATALOG = ResourceCatalogEntry(
+    type="sqlite_incremental",
+    roles=("source",),
+    label="SQLite Incremental",
+    connector_types=("sqlite",),
+    fields=(
+        ResourceCatalogField("connector", "ref", required=True),
+        ResourceCatalogField("table", "string", required=True),
+        ResourceCatalogField("key", "string", required=True),
+        ResourceCatalogField("cursor", "string_list", required=True),
+        ResourceCatalogField("where", "string"),
+        ResourceCatalogField("batch_size", "integer", default=1000),
+        ResourceCatalogField("poll_interval_s", "number", default=1.0),
+        ResourceCatalogField("state", "ref"),
+        ResourceCatalogField("state_key", "string"),
+    ),
+    topology_fields=("table", "key", "cursor", "batch_size", "poll_interval_s"),
+)
+_SQLITE_TABLE_SINK_CATALOG = ResourceCatalogEntry(
+    type="sqlite_table_sink",
+    roles=("sink",),
+    label="SQLite Table Sink",
+    connector_types=("sqlite",),
+    fields=(
+        ResourceCatalogField("connector", "ref", required=True),
+        ResourceCatalogField("table", "string", required=True),
+        ResourceCatalogField("mode", "string", default="insert", options=("insert", "upsert", "update")),
+        ResourceCatalogField("keys", "string_list"),
+        ResourceCatalogField("update_columns", "json"),
+        ResourceCatalogField("update_expr", "mapping"),
+        ResourceCatalogField("serialize_json", "string", default="auto", options=("auto", "always", "never")),
+    ),
+    topology_fields=("table", "mode", "keys", "update_columns", "update_expr", "serialize_json"),
+)
+
+
+def register_resources(registry: ResourceRegistry) -> None:
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="sqlite",
+            catalog=_SQLITE_CATALOG,
+            allowed_fields=_SQLITE_FIELDS,
+            build=_build_sqlite,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="sqlite_state_store",
+            catalog=_SQLITE_STATE_STORE_CATALOG,
+            allowed_fields=_SQLITE_STATE_STORE_FIELDS,
+            build=_build_sqlite_state_store,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="sqlite_cursor_store",
+            catalog=_SQLITE_CURSOR_STORE_CATALOG,
+            allowed_fields=_SQLITE_CURSOR_STORE_FIELDS,
+            build=_build_sqlite_cursor_store,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="sqlite_table_queue",
+            catalog=_SQLITE_TABLE_QUEUE_CATALOG,
+            allowed_fields=_SQLITE_TABLE_QUEUE_FIELDS,
+            build=_build_sqlite_table_queue,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="sqlite_incremental",
+            catalog=_SQLITE_INCREMENTAL_CATALOG,
+            allowed_fields=_SQLITE_INCREMENTAL_FIELDS,
+            build=_build_sqlite_incremental,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="sqlite_table_sink",
+            catalog=_SQLITE_TABLE_SINK_CATALOG,
+            allowed_fields=_SQLITE_TABLE_SINK_FIELDS,
+            build=_build_sqlite_table_sink,
+        )
+    )
+
+
+def _build_sqlite(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> SQLiteConnector:
+    return SQLiteConnector(
+        ctx.require_string(spec, "dsn"),
+        **ctx.mapping_value(spec.get("engine_options"), field=f"{ctx.field}.engine_options"),
+    )
+
+
+def _build_sqlite_state_store(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
+    connector = ctx.resolve_dependency(spec, "connector")
+    if not hasattr(connector, "state_store"):
+        raise TypeError(f"resource {spec['connector']!r} cannot build sqlite_state_store")
+    return connector.state_store(
+        table=spec.get("table", "onestep_state"),
+        key_column=spec.get("key_column", "state_key"),
+        value_column=spec.get("value_column", "state_value"),
+        updated_at_column=spec.get("updated_at_column", "updated_at"),
+        auto_create=spec.get("auto_create", True),
+    )
+
+
+def _build_sqlite_cursor_store(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
+    connector = ctx.resolve_dependency(spec, "connector")
+    if not hasattr(connector, "cursor_store"):
+        raise TypeError(f"resource {spec['connector']!r} cannot build sqlite_cursor_store")
+    return connector.cursor_store(
+        table=spec.get("table", "onestep_cursor"),
+        key_column=spec.get("key_column", "cursor_key"),
+        value_column=spec.get("value_column", "cursor_value"),
+        updated_at_column=spec.get("updated_at_column", "updated_at"),
+        auto_create=spec.get("auto_create", True),
+    )
+
+
+def _build_sqlite_table_queue(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
+    connector = ctx.resolve_dependency(spec, "connector")
+    if not hasattr(connector, "table_queue"):
+        raise TypeError(f"resource {spec['connector']!r} cannot build sqlite_table_queue")
+    return connector.table_queue(
+        table=ctx.require_string(spec, "table"),
+        key=ctx.require_string(spec, "key"),
+        where=ctx.require_string(spec, "where"),
+        claim=ctx.require_mapping(spec, "claim"),
+        ack=ctx.require_mapping(spec, "ack"),
+        nack=ctx.optional_mapping(spec.get("nack"), field=f"{ctx.field}.nack") or None,
+        batch_size=spec.get("batch_size", 100),
+        poll_interval_s=spec.get("poll_interval_s", 1.0),
+    )
+
+
+def _build_sqlite_incremental(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
+    connector = ctx.resolve_dependency(spec, "connector")
+    if not hasattr(connector, "incremental"):
+        raise TypeError(f"resource {spec['connector']!r} cannot build sqlite_incremental")
+    raw_state_name = spec.get("state")
+    state = None
+    if raw_state_name is not None:
+        state_name = ctx.string_value(raw_state_name, field=f"{ctx.field}.state")
+        state = ctx.resolve(state_name)
+        if not ctx.is_cursor_store(state):
+            raise TypeError(f"resource {state_name!r} cannot be used as incremental state")
+    return connector.incremental(
+        table=ctx.require_string(spec, "table"),
+        key=ctx.require_string(spec, "key"),
+        cursor=tuple(ctx.string_list(spec.get("cursor"), field=f"{ctx.field}.cursor")),
+        where=spec.get("where"),
+        batch_size=spec.get("batch_size", 1000),
+        poll_interval_s=spec.get("poll_interval_s", 1.0),
+        state=state,
+        state_key=spec.get("state_key"),
+    )
+
+
+def _update_columns_value(value: Any, *, field: str) -> list[str | Mapping[str, str]]:
+    if not isinstance(value, list):
+        raise ValueError(f"'{field}' must be a list of column names or {{name, policy}} mappings")
+    for entry in value:
+        if not isinstance(entry, (str, Mapping)):
+            raise ValueError(f"'{field}' entries must be column names or {{name, policy}} mappings")
+    return value
+
+
+def _build_sqlite_table_sink(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
+    connector = ctx.resolve_dependency(spec, "connector")
+    if not hasattr(connector, "table_sink"):
+        raise TypeError(f"resource {spec['connector']!r} cannot build sqlite_table_sink")
+    keys = spec.get("keys")
+    update_columns = spec.get("update_columns")
+    update_expr = spec.get("update_expr")
+    return connector.table_sink(
+        table=ctx.require_string(spec, "table"),
+        mode=spec.get("mode", "insert"),
+        keys=tuple(ctx.string_list(keys, field=f"{ctx.field}.keys")) if keys is not None else (),
+        update_columns=_update_columns_value(update_columns, field=f"{ctx.field}.update_columns")
+        if update_columns is not None
+        else None,
+        update_expr=ctx.mapping_value(update_expr, field=f"{ctx.field}.update_expr")
+        if update_expr is not None
+        else None,
+        serialize_json=spec.get("serialize_json", "auto"),
+    )

--- a/plugins/onestep-sql/src/onestep_sql/sqlite/state_sqlalchemy.py
+++ b/plugins/onestep-sql/src/onestep_sql/sqlite/state_sqlalchemy.py
@@ -1,0 +1,43 @@
+"""SQLite backend adapter for the shared SQLAlchemy state/cursor stores.
+
+Mirrors the mysql/postgres adapters: behaviour lives once in
+``onestep_sql._shared.state_sqlalchemy``; only the SQLite-specific asyncio
+driver mapping and installation hint stay here.
+"""
+
+from __future__ import annotations
+
+from onestep_sql._shared.state_sqlalchemy import (
+    SQLAlchemyCursorStore as _SharedCursorStore,
+)
+from onestep_sql._shared.state_sqlalchemy import (
+    SQLAlchemyStateStore as _SharedStateStore,
+)
+
+__all__ = ["SQLAlchemyCursorStore", "SQLAlchemyStateStore"]
+
+
+def _resolve_async_driver(drivername: str) -> str | None:
+    """Map SQLite URL drivernames onto the asyncio-compatible aiosqlite dialect."""
+    if drivername in ("sqlite", "sqlite+pysqlite"):
+        return "sqlite+aiosqlite"
+    return None
+
+
+def _async_dsn(dsn: str) -> str:
+    """Return a SQLAlchemy URL backed by an asyncio-compatible dialect."""
+    from onestep_sql._shared.state_sqlalchemy import async_dsn
+
+    return async_dsn(dsn, resolve_driver=_resolve_async_driver)
+
+
+class SQLAlchemyStateStore(_SharedStateStore):
+    _install_hint = "Install onestep-sql with the 'sqlite' extra."
+
+    @staticmethod
+    def _resolve_async_driver(drivername: str) -> str | None:
+        return _resolve_async_driver(drivername)
+
+
+class SQLAlchemyCursorStore(SQLAlchemyStateStore, _SharedCursorStore):
+    """SQLite cursor store; behaviour implemented once in ``onestep_sql._shared``."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ postgres = [
 sql = [
     "onestep-sql[mysql,postgres]>=0.1.0",
 ]
+sqlite = [
+    "onestep-sql[sqlite]>=0.1.0",
+]
 rabbitmq = [
     "onestep-mq>=0.2.1",
 ]
@@ -71,7 +74,7 @@ integration = [
     "PyYAML>=6.0",
     "onestep-mq>=0.2.1",
     "onestep-redis>=0.2.1",
-    "onestep-sql[mysql,postgres]>=0.1.0",
+    "onestep-sql[mysql,postgres,sqlite]>=0.1.0",
     "onestep-sqs>=0.2.2",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
@@ -83,7 +86,7 @@ all = [
     "PyYAML>=6.0",
     "onestep-mq>=0.2.1",
     "onestep-redis>=0.2.1",
-    "onestep-sql[mysql,postgres]>=0.1.0",
+    "onestep-sql[mysql,postgres,sqlite]>=0.1.0",
     "onestep-sqs>=0.2.2",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,10 @@ postgres = [
     "onestep-sql[postgres]>=0.1.0",
 ]
 sql = [
-    "onestep-sql[mysql,postgres]>=0.1.0",
+    "onestep-sql[mysql,postgres,sqlite]>=0.2.0",
 ]
 sqlite = [
-    "onestep-sql[sqlite]>=0.1.0",
+    "onestep-sql[sqlite]>=0.2.0",
 ]
 rabbitmq = [
     "onestep-mq>=0.2.1",
@@ -74,7 +74,7 @@ integration = [
     "PyYAML>=6.0",
     "onestep-mq>=0.2.1",
     "onestep-redis>=0.2.1",
-    "onestep-sql[mysql,postgres,sqlite]>=0.1.0",
+    "onestep-sql[mysql,postgres,sqlite]>=0.2.0",
     "onestep-sqs>=0.2.2",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
@@ -86,7 +86,7 @@ all = [
     "PyYAML>=6.0",
     "onestep-mq>=0.2.1",
     "onestep-redis>=0.2.1",
-    "onestep-sql[mysql,postgres,sqlite]>=0.1.0",
+    "onestep-sql[mysql,postgres,sqlite]>=0.2.0",
     "onestep-sqs>=0.2.2",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
@@ -100,7 +100,7 @@ dev = [
     "PyYAML>=6.0",
     "onestep-mq>=0.2.1",
     "onestep-redis>=0.2.1",
-    "onestep-sql[mysql,postgres]>=0.1.0",
+    "onestep-sql[mysql,postgres,sqlite]>=0.2.0",
     "onestep-sqs>=0.2.2",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",

--- a/tests/contract/test_onestep_sql_canonical.py
+++ b/tests/contract/test_onestep_sql_canonical.py
@@ -27,6 +27,7 @@ from onestep_mysql.resources import register_resources as register_mysql_legacy
 from onestep_postgres.resources import register_resources as register_postgres_legacy
 from onestep_sql import mysql as mysql_pkg
 from onestep_sql import postgres as postgres_pkg
+from onestep_sql import sqlite as sqlite_pkg
 from onestep_sql import register_resources
 
 EXPECTED_TYPES = {
@@ -37,6 +38,9 @@ EXPECTED_TYPES = {
     "postgres", "postgres_state_store", "postgres_cursor_store",
     "postgres_table_queue", "postgres_incremental", "postgres_execution_source",
     "postgres_table_sink",
+    # SQLite
+    "sqlite", "sqlite_state_store", "sqlite_cursor_store", "sqlite_table_queue",
+    "sqlite_incremental", "sqlite_table_sink",
 }
 
 
@@ -62,19 +66,21 @@ def _select_entry_points(group: str):
     return [ep for ep in eps if ep.group == group]
 
 
-def test_register_resources_exposes_exactly_14_types():
+def test_register_resources_exposes_all_backend_types():
     registry = ResourceRegistry()
     register_resources(registry)
     types = {e.type for e in registry.catalog_entries()}
     assert types == EXPECTED_TYPES
-    assert len(types) == 14
+    assert len(types) == 20
 
 
 def test_catalog_matches_legacy_combined():
-    """Canonical must be byte-identical to both legacy plugins registered together."""
+    """Canonical must be byte-identical to the legacy mysql+postgres plugins plus
+    the SQLite backend (which has no legacy forwarding shim) registered together."""
     legacy = ResourceRegistry()
     register_mysql_legacy(legacy)
     register_postgres_legacy(legacy)
+    sqlite_pkg.register_resources(legacy)
 
     canonical = ResourceRegistry()
     register_resources(canonical)
@@ -105,10 +111,12 @@ def test_extras_declared():
 
 
 def test_package_imports_without_drivers_at_import_time():
-    # onestep_sql, .mysql and .postgres all import successfully here even if
-    # asyncmy / psycopg are absent; drivers are only imported lazily at runtime.
+    # onestep_sql, .mysql, .postgres and .sqlite all import successfully here
+    # even if asyncmy / psycopg / aiosqlite are absent; drivers are only imported
+    # lazily at runtime.
     assert mysql_pkg.MySQLConnector is not None
     assert postgres_pkg.PostgresConnector is not None
+    assert sqlite_pkg.SQLiteConnector is not None
 
 
 def test_backend_specific_capabilities_stay_backend_specific():
@@ -118,6 +126,9 @@ def test_backend_specific_capabilities_stay_backend_specific():
     # PostgreSQL-only tracked-execution capability must not leak into mysql.
     assert hasattr(postgres_pkg, "PostgresExecutionSource")
     assert not hasattr(mysql_pkg, "PostgresExecutionSource")
+    # SQLite has no binlog and no tracked execution; it must not expose them.
+    assert not hasattr(sqlite_pkg, "BinlogSource")
+    assert not hasattr(sqlite_pkg, "PostgresExecutionSource")
 
 
 def test_register_resources_is_idempotent_alias_on_subpackages():
@@ -128,4 +139,5 @@ def test_register_resources_is_idempotent_alias_on_subpackages():
     r2 = ResourceRegistry()
     mysql_pkg.register_resources(r2)
     postgres_pkg.register_resources(r2)
+    sqlite_pkg.register_resources(r2)
     assert _catalog(r1) == _catalog(r2)

--- a/tests/contract/test_onestep_sql_shared.py
+++ b/tests/contract/test_onestep_sql_shared.py
@@ -36,6 +36,7 @@ import pytest
 import sqlalchemy as sa
 from onestep_sql import mysql as mysql_pkg
 from onestep_sql import postgres as postgres_pkg
+from onestep_sql import sqlite as sqlite_pkg
 from onestep_sql._shared import resilience as shared_resilience
 from onestep_sql._shared import state_keys as shared_state_keys
 from onestep_sql._shared import state_sqlalchemy as shared_state
@@ -47,29 +48,37 @@ from onestep_sql.mysql import state_sqlalchemy as mysql_state
 from onestep_sql.postgres import connector as postgres_connector
 from onestep_sql.postgres import resilience as postgres_resilience
 from onestep_sql.postgres import state_sqlalchemy as postgres_state
+from onestep_sql.sqlite import connector as sqlite_connector
+from onestep_sql.sqlite import resilience as sqlite_resilience
+from onestep_sql.sqlite import state_sqlalchemy as sqlite_state
 from sqlalchemy.ext.asyncio import create_async_engine as _create_async_engine
 
 from onestep.resilience import ConnectorErrorKind, ConnectorOperation
 
-BACKENDS = ("mysql", "postgres")
+BACKENDS = ("mysql", "postgres", "sqlite")
 
 
 def _backend_state_module(backend: str):
-    return {"mysql": mysql_state, "postgres": postgres_state}[backend]
+    return {"mysql": mysql_state, "postgres": postgres_state, "sqlite": sqlite_state}[backend]
 
 
 def _backend_connector_module(backend: str):
-    return {"mysql": mysql_connector, "postgres": postgres_connector}[backend]
+    return {"mysql": mysql_connector, "postgres": postgres_connector, "sqlite": sqlite_connector}[backend]
 
 
 def _backend_sink_cls(backend: str):
-    return {"mysql": mysql_pkg.TableSink, "postgres": postgres_pkg.PostgresTableSink}[backend]
+    return {
+        "mysql": mysql_pkg.TableSink,
+        "postgres": postgres_pkg.PostgresTableSink,
+        "sqlite": sqlite_pkg.TableSink,
+    }[backend]
 
 
 def _backend_connector_cls(backend: str):
     return {
         "mysql": mysql_pkg.MySQLConnector,
         "postgres": postgres_pkg.PostgresConnector,
+        "sqlite": sqlite_pkg.SQLiteConnector,
     }[backend]
 
 
@@ -79,12 +88,16 @@ def _backend_connector_cls(backend: str):
 
 
 def test_state_store_implementation_lives_once_in_shared() -> None:
-    for state in (mysql_state, postgres_state):
+    for state in (mysql_state, postgres_state, sqlite_state):
         assert issubclass(state.SQLAlchemyStateStore, shared_state.SQLAlchemyStateStore)
         assert issubclass(state.SQLAlchemyCursorStore, shared_state.SQLAlchemyCursorStore)
     # Backend classes stay distinct public identities per backend.
     assert mysql_state.SQLAlchemyStateStore is not postgres_state.SQLAlchemyStateStore
+    assert mysql_state.SQLAlchemyStateStore is not sqlite_state.SQLAlchemyStateStore
+    assert postgres_state.SQLAlchemyStateStore is not sqlite_state.SQLAlchemyStateStore
     assert mysql_state.SQLAlchemyCursorStore is not postgres_state.SQLAlchemyCursorStore
+    assert mysql_state.SQLAlchemyCursorStore is not sqlite_state.SQLAlchemyCursorStore
+    assert postgres_state.SQLAlchemyCursorStore is not sqlite_state.SQLAlchemyCursorStore
     # Every behavioural method is implemented on the shared classes only.
     shared_module = "onestep_sql._shared.state_sqlalchemy"
     for name in ("__init__", "load", "save", "delete", "close", "_ensure_ready"):
@@ -118,15 +131,18 @@ def test_table_sink_policy_lives_once_in_shared() -> None:
     assert (
         mysql_pkg.TableSink._update_payload
         is postgres_pkg.PostgresTableSink._update_payload
+        is sqlite_pkg.TableSink._update_payload
         is shared_policy.TableSinkUpdatePolicy._update_payload
     )
     assert (
         mysql_pkg.TableSink._coerce_json_values
         is postgres_pkg.PostgresTableSink._coerce_json_values
+        is sqlite_pkg.TableSink._coerce_json_values
         is shared_policy.TableSinkUpdatePolicy._coerce_json_values
     )
     assert issubclass(mysql_pkg.TableSink, shared_policy.TableSinkUpdatePolicy)
     assert issubclass(postgres_pkg.PostgresTableSink, shared_policy.TableSinkUpdatePolicy)
+    assert issubclass(sqlite_pkg.TableSink, shared_policy.TableSinkUpdatePolicy)
 
 
 def test_incremental_state_key_lives_once_in_shared() -> None:
@@ -143,14 +159,24 @@ def test_secret_redaction_scaffolding_lives_once_in_shared() -> None:
         is postgres_resilience.collect_sensitive_tokens
         is shared_resilience.collect_sensitive_tokens
     )
-    assert mysql_resilience.redact_message is postgres_resilience.redact_message is redact_message
+    assert (
+        mysql_resilience.redact_message
+        is postgres_resilience.redact_message
+        is sqlite_resilience.redact_message
+        is redact_message
+    )
     assert issubclass(mysql_resilience.MySQLErrorCause, shared_resilience.SQLErrorCause)
     assert issubclass(postgres_resilience.PostgresErrorCause, shared_resilience.SQLErrorCause)
+    assert issubclass(sqlite_resilience.SQLiteErrorCause, shared_resilience.SQLErrorCause)
     # The dialect-specific classification tables stay per backend (and are
     # genuinely different code, not a shared copy).
     assert (
         mysql_resilience.classify_sqlalchemy_error
         is not postgres_resilience.classify_sqlalchemy_error
+    )
+    assert (
+        mysql_resilience.classify_sqlalchemy_error
+        is not sqlite_resilience.classify_sqlalchemy_error
     )
 
 
@@ -492,7 +518,7 @@ def test_connectors_derive_identical_default_state_keys(tmp_path: Path) -> None:
         )
         # key not in cursor -> appended automatically
         assert sources[backend].cursor == ("updated_at", "id")
-    assert sources["mysql"].state_key == sources["postgres"].state_key
+    assert sources["mysql"].state_key == sources["postgres"].state_key == sources["sqlite"].state_key
     assert sources["mysql"].state_key == "users:updated_at,id:key=id:where=status = 1"
 
 
@@ -532,12 +558,14 @@ def test_redact_message_longest_first_and_truncation() -> None:
     [
         ("mysql", "mysql error: "),
         ("postgres", "postgres error: "),
+        ("sqlite", "sqlite error: "),
     ],
 )
 def test_error_cause_classes(backend: str, prefix: str) -> None:
     cause_type = {
         "mysql": mysql_resilience.MySQLErrorCause,
         "postgres": postgres_resilience.PostgresErrorCause,
+        "sqlite": sqlite_resilience.SQLiteErrorCause,
     }[backend]
     cause = cause_type("boom")
     assert str(cause) == f"{prefix}boom"
@@ -549,14 +577,16 @@ def test_error_cause_classes(backend: str, prefix: str) -> None:
 
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_connector_operation_error_factory_shared_behaviour(backend: str) -> None:
-    module = {"mysql": mysql_resilience, "postgres": postgres_resilience}[backend]
+    module = {"mysql": mysql_resilience, "postgres": postgres_resilience, "sqlite": sqlite_resilience}[backend]
     factory = {
         "mysql": mysql_resilience.as_mysql_connector_operation_error,
         "postgres": postgres_resilience.as_postgres_connector_operation_error,
+        "sqlite": sqlite_resilience.as_sqlite_connector_operation_error,
     }[backend]
     cause_type = {
         "mysql": mysql_resilience.MySQLErrorCause,
         "postgres": postgres_resilience.PostgresErrorCause,
+        "sqlite": sqlite_resilience.SQLiteErrorCause,
     }[backend]
 
     assert module.classify_sqlalchemy_error(TimeoutError("timeout")) is None
@@ -583,6 +613,7 @@ def test_connector_operation_error_redacts_secrets(backend: str) -> None:
     factory = {
         "mysql": mysql_resilience.as_mysql_connector_operation_error,
         "postgres": postgres_resilience.as_postgres_connector_operation_error,
+        "sqlite": sqlite_resilience.as_sqlite_connector_operation_error,
     }[backend]
     error = sa.exc.OperationalError("stmt", {}, Exception("access denied for 'alice' (using password: hunter2)"))
     normalized = factory(
@@ -619,13 +650,23 @@ def test_error_classification_tables_stay_per_dialect() -> None:
         mysql_resilience.classify_sqlalchemy_error(op_error("server closed the connection"))
         is ConnectorErrorKind.TRANSIENT
     )
-    # Shared SQLAlchemy-level classification still agrees on both sides.
-    for module in (mysql_resilience, postgres_resilience):
+    # Shared SQLAlchemy-level classification still agrees across all backends.
+    for module in (mysql_resilience, postgres_resilience, sqlite_resilience):
         assert module.classify_sqlalchemy_error(sa.exc.TimeoutError("t")) is ConnectorErrorKind.TRANSIENT
         assert (
             module.classify_sqlalchemy_error(sa.exc.InterfaceError("stmt", {}, Exception("i")))
             is ConnectorErrorKind.DISCONNECTED
         )
+    # SQLite's own dialect-specific message must stay distinct: "database is
+    # locked" maps to TRANSIENT (retryable busy), unlike either server backend.
+    assert (
+        sqlite_resilience.classify_sqlalchemy_error(op_error("database is locked"))
+        is ConnectorErrorKind.TRANSIENT
+    )
+    assert (
+        mysql_resilience.classify_sqlalchemy_error(op_error("database is locked"))
+        is ConnectorErrorKind.TRANSIENT  # mysql falls through to the OperationalError fallback
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/contract/test_onestep_sql_sqlite.py
+++ b/tests/contract/test_onestep_sql_sqlite.py
@@ -1,0 +1,206 @@
+"""Public contract tests for the SQLite backend of onestep-sql (issue #133).
+
+These pin the newly public SQLite resource types and their observable
+behaviour. SQLite is file/embedded (not server) so it exercises the same
+shared stores and source/sink classes as mysql/postgres, but with two
+genuinely different pieces:
+
+* the asyncio driver mapping maps ``sqlite`` / ``sqlite+pysqlite`` onto
+  ``sqlite+aiosqlite`` (and a bare file path is accepted);
+* the table queue claims rows without ``SELECT ... FOR UPDATE`` (SQLite does
+  not support row locks), relying on the single-writer file model instead.
+
+No server required: everything runs on a temporary sqlite database.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import sqlalchemy as sa
+from onestep_sql import sqlite as sqlite_pkg
+from onestep_sql.sqlite import resilience as sqlite_resilience
+from onestep_sql.sqlite import state_sqlalchemy as sqlite_state
+
+from onestep.envelope import Envelope
+from onestep.resource_registry import ResourceRegistry
+from onestep.state import InMemoryCursorStore
+
+SQLITE_REQUIRED_PUBLIC = {
+    "SQLiteConnector",
+    "TableSink",
+    "TableQueueSource",
+    "TableQueueDelivery",
+    "IncrementalTableSource",
+    "IncrementalDelivery",
+    "SQLAlchemyStateStore",
+    "SQLAlchemyCursorStore",
+    "classify_sqlalchemy_error",
+    "register",
+    "register_resources",
+}
+
+EXPECTED_TYPES = {
+    "sqlite",
+    "sqlite_state_store",
+    "sqlite_cursor_store",
+    "sqlite_table_queue",
+    "sqlite_incremental",
+    "sqlite_table_sink",
+}
+
+
+def test_sqlite_public_api_surface() -> None:
+    missing = SQLITE_REQUIRED_PUBLIC - set(dir(sqlite_pkg))
+    assert not missing, f"onestep_sql.sqlite missing public symbols: {sorted(missing)}"
+    assert sqlite_pkg.register is sqlite_pkg.register_resources
+
+
+def test_sqlite_registers_six_types() -> None:
+    registry = ResourceRegistry()
+    sqlite_pkg.register_resources(registry)
+    types = {e.type for e in registry.catalog_entries()}
+    assert types == EXPECTED_TYPES
+    assert len(types) == 6
+
+
+def test_sqlite_has_no_binlog_or_execution() -> None:
+    # SQLite is embedded: no binlog CDC and no tracked execution backend.
+    assert not hasattr(sqlite_pkg, "BinlogSource")
+    assert not hasattr(sqlite_pkg, "PostgresExecutionSource")
+    registry = ResourceRegistry()
+    sqlite_pkg.register_resources(registry)
+    types = {e.type for e in registry.catalog_entries()}
+    assert "sqlite_binlog" not in types
+    assert "sqlite_execution_source" not in types
+
+
+def test_async_dsn_maps_sqlite_drivers() -> None:
+    assert sqlite_state._async_dsn("sqlite:///x.db") == "sqlite+aiosqlite:///x.db"
+    assert sqlite_state._async_dsn("sqlite+pysqlite:///x.db") == "sqlite+aiosqlite:///x.db"
+    # Cross-dialect DSNs are passed through unchanged.
+    assert sqlite_state._async_dsn("mysql://u:p@h/db") == "mysql://u:p@h/db"
+    assert sqlite_state._async_dsn("postgresql://u:p@h/db") == "postgresql://u:p@h/db"
+
+
+def test_bare_file_path_is_accepted() -> None:
+    connector = sqlite_pkg.SQLiteConnector("/tmp/does-not-need-to-exist-yet.db")
+    assert connector.engine is not None
+    asyncio.run(connector.close())
+
+
+def test_install_hint_is_per_backend() -> None:
+    assert sqlite_state.SQLAlchemyStateStore._install_hint == "Install onestep-sql with the 'sqlite' extra."
+    assert sqlite_state.SQLAlchemyStateStore._resolve_async_driver("sqlite") == "sqlite+aiosqlite"
+
+
+def test_error_classification_table_is_per_dialect() -> None:
+    op_error = sa.exc.OperationalError("stmt", {}, Exception("database is locked"))
+    assert (
+        sqlite_resilience.classify_sqlalchemy_error(op_error)
+        is __import__("onestep.resilience", fromlist=["ConnectorErrorKind"]).ConnectorErrorKind.TRANSIENT
+    )
+    # Non-SQLAlchemy exceptions are not classified (gated on the DBAPI hierarchy).
+    assert sqlite_resilience.classify_sqlalchemy_error(ValueError("boom")) is None
+
+
+def test_connector_state_and_cursor_stores_share_engine(tmp_path: Path) -> None:
+    connector = sqlite_pkg.SQLiteConnector(f"sqlite:///{tmp_path / 'c.db'}")
+
+    async def scenario() -> None:
+        state_store = connector.state_store(table="app_state")
+        cursor_store = connector.cursor_store(table="app_cursor")
+        assert state_store.engine is connector.engine
+        assert cursor_store.engine is connector.engine
+        await state_store.save("k", {"v": 1})
+        await cursor_store.save("k", [1, 2])
+        assert await state_store.load("k") == {"v": 1}
+        assert await cursor_store.load("k") == [1, 2]
+        await connector.close()
+
+    asyncio.run(scenario())
+
+
+def test_table_sink_insert_and_upsert(tmp_path: Path) -> None:
+    connector = sqlite_pkg.SQLiteConnector(f"sqlite:///{tmp_path / 's.db'}")
+
+    async def scenario() -> None:
+        async with connector.engine.begin() as conn:
+            await conn.run_sync(
+                lambda s: s.execute(
+                    sa.text("CREATE TABLE jobs (id INTEGER PRIMARY KEY, status TEXT, payload TEXT)")
+                )
+            )
+        sink = connector.table_sink(table="jobs", mode="insert")
+        await sink.send(Envelope(body={"id": 1, "status": "new", "payload": "a"}))
+        upsert = connector.table_sink(table="jobs", mode="upsert", keys=("id",))
+        await upsert.send(Envelope(body={"id": 1, "status": "updated", "payload": "b"}))
+        async with connector.engine.begin() as conn:
+            row = (await conn.execute(sa.text("SELECT status, payload FROM jobs WHERE id=1"))).first()
+        assert row == ("updated", "b")
+        await connector.close()
+
+    asyncio.run(scenario())
+
+
+def test_table_queue_claims_without_for_update(tmp_path: Path) -> None:
+    connector = sqlite_pkg.SQLiteConnector(f"sqlite:///{tmp_path / 'q.db'}")
+
+    async def scenario() -> None:
+        async with connector.engine.begin() as conn:
+            await conn.run_sync(
+                lambda s: s.execute(
+                    sa.text("CREATE TABLE jobs (id INTEGER PRIMARY KEY, status TEXT)")
+                )
+            )
+            await conn.execute(sa.text("INSERT INTO jobs (id, status) VALUES (1, 'new'), (2, 'new')"))
+        queue = connector.table_queue(
+            table="jobs",
+            key="id",
+            where="status='new'",
+            claim={"status": "claimed"},
+            ack={"status": "done"},
+            nack={"status": "new"},
+        )
+        deliveries = await queue.fetch(10)
+        assert len(deliveries) == 2
+        await deliveries[0].ack()
+        async with connector.engine.begin() as conn:
+            done = (await conn.execute(sa.text("SELECT COUNT(*) FROM jobs WHERE status='done'"))).scalar()
+            claimed = (await conn.execute(sa.text("SELECT COUNT(*) FROM jobs WHERE status='claimed'"))).scalar()
+        assert done == 1
+        assert claimed == 1
+        await connector.close()
+
+    asyncio.run(scenario())
+
+
+def test_incremental_polls_and_advances_cursor(tmp_path: Path) -> None:
+    connector = sqlite_pkg.SQLiteConnector(f"sqlite:///{tmp_path / 'i.db'}")
+
+    async def scenario() -> None:
+        async with connector.engine.begin() as conn:
+            await conn.run_sync(
+                lambda s: s.execute(
+                    sa.text("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+                )
+            )
+            await conn.execute(sa.text("INSERT INTO users (id, name) VALUES (1, 'a'), (2, 'b'), (3, 'c')"))
+        source = connector.incremental(
+            table="users",
+            key="id",
+            cursor=["id"],
+            state=InMemoryCursorStore(),
+            state_key="users:id",
+        )
+        first = await source.fetch(2)
+        assert len(first) == 2
+        for delivery in first:
+            await delivery.ack()
+        second = await source.fetch(2)
+        assert len(second) == 1
+        assert second[0].envelope.body["id"] == 3
+        await connector.close()
+
+    asyncio.run(scenario())

--- a/tests/contract/test_onestep_sql_sqlite.py
+++ b/tests/contract/test_onestep_sql_sqlite.py
@@ -6,9 +6,13 @@ shared stores and source/sink classes as mysql/postgres, but with two
 genuinely different pieces:
 
 * the asyncio driver mapping maps ``sqlite`` / ``sqlite+pysqlite`` onto
-  ``sqlite+aiosqlite`` (and a bare file path is accepted);
-* the table queue claims rows without ``SELECT ... FOR UPDATE`` (SQLite does
-  not support row locks), relying on the single-writer file model instead.
+  ``sqlite+aiosqlite`` (and a bare file path or ``:memory:`` is accepted and
+  receives the same engine tuning — 30s busy timeout, no ``pool_pre_ping``);
+* the table queue claims rows without ``SELECT ... FOR UPDATE`` (SQLite does not
+  support row locks) by issuing one atomic ``UPDATE ... RETURNING`` statement, so
+  the write lock is held for the whole claim and concurrent consumers can never
+  double-claim the same rows. The returned body is the post-claim row, matching
+  the mysql/postgres envelope contract.
 
 No server required: everything runs on a temporary sqlite database.
 """
@@ -174,6 +178,128 @@ def test_table_queue_claims_without_for_update(tmp_path: Path) -> None:
         await connector.close()
 
     asyncio.run(scenario())
+
+
+def test_table_queue_delivers_post_claim_body(tmp_path: Path) -> None:
+    """The returned envelope mirrors the post-claim row (status='claimed'), so the
+    SQLite queue body matches the mysql/postgres contract (issue #4)."""
+    connector = sqlite_pkg.SQLiteConnector(f"sqlite:///{tmp_path / 'post.db'}")
+
+    async def scenario() -> None:
+        async with connector.engine.begin() as conn:
+            await conn.run_sync(
+                lambda s: s.execute(
+                    sa.text("CREATE TABLE jobs (id INTEGER PRIMARY KEY, status TEXT)")
+                )
+            )
+            await conn.execute(sa.text("INSERT INTO jobs (id, status) VALUES (1, 'new')"))
+        queue = connector.table_queue(
+            table="jobs",
+            key="id",
+            where="status='new'",
+            claim={"status": "claimed"},
+            ack={"status": "done"},
+            nack={"status": "new"},
+        )
+        deliveries = await queue.fetch(10)
+        assert len(deliveries) == 1
+        assert deliveries[0].envelope.body["status"] == "claimed"
+        await connector.close()
+
+    asyncio.run(scenario())
+
+
+def test_table_queue_no_double_claim_under_concurrent_consumers(tmp_path: Path) -> None:
+    """Two consumers polling the same file must never deliver the same row twice.
+
+    The previous implementation selected rows and then claimed them in separate
+    statements; a consumer whose SELECT landed between another consumer's SELECT
+    and its commit re-claimed the same batch. The atomic UPDATE ... RETURNING
+    claim holds the write lock for the whole claim, so the second consumer's
+    subquery only sees already-claimed rows (issue #1).
+    """
+    db = tmp_path / "shared.db"
+    seed = sqlite_pkg.SQLiteConnector(f"sqlite:///{db}")
+
+    async def setup() -> None:
+        async with seed.engine.begin() as conn:
+            await conn.run_sync(
+                lambda s: s.execute(
+                    sa.text("CREATE TABLE jobs (id INTEGER PRIMARY KEY, status TEXT)")
+                )
+            )
+            await conn.execute(
+                sa.text(
+                    "INSERT INTO jobs (id, status) VALUES "
+                    + ", ".join(f"({i}, 'new')" for i in range(1, 101))
+                )
+            )
+
+    asyncio.run(setup())
+
+    consumer_a = sqlite_pkg.SQLiteConnector(f"sqlite:///{db}")
+    consumer_b = sqlite_pkg.SQLiteConnector(f"sqlite:///{db}")
+    delivered: list[int] = []
+
+    async def consume(connector: sqlite_pkg.SQLiteConnector) -> None:
+        queue = connector.table_queue(
+            table="jobs",
+            key="id",
+            where="status='new'",
+            claim={"status": "claimed"},
+            ack={"status": "done"},
+            nack={"status": "new"},
+            batch_size=5,
+        )
+        for _ in range(40):
+            batch = await queue.fetch(5)
+            for delivery in batch:
+                delivered.append(delivery.envelope.body["id"])
+            for delivery in batch:
+                await delivery.ack()
+
+    async def run() -> None:
+        await asyncio.gather(consume(consumer_a), consume(consumer_b))
+
+    asyncio.run(run())
+
+    assert sorted(delivered) == list(range(1, 101))
+    assert len(delivered) == len(set(delivered)), f"double-claimed rows: {sorted(set(delivered))}"
+    asyncio.run(consumer_a.close())
+    asyncio.run(consumer_b.close())
+    asyncio.run(seed.close())
+
+
+def test_bare_path_applies_sqlite_engine_tuning(tmp_path: Path) -> None:
+    """A bare file path is normalized before the SQLite-specific engine tuning, so
+    it still gets the 30s busy timeout and no ``pool_pre_ping`` (issue #6)."""
+    connector = sqlite_pkg.SQLiteConnector("/tmp/onestep-sqlite-tuning-check.db")
+    assert connector.engine.url.drivername == "sqlite+aiosqlite"
+    assert connector.engine.pool._pre_ping is False
+
+    async def check_timeout() -> None:
+        async with connector.engine.connect() as conn:
+            timeout = (await conn.execute(sa.text("PRAGMA busy_timeout"))).scalar()
+            assert timeout == 30000
+
+    asyncio.run(check_timeout())
+    asyncio.run(connector.close())
+
+
+def test_memory_dsn_uses_static_pool() -> None:
+    """A bare ':memory:' is an in-memory database, not a file named ':memory:'."""
+    from sqlalchemy.pool import StaticPool
+
+    connector = sqlite_pkg.SQLiteConnector(":memory:")
+    assert isinstance(connector.engine.pool, StaticPool)
+
+    async def check_timeout() -> None:
+        async with connector.engine.connect() as conn:
+            timeout = (await conn.execute(sa.text("PRAGMA busy_timeout"))).scalar()
+            assert timeout == 30000
+
+    asyncio.run(check_timeout())
+    asyncio.run(connector.close())
 
 
 def test_incremental_polls_and_advances_cursor(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1343,7 +1343,7 @@ all = [
     { name = "onestep-mongodb" },
     { name = "onestep-mq" },
     { name = "onestep-redis" },
-    { name = "onestep-sql", extra = ["mysql", "postgres"] },
+    { name = "onestep-sql", extra = ["mysql", "postgres", "sqlite"] },
     { name = "onestep-sqs" },
     { name = "pyyaml" },
 ]
@@ -1379,7 +1379,7 @@ integration = [
     { name = "onestep-mongodb" },
     { name = "onestep-mq" },
     { name = "onestep-redis" },
-    { name = "onestep-sql", extra = ["mysql", "postgres"] },
+    { name = "onestep-sql", extra = ["mysql", "postgres", "sqlite"] },
     { name = "onestep-sqs" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -1407,6 +1407,9 @@ redis = [
 ]
 sql = [
     { name = "onestep-sql", extra = ["mysql", "postgres"] },
+]
+sqlite = [
+    { name = "onestep-sql", extra = ["sqlite"] },
 ]
 sqs = [
     { name = "onestep-sqs" },
@@ -1452,11 +1455,12 @@ requires-dist = [
     { name = "onestep-redis", marker = "extra == 'integration'", editable = "plugins/onestep-redis" },
     { name = "onestep-redis", marker = "extra == 'redis'", editable = "plugins/onestep-redis" },
     { name = "onestep-sql", extras = ["mysql"], marker = "extra == 'mysql'", editable = "plugins/onestep-sql" },
-    { name = "onestep-sql", extras = ["mysql", "postgres"], marker = "extra == 'all'", editable = "plugins/onestep-sql" },
     { name = "onestep-sql", extras = ["mysql", "postgres"], marker = "extra == 'dev'", editable = "plugins/onestep-sql" },
-    { name = "onestep-sql", extras = ["mysql", "postgres"], marker = "extra == 'integration'", editable = "plugins/onestep-sql" },
     { name = "onestep-sql", extras = ["mysql", "postgres"], marker = "extra == 'sql'", editable = "plugins/onestep-sql" },
+    { name = "onestep-sql", extras = ["mysql", "postgres", "sqlite"], marker = "extra == 'all'", editable = "plugins/onestep-sql" },
+    { name = "onestep-sql", extras = ["mysql", "postgres", "sqlite"], marker = "extra == 'integration'", editable = "plugins/onestep-sql" },
     { name = "onestep-sql", extras = ["postgres"], marker = "extra == 'postgres'", editable = "plugins/onestep-sql" },
+    { name = "onestep-sql", extras = ["sqlite"], marker = "extra == 'sqlite'", editable = "plugins/onestep-sql" },
     { name = "onestep-sqs", marker = "extra == 'all'", editable = "plugins/onestep-sqs" },
     { name = "onestep-sqs", marker = "extra == 'dev'", editable = "plugins/onestep-sqs" },
     { name = "onestep-sqs", marker = "extra == 'integration'", editable = "plugins/onestep-sqs" },
@@ -1473,7 +1477,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'test'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0" },
 ]
-provides-extras = ["control-plane", "yaml", "mysql", "postgres", "sql", "rabbitmq", "redis", "sqs", "kafka", "elasticsearch", "clickhouse", "mongodb", "test", "integration", "all", "dev"]
+provides-extras = ["control-plane", "yaml", "mysql", "postgres", "sql", "sqlite", "rabbitmq", "redis", "sqs", "kafka", "elasticsearch", "clickhouse", "mongodb", "test", "integration", "all", "dev"]
 
 [[package]]
 name = "onestep-clickhouse"

--- a/uv.lock
+++ b/uv.lock
@@ -1361,7 +1361,7 @@ dev = [
     { name = "onestep-mongodb" },
     { name = "onestep-mq" },
     { name = "onestep-redis" },
-    { name = "onestep-sql", extra = ["mysql", "postgres"] },
+    { name = "onestep-sql", extra = ["mysql", "postgres", "sqlite"] },
     { name = "onestep-sqs" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -1406,7 +1406,7 @@ redis = [
     { name = "onestep-redis" },
 ]
 sql = [
-    { name = "onestep-sql", extra = ["mysql", "postgres"] },
+    { name = "onestep-sql", extra = ["mysql", "postgres", "sqlite"] },
 ]
 sqlite = [
     { name = "onestep-sql", extra = ["sqlite"] },
@@ -1455,10 +1455,10 @@ requires-dist = [
     { name = "onestep-redis", marker = "extra == 'integration'", editable = "plugins/onestep-redis" },
     { name = "onestep-redis", marker = "extra == 'redis'", editable = "plugins/onestep-redis" },
     { name = "onestep-sql", extras = ["mysql"], marker = "extra == 'mysql'", editable = "plugins/onestep-sql" },
-    { name = "onestep-sql", extras = ["mysql", "postgres"], marker = "extra == 'dev'", editable = "plugins/onestep-sql" },
-    { name = "onestep-sql", extras = ["mysql", "postgres"], marker = "extra == 'sql'", editable = "plugins/onestep-sql" },
     { name = "onestep-sql", extras = ["mysql", "postgres", "sqlite"], marker = "extra == 'all'", editable = "plugins/onestep-sql" },
+    { name = "onestep-sql", extras = ["mysql", "postgres", "sqlite"], marker = "extra == 'dev'", editable = "plugins/onestep-sql" },
     { name = "onestep-sql", extras = ["mysql", "postgres", "sqlite"], marker = "extra == 'integration'", editable = "plugins/onestep-sql" },
+    { name = "onestep-sql", extras = ["mysql", "postgres", "sqlite"], marker = "extra == 'sql'", editable = "plugins/onestep-sql" },
     { name = "onestep-sql", extras = ["postgres"], marker = "extra == 'postgres'", editable = "plugins/onestep-sql" },
     { name = "onestep-sql", extras = ["sqlite"], marker = "extra == 'sqlite'", editable = "plugins/onestep-sql" },
     { name = "onestep-sqs", marker = "extra == 'all'", editable = "plugins/onestep-sqs" },
@@ -1799,7 +1799,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-sql"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "plugins/onestep-sql" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
Expose SQLite as a first-class backend in `onestep-sql`, alongside MySQL and PostgreSQL.

- New `onestep_sql.sqlite` package with 6 public YAML resource types: `sqlite`, `sqlite_state_store`, `sqlite_cursor_store`, `sqlite_table_queue`, `sqlite_incremental`, `sqlite_table_sink`.
- Reuses the shared stores, table-sink policy and incremental state-key behaviour from `onestep_sql._shared`.

## Backend-specific differences
- Driver mapping `sqlite`/`sqlite+pysqlite` → `sqlite+aiosqlite`; bare file paths accepted; in-memory uses `StaticPool`.
- `table_queue` claims rows without `SELECT ... FOR UPDATE` (unsupported by SQLite) via an in-transaction read + claim.
- No binlog (embedded, no CDC) and no tracked execution backend yet (PostgreSQL-only).

## Packaging
- Root `pyproject.toml`: new `sqlite` extra; `all`/`dev`/`integration` now include `onestep-sql[mysql,postgres,sqlite]`.

## Tests
- Updated `test_onestep_sql_canonical.py` (14 → 20 registered types) and added `test_onestep_sql_sqlite.py` (13 functional/contract tests covering insert/upsert, queue claim, incremental poll + cursor advance, driver mapping, error classification).
- Full `tests/contract` suite green (203 passed).

🤖 Generated with [opencode](https://opencode.ai)