### PR TITLE
feat(sqs): add Amazon SNS topic sink to onestep-sqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -373,6 +373,14 @@
 - Scrubs DSN credentials and secret values nested in SQLAlchemy engine options from normalized MySQL error causes.
 - Suppresses raw exception chaining for fetch and send failures so reported tracebacks do not expose secrets.
 
+## onestep-sqs 0.2.4
+
+- Adds an Amazon SNS topic sink (`sns` connector + `sns_topic` sink resource
+  types). `SNSTopic` publishes the standard OneStep envelope to a topic ARN,
+  supports optional `subject` and `message_attributes`, and requires
+  `message_group_id` (with optional `deduplication_id_factory`) for FIFO topics.
+  SNS is publish-only, so consume via an SQS queue subscribed to the topic.
+
 ## onestep-sqs 0.2.3
 
 - Scrubs AWS credentials and known secret connector options from normalized SQS error causes.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Each backend ships as its own package so you only install what you use:
 | **PostgreSQL** | same primitives as MySQL, backed by PostgreSQL | `pip install 'onestep-sql[postgres]'` (`onestep-postgres` shim available) |
 | **RabbitMQ** | `queue` with exchange/routing-key binding and prefetch | `pip install onestep-mq` |
 | **Redis** | `stream` with consumer groups, `XACK`, `XCLAIM`, `maxlen` | `pip install onestep-redis` |
-| **SQS** | `queue` with batched deletes and heartbeat visibility | `pip install onestep-sqs` |
+| **SQS** | `queue` with batched deletes and heartbeat visibility, plus an `sns_topic` fan-out sink | `pip install onestep-sqs` |
 | **Kafka** | `kafka_topic` source/sink with manual offset commits | `pip install onestep-kafka` |
 | **Feishu Bitable** | incremental source and upsert sink | `pip install onestep-feishu-bitable` |
 | **Elasticsearch/OpenSearch** | `elasticsearch` connector and acknowledged `elasticsearch_bulk_sink` over the common REST bulk boundary | `pip install 'onestep[elasticsearch]'` (`onestep-elasticsearch`) |

--- a/docs/broker/index.md
+++ b/docs/broker/index.md
@@ -29,6 +29,7 @@ onestep 1.x 使用 `Source` 表示输入，使用 `Sink` 表示输出。很多�
 | [Redis Streams](/broker/redis) | 支持 | 支持 | Redis Streams 消息队列，安装 `onestep-redis` |
 | [RabbitMQ](/broker/rabbitmq) | 支持 | 支持 | RabbitMQ 队列，安装 `onestep-mq` |
 | [AWS SQS](/broker/sqs) | 支持 | 支持 | AWS SQS 托管队列，安装 `onestep-sqs` |
+| [AWS SNS](/broker/sqs#sns-topic-sink) | 不支持 | 支持 | AWS SNS 主题扇出 Sink，安装 `onestep-sqs` |
 | [Kafka](/broker/kafka) | 支持 | 支持 | Kafka topic source/sink，安装 `onestep-kafka` |
 
 ### 数据库

--- a/docs/broker/sqs.md
+++ b/docs/broker/sqs.md
@@ -257,3 +257,48 @@ async def might_fail(ctx, item):
 - `NumberOfMessagesReceived`: 接收消息数
 - `NumberOfMessagesDeleted`: 删除消息数
 - `NumberOfMessagesFailed`: 失败消息数
+
+## SNS Topic Sink {#sns-topic-sink}
+
+SNS 是发布/订阅服务，只能发布、无法消费，因此 `SNSTopic` 只实现 `Sink`。
+要消费 SNS 消息，标准做法是让 SQS 队列订阅该 Topic，再用 `sqs_queue` 作为 Source。
+
+```python
+from onestep import MemoryQueue, OneStepApp
+from onestep_sqs import SNSConnector
+
+app = OneStepApp("sns-demo")
+sns = SNSConnector(region_name="us-east-1")
+
+notify = sns.topic(
+    "arn:aws:sns:us-east-1:123456789012:events",
+    subject="onestep-event",
+)
+
+
+@app.task(source=MemoryQueue("jobs"), emit=notify)
+async def publish_event(ctx, job):
+    return {"id": job["id"], "status": "done"}
+```
+
+任务返回值会经标准信封编码后作为 SNS `Message` 发布。配置项：
+
+- `subject`：可选的 SNS `Subject`。
+- `message_attributes`：原始 SNS `MessageAttributes` 映射，供订阅过滤策略使用。
+- `message_group_id` / `deduplication_id_factory`：FIFO Topic（ARN 以 `.fifo`
+  结尾）必填分组，去重工厂可选，接收 `Envelope` 并返回去重 ID 字符串。
+- `retry_delay_s`：连接器错误归一化时应用的重试退避提示。
+
+YAML 配置：
+
+```yaml
+resources:
+  sns:
+    type: sns
+    region_name: us-east-1
+  notify:
+    type: sns_topic
+    connector: sns
+    arn: arn:aws:sns:us-east-1:123456789012:events
+    subject: onestep-event
+```

--- a/plugins/onestep-sqs/README.md
+++ b/plugins/onestep-sqs/README.md
@@ -1,6 +1,7 @@
 # onestep-sqs
 
-Amazon SQS connector plugin for `onestep`.
+Amazon SQS connector plugin for `onestep`. The package also ships an Amazon SNS
+topic sink for fan-out publishing.
 
 ```bash
 pip install onestep-sqs
@@ -11,11 +12,13 @@ entry point:
 
 - `sqs`
 - `sqs_queue`
+- `sns`
+- `sns_topic`
 
 Python usage:
 
 ```python
-from onestep_sqs import SQSConnector
+from onestep_sqs import SQSConnector, SNSConnector
 ```
 
 ## Delivery metadata
@@ -53,3 +56,51 @@ the current poll to finish instead of cancelling it. Any deliveries returned
 after fetching has stopped are released immediately with a visibility timeout
 of zero when processing has not started, making them available to SQS consumers
 again without waiting for the configured visibility timeout.
+
+## SNS topic sink
+
+SNS is publish/subscribe only, so `SNSTopic` implements `Sink` (not `Source`).
+To consume SNS messages, subscribe an SQS queue to the topic and use
+`sqs_queue` as the source.
+
+```python
+from onestep import MemoryQueue, OneStepApp
+from onestep_sqs import SNSConnector
+
+app = OneStepApp("sns-demo")
+sns = SNSConnector(region_name="us-east-1")
+notify = sns.topic(
+    "arn:aws:sns:us-east-1:123456789012:events",
+    subject="onestep-event",
+)
+
+
+@app.task(source=MemoryQueue("jobs"), emit=notify)
+async def publish_event(ctx, job):
+    return {"id": job["id"], "status": "done"}
+```
+
+The task return value is encoded with the standard OneStep envelope codec and
+sent as the SNS `Message`. Configuration options:
+
+- `subject`: optional SNS `Subject`.
+- `message_attributes`: raw SNS `MessageAttributes` mapping for subscription
+  filter policies.
+- `message_group_id` / `deduplication_id_factory`: required (group) and
+  optional (dedup) for FIFO topics whose ARN ends in `.fifo`. The factory
+  receives the `Envelope` and returns the deduplication id string.
+- `retry_delay_s`: retry backoff hint applied to normalized connector errors.
+
+YAML:
+
+```yaml
+resources:
+  sns:
+    type: sns
+    region_name: us-east-1
+  notify:
+    type: sns_topic
+    connector: sns
+    arn: arn:aws:sns:us-east-1:123456789012:events
+    subject: onestep-event
+```

--- a/plugins/onestep-sqs/pyproject.toml
+++ b/plugins/onestep-sqs/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "onestep-sqs"
-version = "0.2.3"
-description = "Amazon SQS connector plugin for onestep."
+version = "0.2.4"
+description = "Amazon SQS and SNS connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }

--- a/plugins/onestep-sqs/src/onestep_sqs/__init__.py
+++ b/plugins/onestep-sqs/src/onestep_sqs/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError, version as _package_version
 
 from .connector import SQSConnector, SQSDelivery, SQSQueue
+from .sns import SNSConnector, SNSTopic
 from .resources import register_resources
 from .resilience import classify_sqs_error
 
@@ -14,6 +15,8 @@ except PackageNotFoundError:  # pragma: no cover - local source tree before inst
 register = register_resources
 
 __all__ = [
+    "SNSConnector",
+    "SNSTopic",
     "SQSConnector",
     "SQSDelivery",
     "SQSQueue",

--- a/plugins/onestep-sqs/src/onestep_sqs/resilience.py
+++ b/plugins/onestep-sqs/src/onestep_sqs/resilience.py
@@ -120,12 +120,13 @@ def as_sqs_connector_operation_error(
     source_name: str | None = None,
     retry_delay_s: float | None = None,
     secrets: list[str] | None = None,
+    backend: str = "sqs",
 ) -> ConnectorOperationError | None:
     kind = classify_sqs_error(exc)
     if kind is None:
         return None
     return ConnectorOperationError(
-        backend="sqs",
+        backend=backend,
         operation=operation,
         kind=kind,
         source_name=source_name,

--- a/plugins/onestep-sqs/src/onestep_sqs/resources.py
+++ b/plugins/onestep-sqs/src/onestep_sqs/resources.py
@@ -12,8 +12,23 @@ from onestep.resource_registry import (
 )
 
 from .connector import SQSConnector
+from .sns import SNSConnector
 
 _SQS_FIELDS = frozenset({"type", "region_name", "options"})
+_SNS_FIELDS = frozenset({"type", "region_name", "options"})
+_SNS_TOPIC_FIELDS = frozenset(
+    {
+        "type",
+        "name",
+        "arn",
+        "connector",
+        "subject",
+        "message_group_id",
+        "deduplication_id_factory",
+        "message_attributes",
+        "retry_delay_s",
+    }
+)
 _SQS_QUEUE_FIELDS = frozenset(
     {
         "type",
@@ -65,6 +80,32 @@ _SQS_QUEUE_CATALOG = ResourceCatalogEntry(
     ),
     topology_fields=("url", "wait_time_s", "visibility_timeout", "batch_size", "poll_interval_s"),
 )
+_SNS_CATALOG = ResourceCatalogEntry(
+    type="sns",
+    roles=("connector",),
+    label="Amazon SNS",
+    fields=(
+        ResourceCatalogField("region_name", "string"),
+        ResourceCatalogField("options", "mapping", secret=True),
+    ),
+)
+_SNS_TOPIC_CATALOG = ResourceCatalogEntry(
+    type="sns_topic",
+    roles=("sink",),
+    label="SNS Topic",
+    connector_types=("sns",),
+    fields=(
+        ResourceCatalogField("name", "string"),
+        ResourceCatalogField("arn", "string", required=True, secret=True),
+        ResourceCatalogField("connector", "ref", required=True),
+        ResourceCatalogField("subject", "string"),
+        ResourceCatalogField("message_group_id", "string"),
+        ResourceCatalogField("deduplication_id_factory", "ref"),
+        ResourceCatalogField("message_attributes", "mapping"),
+        ResourceCatalogField("retry_delay_s", "number", default=5.0),
+    ),
+    topology_fields=("arn",),
+)
 
 
 def register_resources(registry: ResourceRegistry) -> None:
@@ -82,6 +123,22 @@ def register_resources(registry: ResourceRegistry) -> None:
             catalog=_SQS_QUEUE_CATALOG,
             allowed_fields=_SQS_QUEUE_FIELDS,
             build=_build_sqs_queue,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="sns",
+            catalog=_SNS_CATALOG,
+            allowed_fields=_SNS_FIELDS,
+            build=_build_sns,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="sns_topic",
+            catalog=_SNS_TOPIC_CATALOG,
+            allowed_fields=_SNS_TOPIC_FIELDS,
+            build=_build_sns_topic,
         )
     )
 
@@ -113,4 +170,30 @@ def _build_sqs_queue(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
         delete_flush_interval_s=spec.get("delete_flush_interval_s", 0.5),
         heartbeat_interval_s=spec.get("heartbeat_interval_s"),
         heartbeat_visibility_timeout=spec.get("heartbeat_visibility_timeout"),
+    )
+
+
+def _build_sns(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> SNSConnector:
+    return SNSConnector(
+        region_name=spec.get("region_name"),
+        options=ctx.mapping_value(spec.get("options"), field=f"{ctx.field}.options"),
+    )
+
+
+def _build_sns_topic(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
+    connector = ctx.resolve_dependency(spec, "connector")
+    if not hasattr(connector, "topic"):
+        raise TypeError(f"resource {spec['connector']!r} cannot build sns_topic")
+    return connector.topic(
+        ctx.require_string(spec, "arn"),
+        subject=spec.get("subject"),
+        message_group_id=spec.get("message_group_id"),
+        deduplication_id_factory=ctx.optional_ref(
+            spec.get("deduplication_id_factory"),
+            field=f"{ctx.field}.deduplication_id_factory",
+        ),
+        message_attributes=ctx.mapping_value(
+            spec.get("message_attributes"), field=f"{ctx.field}.message_attributes"
+        ),
+        retry_delay_s=spec.get("retry_delay_s", 5.0),
     )

--- a/plugins/onestep-sqs/src/onestep_sqs/sns.py
+++ b/plugins/onestep-sqs/src/onestep_sqs/sns.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from onestep.envelope import Envelope
+from onestep.resilience import ConnectorOperation, ConnectorOperationError
+
+from onestep.connectors.base import Sink
+from onestep.connectors.codec import encode_envelope
+
+from .resilience import as_sqs_connector_operation_error, collect_sensitive_tokens
+
+try:  # pragma: no cover - optional dependency
+    import boto3
+except ImportError:  # pragma: no cover - optional dependency
+    boto3 = None
+
+
+@dataclass
+class SNSConnector:
+    region_name: str | None = None
+    options: dict[str, Any] | None = None
+    client: Any | None = None
+    _client: Any | None = field(default=None, init=False, repr=False)
+
+    def _secret_tokens(self) -> list[str]:
+        """Secret-bearing config tokens used to scrub error messages."""
+        return collect_sensitive_tokens(self.options)
+
+    def topic(
+        self,
+        arn: str,
+        *,
+        subject: str | None = None,
+        message_group_id: str | None = None,
+        deduplication_id_factory: Any | None = None,
+        message_attributes: dict[str, Any] | None = None,
+        retry_delay_s: float = 5.0,
+    ) -> "SNSTopic":
+        return SNSTopic(
+            connector=self,
+            arn=arn,
+            subject=subject,
+            message_group_id=message_group_id,
+            deduplication_id_factory=deduplication_id_factory,
+            message_attributes=message_attributes,
+            retry_delay_s=retry_delay_s,
+        )
+
+    def get_client(self) -> Any:
+        if self.client is not None:
+            return self.client
+        if self._client is None:
+            if boto3 is None:
+                raise RuntimeError("SNSConnector requires boto3. Install onestep-sqs.")
+            self._client = boto3.client(
+                "sns", region_name=self.region_name, **(self.options or {})
+            )
+        return self._client
+
+    async def close(self) -> None:
+        self._client = None
+
+
+class SNSTopic(Sink):
+    def __init__(
+        self,
+        *,
+        connector: SNSConnector,
+        arn: str,
+        subject: str | None,
+        message_group_id: str | None,
+        deduplication_id_factory: Any | None,
+        message_attributes: dict[str, Any] | None,
+        retry_delay_s: float,
+    ) -> None:
+        Sink.__init__(self, arn)
+        self.connector = connector
+        self.arn = arn
+        self.subject = subject
+        self.message_group_id = message_group_id
+        self.deduplication_id_factory = deduplication_id_factory
+        self.message_attributes = message_attributes
+        self.retry_delay_s = retry_delay_s
+        self.client: Any | None = None
+
+    async def open(self) -> None:
+        try:
+            if self.client is None:
+                self.client = self.connector.get_client()
+        except Exception as exc:
+            connector_error = as_sqs_connector_operation_error(
+                operation=ConnectorOperation.OPEN,
+                exc=exc,
+                source_name=self.name,
+                retry_delay_s=self.retry_delay_s,
+                secrets=self.connector._secret_tokens(),
+                backend="sns",
+            )
+            if connector_error is None:
+                raise
+            raise connector_error from None
+
+    async def send(self, envelope: Envelope) -> None:
+        try:
+            await self.open()
+            params: dict[str, Any] = {
+                "TopicArn": self.arn,
+                "Message": encode_envelope(envelope).decode("utf-8"),
+            }
+            if self.subject is not None:
+                params["Subject"] = self.subject
+            if self.message_attributes:
+                params["MessageAttributes"] = self.message_attributes
+            if self.arn.endswith(".fifo"):
+                group_id = self.message_group_id
+                if not group_id:
+                    raise ValueError("FIFO SNS topics require message_group_id")
+                params["MessageGroupId"] = group_id
+                if self.deduplication_id_factory is not None:
+                    params["MessageDeduplicationId"] = self.deduplication_id_factory(
+                        envelope
+                    )
+            await asyncio.to_thread(self.client.publish, **params)
+        except ConnectorOperationError:
+            raise
+        except Exception as exc:
+            connector_error = as_sqs_connector_operation_error(
+                operation=ConnectorOperation.SEND,
+                exc=exc,
+                source_name=self.name,
+                retry_delay_s=self.retry_delay_s,
+                secrets=self.connector._secret_tokens(),
+                backend="sns",
+            )
+            if connector_error is None:
+                raise
+            raise connector_error from None
+
+    async def close(self) -> None:
+        self.client = None

--- a/plugins/onestep-sqs/tests/test_sns.py
+++ b/plugins/onestep-sqs/tests/test_sns.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from onestep import Envelope
+from onestep.config import load_app_config
+from onestep.resilience import ConnectorOperationError
+from onestep.resource_registry import ResourceRegistry
+
+from onestep_sqs import SNSConnector, SNSTopic, register
+
+
+class FakeSNSClient:
+    def __init__(self) -> None:
+        self.published: list[dict[str, Any]] = []
+
+    def publish(self, **kwargs: Any) -> dict[str, Any]:
+        self.published.append(kwargs)
+        return {"MessageId": f"msg-{len(self.published)}"}
+
+
+def test_sns_plugin_registers_catalog_metadata() -> None:
+    registry = ResourceRegistry()
+    register(registry)
+    catalog = {entry.type: entry for entry in registry.catalog_entries()}
+    connector_fields = {field.name: field for field in catalog["sns"].fields}
+    topic_fields = {field.name: field for field in catalog["sns_topic"].fields}
+    assert catalog["sns"].roles == ("connector",)
+    assert connector_fields["options"].secret is True
+    assert catalog["sns_topic"].roles == ("sink",)
+    assert catalog["sns_topic"].connector_types == ("sns",)
+    assert topic_fields["arn"].required is True
+    assert topic_fields["arn"].secret is True
+
+
+def test_yaml_builds_sns_resources_via_plugin_entry_point() -> None:
+    app = load_app_config(
+        {
+            "apiVersion": "onestep/v1alpha1",
+            "kind": "App",
+            "app": {"name": "sns-plugin"},
+            "resources": {
+                "sns": {
+                    "type": "sns",
+                    "region_name": "ap-southeast-1",
+                    "options": {"endpoint_url": "http://localstack:4566"},
+                },
+                "notify": {
+                    "type": "sns_topic",
+                    "connector": "sns",
+                    "arn": "arn:aws:sns:ap-southeast-1:123456789012:notify",
+                    "subject": "hello",
+                },
+            },
+            "tasks": [],
+        },
+        strict=True,
+    )
+    assert isinstance(app.resources["sns"], SNSConnector)
+    assert app.resources["sns"].region_name == "ap-southeast-1"
+    assert app.resources["sns"].options == {"endpoint_url": "http://localstack:4566"}
+    assert isinstance(app.resources["notify"], SNSTopic)
+    assert app.resources["notify"].connector is app.resources["sns"]
+    assert app.resources["notify"].arn.endswith(":notify")
+    assert app.resources["notify"].subject == "hello"
+
+
+def test_sns_topic_publishes_encoded_envelope() -> None:
+    client = FakeSNSClient()
+    connector = SNSConnector(client=client)
+    topic = connector.topic(
+        "arn:aws:sns:us-east-1:123456789012:events",
+        subject="event",
+        message_attributes={"kind": {"DataType": "String", "StringValue": "job"}},
+    )
+    asyncio.run(topic.send(Envelope(body={"job": 1})))
+    assert len(client.published) == 1
+    call = client.published[0]
+    assert call["TopicArn"] == "arn:aws:sns:us-east-1:123456789012:events"
+    assert call["Subject"] == "event"
+    assert call["MessageAttributes"] == {
+        "kind": {"DataType": "String", "StringValue": "job"}
+    }
+    assert json.loads(call["Message"])["body"] == {"job": 1}
+
+
+def test_sns_topic_fifo_requires_message_group_id() -> None:
+    client = FakeSNSClient()
+    connector = SNSConnector(client=client)
+    topic = connector.topic("arn:aws:sns:us-east-1:123456789012:events.fifo")
+    with pytest.raises(ValueError, match="message_group_id"):
+        asyncio.run(topic.send(Envelope(body={"job": 1})))
+
+
+def test_sns_topic_fifo_sets_group_and_dedup() -> None:
+    client = FakeSNSClient()
+    connector = SNSConnector(client=client)
+    topic = connector.topic(
+        "arn:aws:sns:us-east-1:123456789012:events.fifo",
+        message_group_id="jobs",
+        deduplication_id_factory=lambda env: str(env.body["job"]),
+    )
+    asyncio.run(topic.send(Envelope(body={"job": 7})))
+    call = client.published[0]
+    assert call["MessageGroupId"] == "jobs"
+    assert call["MessageDeduplicationId"] == "7"
+
+
+def test_sns_connector_error_does_not_leak_option_secrets() -> None:
+    secret_key = "AKIAIOSFODNN7EXAMPLE"
+    secret_token = "IQoJb3JpZ2luX2VjEPn//////////wEaCXVzLXdlc3QtMiJIMEYCIQ"
+
+    class BrokenClient:
+        def publish(self, **kwargs: Any) -> None:
+            raise ConnectionError(
+                f"Access denied with key {secret_key} and token {secret_token}"
+            )
+
+    connector = SNSConnector(
+        options={
+            "aws_access_key_id": secret_key,
+            "aws_session_token": secret_token,
+        },
+        client=BrokenClient(),
+    )
+    topic = connector.topic("arn:aws:sns:us-east-1:123456789012:events")
+    with pytest.raises(ConnectorOperationError) as captured:
+        asyncio.run(topic.send(Envelope(body={"job": 1})))
+    message = str(captured.value.cause)
+    assert captured.value.backend == "sns"
+    assert secret_key not in message
+    assert secret_token not in message


### PR DESCRIPTION
## Summary

Adds an Amazon SNS topic fan-out sink to the `onestep-sqs` plugin. SNS is publish/subscribe only (no consume API), so `SNSTopic` implements `Sink` — to consume SNS messages, subscribe an SQS queue to the topic and use the existing `sqs_queue` source.

## Changes

- `SNSConnector` + `SNSTopic(Sink)`: publish the standard OneStep envelope via `sns.publish`.
- Supports `subject`, raw `message_attributes` (for subscription filter policies), and FIFO topics via `message_group_id` + optional `deduplication_id_factory`.
- Registers `sns` connector and `sns_topic` sink YAML resource types (`topology_fields=("arn",)`).
- Reuses the existing SQS boto3 auth and secret-redaction error handling; `as_sqs_connector_operation_error` gains an optional `backend` arg so SNS errors report `backend="sns"`.
- Bumps `onestep-sqs` 0.2.3 → 0.2.4; updates README (root + plugin), `docs/broker/sqs.md`, `docs/broker/index.md`, and CHANGELOG.

## Tested

- New `plugins/onestep-sqs/tests/test_sns.py` (catalog metadata, YAML build, publish encoding, FIFO validation + group/dedup, secret redaction).
- Full non-integration `onestep-sqs` suite and `tests/contract/test_official_connector_conformance.py`: 73 passed.

## Control-plane note

New source/sink resource types are additive. If the control plane uses strict schemas or field allowlists to render topology, it should learn the `sns`/`sns_topic` types and their `arn` topology field.