### PR TITLE
feat(control-plane): describe SNS topic sink in reporter topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
   (`tests/contract/test_onestep_sql_shared.py`) that pin the shared behaviour
   for both backends.
 
+## onestep-control-plane 0.1.2
+
+- Teaches the reporter to describe the `onestep-sqs` SNS topic sink: maps
+  `SNSTopic` to the `sns_topic` kind and emits its `arn`, `subject`,
+  `message_group_id`, `message_attributes`, and `retry_delay_s` in the topology
+  descriptor so the control plane renders SNS fan-out sinks correctly.
+
 ## onestep-sql 0.2.0
 
 - Publicly exposes the SQLite backend of the canonical `onestep-sql` package

--- a/apps/control-plane/backend/src/onestep_control_plane_api/api/constants.py
+++ b/apps/control-plane/backend/src/onestep_control_plane_api/api/constants.py
@@ -22,6 +22,6 @@ TASK_FAILING_EVENT_KINDS = ("failed", "dead_lettered")
 # Config keys inspected (in order) to derive a human-readable source/sink label
 # from connector config dicts.
 SOURCE_LABEL_CONFIG_KEYS = ("topic", "queue", "stream", "url", "schedule", "cron")
-SINK_LABEL_CONFIG_KEYS = ("topic", "queue", "stream", "url", "table", "database")
+SINK_LABEL_CONFIG_KEYS = ("topic", "queue", "stream", "url", "arn", "table", "database")
 # Config keys inspected (in order) to derive retry attempts from retry policy.
 RETRY_ATTEMPTS_CONFIG_KEYS = ("attempts", "max_attempts", "retries")

--- a/plugins/onestep-control-plane/pyproject.toml
+++ b/plugins/onestep-control-plane/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-control-plane"
-version = "0.1.1"
+version = "0.1.2"
 description = "Control-plane reporter and WebSocket integration plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/plugins/onestep-control-plane/src/onestep_control_plane/reporter.py
+++ b/plugins/onestep-control-plane/src/onestep_control_plane/reporter.py
@@ -115,6 +115,7 @@ _KIND_OVERRIDES = {
     "NoRetry": "no_retry",
     "RabbitMQQueue": "rabbitmq_queue",
     "RedisStreamQueue": "redis_stream",
+    "SNSTopic": "sns_topic",
     "SQSQueue": "sqs_queue",
     "TableQueueSource": "mysql_table_queue",
     "TableSink": "mysql_table_sink",
@@ -802,6 +803,14 @@ class ControlPlaneReporter:
                 "delete_flush_interval_s": resource.delete_flush_interval_s,
                 "heartbeat_interval_s": resource.heartbeat_interval_s,
                 "heartbeat_visibility_timeout": resource.heartbeat_visibility_timeout,
+            }
+        if class_name == "SNSTopic":
+            return {
+                "arn": resource.arn,
+                "subject": resource.subject,
+                "message_group_id": resource.message_group_id,
+                "message_attributes": resource.message_attributes,
+                "retry_delay_s": resource.retry_delay_s,
             }
         if class_name == "RedisStreamQueue":
             return {

--- a/plugins/onestep-control-plane/tests/test_sns_topology.py
+++ b/plugins/onestep-control-plane/tests/test_sns_topology.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from control_plane_testkit import SenderRecorder, make_config
+from onestep import MemoryQueue, OneStepApp
+from onestep.connectors.base import Sink
+from onestep.envelope import Envelope
+from onestep_control_plane import ControlPlaneReporter
+
+
+class SNSTopic(Sink):
+    """Minimal stand-in mirroring onestep_sqs.SNSTopic's shape.
+
+    The reporter maps connectors by class name, so this avoids a hard
+    onestep-sqs test dependency while exercising the sns_topic descriptor.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("arn:aws:sns:us-east-1:123456789012:events.fifo")
+        self.arn = "arn:aws:sns:us-east-1:123456789012:events.fifo"
+        self.subject = "onestep-event"
+        self.message_group_id = "jobs"
+        self.message_attributes = {
+            "kind": {"DataType": "String", "StringValue": "job"}
+        }
+        self.retry_delay_s = 7.5
+
+    async def send(self, envelope: Envelope) -> None:  # pragma: no cover - unused
+        return None
+
+
+def test_reporter_describes_sns_topic_kind_and_config() -> None:
+    recorder = SenderRecorder()
+    app = OneStepApp("events-fanout")
+    sink = SNSTopic()
+
+    @app.task(source=MemoryQueue("incoming"), emit=sink)
+    async def forward(ctx, payload):
+        return payload
+
+    reporter = ControlPlaneReporter(make_config(), sender=recorder)
+    reporter.attach(app)
+
+    asyncio.run(reporter.send_sync_now())
+
+    sync_payload = next(payload for channel, payload in recorder.calls if channel == "sync")
+    emit = sync_payload["app"]["tasks"][0]["emit"][0]
+    assert emit == {
+        "kind": "sns_topic",
+        "name": "arn:aws:sns:us-east-1:123456789012:events.fifo",
+        "config": {
+            "arn": "arn:aws:sns:us-east-1:123456789012:events.fifo",
+            "subject": "onestep-event",
+            "message_group_id": "jobs",
+            "message_attributes": {
+                "kind": {"DataType": "String", "StringValue": "job"}
+            },
+            "retry_delay_s": 7.5,
+        },
+    }
+    assert json.loads(json.dumps(sync_payload["app"]))["tasks"][0]["emit"][0]["kind"] == "sns_topic"


### PR DESCRIPTION
## Summary

Companion PR to #142 (onestep-sqs SNS topic sink). Teaches the control-plane reporter and dashboard to recognize and render the new `sns_topic` sink.

Related: #142

## Changes

- **Reporter** (`onestep-control-plane`): map `SNSTopic` → `sns_topic` kind via `_KIND_OVERRIDES` (the auto snake_case would otherwise emit `s_n_s_topic`), and add a `_build_connector_config` branch emitting `arn`, `subject`, `message_group_id`, `message_attributes`, and `retry_delay_s`.
- **Plane backend**: add `arn` to `SINK_LABEL_CONFIG_KEYS` so an SNS sink without an explicit name still derives a readable label from its topic ARN.
- Bump `onestep-control-plane` 0.1.1 → 0.1.2; changelog entry.

## Why this is needed

Per the repo's control-plane coordination rules, adding a new sink resource type is an additive topology field change. The reporter maps connectors by class name, so without the `_KIND_OVERRIDES` entry the SNS sink would report as `s_n_s_topic` and lose its typed config. The plane otherwise renders unknown configs generically, so this is a forward-compatible enrichment (no schema/allowlist rejection was found).

## Tested

- New `plugins/onestep-control-plane/tests/test_sns_topology.py` asserts the reporter emits the `sns_topic` kind and full config (using a minimal SNSTopic stand-in to avoid a hard onestep-sqs test dependency).
- `onestep-control-plane` plugin suite: 159 passed.
- Plane backend suite: 333 passed (includes sink-label/topology/query tests).

## Deploy note

Per AGENTS.md, control-plane code changes baked into the image require `docker compose build plane && docker compose up -d plane` for local dev. No DB migration is involved (the label-key and reporter changes are code-only).