### PR TITLE
feat(cf-queues): add Cloudflare Queues HTTP pull-consumer connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Adds the `onestep-cf-queues` plugin: a Cloudflare Queues connector that
+  consumes and publishes over the HTTP pull-consumer REST API (works outside
+  Cloudflare Workers). Registers YAML resource types `cf_queues` (connector)
+  and `cf_queue` (source + sink), with batched lease ack/retry, base64 body
+  decoding for the `json`/`bytes` content types, `on_fail` policy
+  (`leave`/`retry`/`ack`), and short-polling `fetch` (`fetch_is_cancel_safe`).
+  Install via `pip install 'onestep[cloudflare]'`.
+
 - Adds `onestep render <target>`: renders the worker topology of any Python or
   YAML target as a Mermaid flowchart (`--format mermaid`, the only format for
   now). Task nodes carry concurrency, retry, and timeout; edges are labeled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@
 ## Unreleased
 
 - Adds the `onestep-cf-queues` plugin: a Cloudflare Queues connector that
-  consumes and publishes over the HTTP pull-consumer REST API (works outside
-  Cloudflare Workers). Registers YAML resource types `cf_queues` (connector)
-  and `cf_queue` (source + sink), with batched lease ack/retry, base64 body
-  decoding for the `json`/`bytes` content types, `on_fail` policy
-  (`leave`/`retry`/`ack`), and short-polling `fetch` (`fetch_is_cancel_safe`).
-  Install via `pip install 'onestep[cloudflare]'`.
+  wraps the official `cloudflare` Python SDK to consume and publish over the
+  HTTP pull-consumer REST API (works outside Cloudflare Workers). Registers
+  YAML resource types `cf_queues` (connector) and `cf_queue` (source + sink),
+  with batched lease ack/retry, base64 body decoding for the `json`/`bytes`
+  content types, `on_fail` policy (`leave`/`retry`/`ack`), and short-polling
+  `fetch` (`fetch_is_cancel_safe`). Install via
+  `pip install 'onestep[cloudflare]'`.
 
 - Adds `onestep render <target>`: renders the worker topology of any Python or
   YAML target as a Mermaid flowchart (`--format mermaid`, the only format for

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Each backend ships as its own package so you only install what you use:
 | **RabbitMQ** | `queue` with exchange/routing-key binding and prefetch | `pip install onestep-mq` |
 | **Redis** | `stream` with consumer groups, `XACK`, `XCLAIM`, `maxlen` | `pip install onestep-redis` |
 | **SQS** | `queue` with batched deletes and heartbeat visibility, plus an `sns_topic` fan-out sink | `pip install onestep-sqs` |
-| **Cloudflare Queues** | `cf_queue` HTTP pull-consumer source/sink with batched lease ack/retry | `pip install 'onestep[cloudflare]'` (`onestep-cf-queues`) |
+| **Cloudflare Queues** | `cf_queue` HTTP pull-consumer source/sink (official `cloudflare` SDK) with batched lease ack/retry | `pip install 'onestep[cloudflare]'` (`onestep-cf-queues`) |
 | **Kafka** | `kafka_topic` source/sink with manual offset commits | `pip install onestep-kafka` |
 | **Feishu Bitable** | incremental source and upsert sink | `pip install onestep-feishu-bitable` |
 | **Elasticsearch/OpenSearch** | `elasticsearch` connector and acknowledged `elasticsearch_bulk_sink` over the common REST bulk boundary | `pip install 'onestep[elasticsearch]'` (`onestep-elasticsearch`) |

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ multiple tasks appear once, so chained topologies are drawn as connected graphs.
 
 | Capability | Where |
 | --- | --- |
-| **Fetch work** from a queue, schedule, webhook, or DB cursor | `MemoryQueue`, `IntervalSource`, `CronSource`, `WebhookSource`, MySQL `table_queue` / `incremental` / binlog, RabbitMQ `queue`, Redis `stream`, SQS `queue`, Kafka `kafka_topic`, MongoDB `mongodb_polling` / `mongodb_change_stream` |
+| **Fetch work** from a queue, schedule, webhook, or DB cursor | `MemoryQueue`, `IntervalSource`, `CronSource`, `WebhookSource`, MySQL `table_queue` / `incremental` / binlog, RabbitMQ `queue`, Redis `stream`, SQS `queue`, Cloudflare `cf_queue`, Kafka `kafka_topic`, MongoDB `mongodb_polling` / `mongodb_change_stream` |
 | **Emit results** to a downstream sink | any source doubles as a sink; MySQL `table_sink`; Kafka `kafka_topic`; Elasticsearch/OpenSearch `elasticsearch_bulk_sink`; ClickHouse `clickhouse_table_sink`; MongoDB `mongodb_collection_sink`; HTTP `http_sink`; Feishu Bitable sink |
 | **Schedule** recurring work | `IntervalSource.every(...)`, `CronSource(...)` with overlap control (`allow` / `skip` / `queue`) |
 | **Ingest external events** | `WebhookSource` with bearer auth, shared listeners, body parsing |
@@ -218,6 +218,7 @@ Each backend ships as its own package so you only install what you use:
 | **RabbitMQ** | `queue` with exchange/routing-key binding and prefetch | `pip install onestep-mq` |
 | **Redis** | `stream` with consumer groups, `XACK`, `XCLAIM`, `maxlen` | `pip install onestep-redis` |
 | **SQS** | `queue` with batched deletes and heartbeat visibility, plus an `sns_topic` fan-out sink | `pip install onestep-sqs` |
+| **Cloudflare Queues** | `cf_queue` HTTP pull-consumer source/sink with batched lease ack/retry | `pip install 'onestep[cloudflare]'` (`onestep-cf-queues`) |
 | **Kafka** | `kafka_topic` source/sink with manual offset commits | `pip install onestep-kafka` |
 | **Feishu Bitable** | incremental source and upsert sink | `pip install onestep-feishu-bitable` |
 | **Elasticsearch/OpenSearch** | `elasticsearch` connector and acknowledged `elasticsearch_bulk_sink` over the common REST bulk boundary | `pip install 'onestep[elasticsearch]'` (`onestep-elasticsearch`) |

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -26,6 +26,8 @@ COPY plugins/onestep-postgres/pyproject.toml plugins/onestep-postgres/README.md 
 COPY plugins/onestep-postgres/src/onestep_postgres /tmp/onestep/plugins/onestep-postgres/src/onestep_postgres
 COPY plugins/onestep-sqs/pyproject.toml plugins/onestep-sqs/README.md /tmp/onestep/plugins/onestep-sqs/
 COPY plugins/onestep-sqs/src/onestep_sqs /tmp/onestep/plugins/onestep-sqs/src/onestep_sqs
+COPY plugins/onestep-cf-queues/pyproject.toml plugins/onestep-cf-queues/README.md /tmp/onestep/plugins/onestep-cf-queues/
+COPY plugins/onestep-cf-queues/src/onestep_cf_queues /tmp/onestep/plugins/onestep-cf-queues/src/onestep_cf_queues
 COPY plugins/onestep-kafka/pyproject.toml plugins/onestep-kafka/README.md /tmp/onestep/plugins/onestep-kafka/
 COPY plugins/onestep-kafka/src/onestep_kafka /tmp/onestep/plugins/onestep-kafka/src/onestep_kafka
 COPY plugins/onestep-elasticsearch/pyproject.toml plugins/onestep-elasticsearch/README.md /tmp/onestep/plugins/onestep-elasticsearch/
@@ -45,6 +47,7 @@ RUN python -m pip install --upgrade pip \
         /tmp/onestep/plugins/onestep-mysql \
         /tmp/onestep/plugins/onestep-postgres \
         /tmp/onestep/plugins/onestep-sqs \
+        /tmp/onestep/plugins/onestep-cf-queues \
         /tmp/onestep/plugins/onestep-kafka \
         /tmp/onestep/plugins/onestep-elasticsearch \
         /tmp/onestep/plugins/onestep-clickhouse \

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -97,6 +97,7 @@ export default defineConfig({
           { text: 'RabbitMQ', link: '/broker/rabbitmq' },
           { text: 'Redis Streams', link: '/broker/redis' },
           { text: 'AWS SQS', link: '/broker/sqs' },
+          { text: 'Cloudflare Queues', link: '/broker/cf-queues' },
           { text: 'MySQL', link: '/broker/mysql' },
           { text: 'PostgreSQL', link: '/broker/postgres' },
           { text: 'PostgreSQL Tracked Execution', link: '/broker/postgres-execution' },

--- a/docs/broker/cf-queues.md
+++ b/docs/broker/cf-queues.md
@@ -5,7 +5,8 @@ outline: deep
 
 # Cloudflare Queues
 
-[Cloudflare Queues](https://developers.cloudflare.com/queues/) 是 Cloudflare 提供的托管消息队列。onestep 通过其
+[Cloudflare Queues](https://developers.cloudflare.com/queues/) 是 Cloudflare 提供的托管消息队列。onestep 通过官方
+[`cloudflare` Python SDK](https://github.com/cloudflare/cloudflare-python) 调用其
 [HTTP 拉取消费者（pull consumer）REST API](https://developers.cloudflare.com/queues/configuration/pull-consumers/)
 接入，因此可以在 Cloudflare Workers 之外的任意环境中消费和投递消息。
 
@@ -73,7 +74,7 @@ tasks:
 
 ## 资源类型
 
-- `cf_queues`：连接器，持有 `account_id`、`api_token`、`base_url`、`timeout_s`。
+- `cf_queues`：连接器，持有 `account_id`、`api_token`，以及可选 `base_url`、`timeout_s`。
 - `cf_queue`：既是 source 又是 sink，通过 `connector` 引用连接器。
 
 `cf_queue` 字段：
@@ -90,12 +91,14 @@ tasks:
 
 ## 语义映射
 
-| onestep | Cloudflare Queues API |
+连接器封装官方 `cloudflare` SDK 的异步客户端（`AsyncCloudflare().queues.messages`）：
+
+| onestep | cloudflare SDK 调用 |
 | --- | --- |
-| `Source.fetch` | `POST /accounts/{id}/queues/{qid}/messages/pull` |
-| `Delivery.ack` | `POST .../messages/ack`，`acks: [{lease_id}]` |
-| `Delivery.retry(delay_s)` | `POST .../messages/ack`，`retries: [{lease_id, delay_seconds}]` |
-| `Sink.send` | `POST .../messages` |
+| `Source.fetch` | `queues.messages.pull(queue_id, account_id=...)` |
+| `Delivery.ack` | `queues.messages.ack(..., acks=[{lease_id}])` |
+| `Delivery.retry(delay_s)` | `queues.messages.ack(..., retries=[{lease_id, delay_seconds}])` |
+| `Sink.send` | `queues.messages.push(...)` |
 
 ack 与 retry 会被缓冲，达到 `ack_batch_size` 或经过 `ack_flush_interval_s` 后合并为单次 `/ack` 请求。
 

--- a/docs/broker/cf-queues.md
+++ b/docs/broker/cf-queues.md
@@ -1,0 +1,146 @@
+---
+title: Cloudflare Queues | Broker
+outline: deep
+---
+
+# Cloudflare Queues
+
+[Cloudflare Queues](https://developers.cloudflare.com/queues/) 是 Cloudflare 提供的托管消息队列。onestep 通过其
+[HTTP 拉取消费者（pull consumer）REST API](https://developers.cloudflare.com/queues/configuration/pull-consumers/)
+接入，因此可以在 Cloudflare Workers 之外的任意环境中消费和投递消息。
+
+## 安装
+
+```bash
+pip install onestep-cf-queues
+# 或作为 onestep 的可选依赖
+pip install 'onestep[cloudflare]'
+```
+
+## 前置条件
+
+1. 为队列启用 HTTP 拉取：
+
+   ```bash
+   npx wrangler queues consumer http add <QUEUE-NAME>
+   ```
+
+   一个队列不能同时拥有 Worker（推送）消费者和 HTTP（拉取）消费者。
+
+2. 创建具有 **Queues** `Edit`（读 + 写）权限的 API Token。拉取消费者需要写权限来确认（ack）消息。
+
+## 配置
+
+Python：
+
+```python
+from onestep import OneStepApp
+from onestep_cf_queues import CFQueuesConnector
+
+app = OneStepApp("cf-queues-demo")
+cf = CFQueuesConnector(account_id="<account-id>", api_token="<api-token>")
+jobs = cf.queue("<queue-id>", batch_size=10, visibility_timeout_ms=30000)
+
+
+@app.task(source=jobs)
+async def consume(ctx, item):
+    print("processing", item)
+```
+
+YAML：
+
+```yaml
+resources:
+  cf:
+    type: cf_queues
+    account_id: "${CF_ACCOUNT_ID}"
+    api_token: "${CF_QUEUES_TOKEN}"
+
+  jobs:
+    type: cf_queue
+    connector: cf
+    queue_id: "${CF_QUEUE_ID}"
+    batch_size: 10
+    visibility_timeout_ms: 30000
+    on_fail: leave
+
+tasks:
+  - name: consume
+    source: jobs
+    handler:
+      ref: your_package.tasks:consume
+```
+
+## 资源类型
+
+- `cf_queues`：连接器，持有 `account_id`、`api_token`、`base_url`、`timeout_s`。
+- `cf_queue`：既是 source 又是 sink，通过 `connector` 引用连接器。
+
+`cf_queue` 字段：
+
+| 字段 | 默认 | 说明 |
+| --- | --- | --- |
+| `queue_id` | （必填） | Cloudflare 队列 ID |
+| `batch_size` | 5 | 每次拉取返回的消息数（1–100） |
+| `visibility_timeout_ms` | 服务端默认 30s | 租约时长，最大 12 小时 |
+| `poll_interval_s` | 1.0 | 短轮询间隔 |
+| `on_fail` | `leave` | 失败处理：`leave` / `retry` / `ack` |
+| `ack_batch_size` | 100 | 单次 `/ack` 请求合并的 lease 数（1–100） |
+| `ack_flush_interval_s` | 0.5 | ack/retry 定时刷新间隔 |
+
+## 语义映射
+
+| onestep | Cloudflare Queues API |
+| --- | --- |
+| `Source.fetch` | `POST /accounts/{id}/queues/{qid}/messages/pull` |
+| `Delivery.ack` | `POST .../messages/ack`，`acks: [{lease_id}]` |
+| `Delivery.retry(delay_s)` | `POST .../messages/ack`，`retries: [{lease_id, delay_seconds}]` |
+| `Sink.send` | `POST .../messages` |
+
+ack 与 retry 会被缓冲，达到 `ack_batch_size` 或经过 `ack_flush_interval_s` 后合并为单次 `/ack` 请求。
+
+## 消息元数据
+
+拉取到的消息会解码标准 onestep envelope，并在 `delivery.envelope.meta["cf_queues"]` 暴露 Cloudflare 元数据：
+
+```python
+{
+    "id": "1ad27d24c83de78953da635dc2ea208f",
+    "timestamp_ms": 1689615013586,
+    "attempts": 2,
+    "metadata": {"CF-Content-Type": "json"},
+}
+```
+
+`lease_id` 仅用于内部 ack/retry/release，不会暴露到 envelope。
+
+## Content type 与编码
+
+拉取消费者只能处理 `text`、`bytes`、`json` content type（默认 `json`），无法解码
+Workers 专用的 `v8`。对于 `json` 和 `bytes`，body 会以 base64 传输，连接器会自动
+base64 解码后再交给 envelope 编解码器。
+
+## 失败处理（`on_fail`）
+
+- `leave`（默认）：失败时不动，等 `visibility_timeout` 到期后由服务端重投。
+- `retry`：立即标记重试，消息马上回到队列。
+- `ack`：失败时确认（丢弃）消息，例如死信 sink 已处理完毕。
+
+## 短轮询与无租约续期
+
+与 SQS 长轮询不同，Cloudflare 拉取是**短轮询**：`fetch` 立即返回（无消息时返回空），
+因此 `fetch_is_cancel_safe` 为 `True`，用 `poll_interval_s` 控制轮询频率。
+
+Cloudflare Queues **没有租约续期（heartbeat）端点**，租约时长固定为
+`visibility_timeout`（默认 30s，最大 12 小时）。对于长耗时 handler，需要把
+`visibility_timeout_ms` 设得足够大以覆盖最坏处理时间，因为处理中途无法延长租约。
+
+## 限制
+
+- 消息大小：128 KB。
+- 消费者批量：最多 100 条。
+- `visibility_timeout`：最大 12 小时。
+- retry `delay_seconds`：最大 24 小时。
+- 单队列吞吐：5,000 消息/秒。
+
+投递语义为 at-least-once，重复敏感的场景请保证 handler 幂等。

--- a/plugins/onestep-cf-queues/README.md
+++ b/plugins/onestep-cf-queues/README.md
@@ -1,0 +1,132 @@
+# onestep-cf-queues
+
+Cloudflare Queues connector plugin for `onestep`. It consumes and publishes over
+the [HTTP pull-consumer REST API](https://developers.cloudflare.com/queues/configuration/pull-consumers/),
+so it runs from any environment outside Cloudflare Workers.
+
+```bash
+pip install onestep-cf-queues
+```
+
+The package registers these YAML resource types through the `onestep.resources`
+entry point:
+
+- `cf_queues` (connector)
+- `cf_queue` (source + sink)
+
+Python usage:
+
+```python
+from onestep import OneStepApp
+from onestep_cf_queues import CFQueuesConnector
+
+app = OneStepApp("cf-queues-demo")
+cf = CFQueuesConnector(account_id="<account-id>", api_token="<api-token>")
+jobs = cf.queue("<queue-id>", batch_size=10, visibility_timeout_ms=30000)
+
+
+@app.task(source=jobs)
+async def consume(ctx, item):
+    print("processing", item)
+```
+
+YAML:
+
+```yaml
+resources:
+  cf:
+    type: cf_queues
+    account_id: "${CF_ACCOUNT_ID}"
+    api_token: "${CF_QUEUES_TOKEN}"
+
+  jobs:
+    type: cf_queue
+    connector: cf
+    queue_id: "${CF_QUEUE_ID}"
+    batch_size: 10
+    visibility_timeout_ms: 30000
+    on_fail: leave
+
+tasks:
+  - name: consume
+    source: jobs
+    handler:
+      ref: your_package.tasks:consume
+```
+
+## Prerequisites
+
+1. Enable HTTP pull on the queue: `npx wrangler queues consumer http add <QUEUE-NAME>`.
+   A queue cannot have both a Worker (push) consumer and an HTTP (pull) consumer.
+2. Create an API token with the **Queues** `Edit` permission (read **and** write).
+   A pull consumer must be able to write to acknowledge messages.
+
+## How it maps to onestep
+
+| onestep | Cloudflare Queues API |
+|---|---|
+| `Source.fetch` | `POST /accounts/{id}/queues/{qid}/messages/pull` |
+| `Delivery.ack` | `POST .../messages/ack` with `acks: [{lease_id}]` |
+| `Delivery.retry(delay_s)` | `POST .../messages/ack` with `retries: [{lease_id, delay_seconds}]` |
+| `Sink.send` | `POST .../messages` (single message) |
+
+Acks and retries are buffered and flushed in batches (`ack_batch_size`, up to
+100 per request) or on a timer (`ack_flush_interval_s`), then combined into a
+single `/ack` call.
+
+## Delivery metadata
+
+Fetched messages decode the standard onestep envelope and expose Cloudflare
+message metadata under `delivery.envelope.meta["cf_queues"]`:
+
+```python
+{
+    "id": "1ad27d24c83de78953da635dc2ea208f",
+    "timestamp_ms": 1689615013586,
+    "attempts": 2,
+    "metadata": {"CF-Content-Type": "json"},
+}
+```
+
+`lease_id` is kept internal to ack/retry/release handling and is not exposed on
+the envelope.
+
+## Content types
+
+Attach a pull consumer only to queues whose messages use the `text`, `bytes`,
+or `json` content type (the default is `json`). The `v8` content type is
+Workers-only and cannot be decoded. For `json` and `bytes` content types the
+body arrives base64-encoded; the connector decodes base64 automatically before
+running it through the envelope codec.
+
+## Failure handling (`on_fail`)
+
+- `leave` (default): do nothing on failure. The message is re-delivered once its
+  `visibility_timeout` expires.
+- `retry`: mark the message for immediate retry (put back in the queue now).
+- `ack`: acknowledge (drop) the message on failure, e.g. after a dead-letter
+  sink has already handled it.
+
+## Short polling and no lease renewal
+
+Unlike SQS long polling, Cloudflare pull uses **short polling**: `fetch` returns
+immediately (empty when there are no messages), so `fetch_is_cancel_safe` is
+`True`. Configure `poll_interval_s` to control how often the source polls.
+
+Cloudflare Queues has **no lease-renewal (heartbeat) endpoint**. A message's
+lease lasts exactly `visibility_timeout` (default 30s, max 12 hours). For
+long-running handlers, set `visibility_timeout_ms` large enough to cover the
+worst-case processing time, since the lease cannot be extended mid-processing.
+
+## Limits
+
+Cloudflare Queues enforces these limits (see the
+[limits docs](https://developers.cloudflare.com/queues/platform/limits/)):
+
+- Message size: 128 KB.
+- Consumer batch size: up to 100 messages (`batch_size`, `ack_batch_size`).
+- `visibility_timeout`: up to 12 hours.
+- Retry `delay_seconds`: up to 24 hours.
+- Per-queue throughput: 5,000 messages/second.
+
+Delivery is at-least-once, so make handlers idempotent when duplicates matter.

--- a/plugins/onestep-cf-queues/README.md
+++ b/plugins/onestep-cf-queues/README.md
@@ -1,7 +1,9 @@
 # onestep-cf-queues
 
-Cloudflare Queues connector plugin for `onestep`. It consumes and publishes over
-the [HTTP pull-consumer REST API](https://developers.cloudflare.com/queues/configuration/pull-consumers/),
+Cloudflare Queues connector plugin for `onestep`. It uses the official
+[`cloudflare` Python SDK](https://github.com/cloudflare/cloudflare-python) to
+consume and publish over the
+[HTTP pull-consumer REST API](https://developers.cloudflare.com/queues/configuration/pull-consumers/),
 so it runs from any environment outside Cloudflare Workers.
 
 ```bash
@@ -63,12 +65,15 @@ tasks:
 
 ## How it maps to onestep
 
-| onestep | Cloudflare Queues API |
+The connector wraps the official `cloudflare` SDK's async client
+(`AsyncCloudflare().queues.messages`):
+
+| onestep | cloudflare SDK call |
 |---|---|
-| `Source.fetch` | `POST /accounts/{id}/queues/{qid}/messages/pull` |
-| `Delivery.ack` | `POST .../messages/ack` with `acks: [{lease_id}]` |
-| `Delivery.retry(delay_s)` | `POST .../messages/ack` with `retries: [{lease_id, delay_seconds}]` |
-| `Sink.send` | `POST .../messages` (single message) |
+| `Source.fetch` | `queues.messages.pull(queue_id, account_id=...)` |
+| `Delivery.ack` | `queues.messages.ack(..., acks=[{lease_id}])` |
+| `Delivery.retry(delay_s)` | `queues.messages.ack(..., retries=[{lease_id, delay_seconds}])` |
+| `Sink.send` | `queues.messages.push(...)` |
 
 Acks and retries are buffered and flushed in batches (`ack_batch_size`, up to
 100 per request) or on a timer (`ack_flush_interval_s`), then combined into a

--- a/plugins/onestep-cf-queues/pyproject.toml
+++ b/plugins/onestep-cf-queues/pyproject.toml
@@ -1,0 +1,38 @@
+[project]
+name = "onestep-cf-queues"
+version = "0.1.0"
+description = "Cloudflare Queues HTTP pull-consumer connector plugin for onestep."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+dependencies = [
+    "onestep>=1.7.1",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[project.entry-points."onestep.resources"]
+cf_queues = "onestep_cf_queues:register"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/onestep_cf_queues"]
+
+[tool.uv.sources]
+onestep = { workspace = true }
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+markers = ["integration: live external service tests"]

--- a/plugins/onestep-cf-queues/pyproject.toml
+++ b/plugins/onestep-cf-queues/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.9"
 license = { text = "MIT" }
 dependencies = [
     "onestep>=1.7.1",
-    "httpx>=0.27",
+    "cloudflare>=4,<6",
 ]
 
 [project.optional-dependencies]

--- a/plugins/onestep-cf-queues/src/onestep_cf_queues/__init__.py
+++ b/plugins/onestep-cf-queues/src/onestep_cf_queues/__init__.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version as _package_version
+
+from .connector import CFQueue, CFQueuesConnector, CFQueuesDelivery
+from .resilience import (
+    CFQueuesErrorCause,
+    CFQueuesHTTPError,
+    as_cf_connector_operation_error,
+    classify_cf_error,
+)
+from .resources import register_resources
+
+try:
+    __version__ = _package_version("onestep-cf-queues")
+except PackageNotFoundError:  # pragma: no cover - local source tree before install
+    __version__ = "dev"
+
+register = register_resources
+
+__all__ = [
+    "CFQueue",
+    "CFQueuesConnector",
+    "CFQueuesDelivery",
+    "CFQueuesErrorCause",
+    "CFQueuesHTTPError",
+    "__version__",
+    "as_cf_connector_operation_error",
+    "classify_cf_error",
+    "register",
+    "register_resources",
+]

--- a/plugins/onestep-cf-queues/src/onestep_cf_queues/__init__.py
+++ b/plugins/onestep-cf-queues/src/onestep_cf_queues/__init__.py
@@ -5,7 +5,6 @@ from importlib.metadata import PackageNotFoundError, version as _package_version
 from .connector import CFQueue, CFQueuesConnector, CFQueuesDelivery
 from .resilience import (
     CFQueuesErrorCause,
-    CFQueuesHTTPError,
     as_cf_connector_operation_error,
     classify_cf_error,
 )
@@ -23,7 +22,6 @@ __all__ = [
     "CFQueuesConnector",
     "CFQueuesDelivery",
     "CFQueuesErrorCause",
-    "CFQueuesHTTPError",
     "__version__",
     "as_cf_connector_operation_error",
     "classify_cf_error",

--- a/plugins/onestep-cf-queues/src/onestep_cf_queues/connector.py
+++ b/plugins/onestep-cf-queues/src/onestep_cf_queues/connector.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from onestep.connectors.base import Delivery, Sink, Source
+from onestep.connectors.codec import decode_envelope, encode_envelope
+from onestep.envelope import Envelope
+from onestep.resilience import ConnectorOperation, ConnectorOperationError
+
+from .resilience import (
+    CFQueuesHTTPError,
+    as_cf_connector_operation_error,
+    collect_sensitive_tokens,
+)
+
+try:  # pragma: no cover - optional dependency
+    import httpx
+except ImportError:  # pragma: no cover - optional dependency
+    httpx = None
+
+_DEFAULT_BASE_URL = "https://api.cloudflare.com/client/v4"
+
+# Cloudflare Queues limits (see docs/platform/limits).
+_MAX_BATCH_SIZE = 100
+_MAX_VISIBILITY_TIMEOUT_MS = 12 * 60 * 60 * 1000  # 12 hours
+_MAX_DELAY_SECONDS = 24 * 60 * 60  # 24 hours
+
+
+def _decode_message_body(raw: Any) -> Envelope:
+    """Decode a Cloudflare pull message ``body`` into an onestep Envelope.
+
+    Pull consumers may receive the body as a structured JSON value, a plain
+    UTF-8 string (``text`` content type), or a base64-encoded string (``json``
+    or ``bytes`` content types). This normalizes all of those into the envelope
+    codec input.
+    """
+    if isinstance(raw, (dict, list)):
+        return decode_envelope(raw)
+    if isinstance(raw, (bytes, bytearray)):
+        return decode_envelope(bytes(raw))
+    if isinstance(raw, str):
+        # json / bytes content types arrive base64-encoded; text arrives as a
+        # plain (possibly already-JSON) string. Try base64 first, but only
+        # accept it when the decoded bytes parse as JSON, otherwise treat the
+        # string as-is.
+        try:
+            decoded = base64.b64decode(raw, validate=True)
+        except (binascii.Error, ValueError):
+            decoded = None
+        if decoded is not None:
+            try:
+                json.loads(decoded.decode("utf-8"))
+            except (ValueError, UnicodeDecodeError):
+                pass
+            else:
+                return decode_envelope(decoded)
+        return decode_envelope(raw)
+    return decode_envelope(raw)
+
+
+class CFQueuesDelivery(Delivery):
+    def __init__(self, queue: "CFQueue", message: dict[str, Any]) -> None:
+        envelope = _decode_message_body(message.get("body"))
+        existing_meta = envelope.meta.get("cf_queues")
+        cf_meta = dict(existing_meta) if isinstance(existing_meta, dict) else {}
+        for key in ("id", "timestamp_ms", "attempts", "metadata"):
+            cf_meta.pop(key, None)
+        if "id" in message:
+            cf_meta["id"] = message["id"]
+        if "timestamp_ms" in message:
+            cf_meta["timestamp_ms"] = message["timestamp_ms"]
+        if "attempts" in message:
+            cf_meta["attempts"] = message["attempts"]
+        if isinstance(message.get("metadata"), dict):
+            cf_meta["metadata"] = dict(message["metadata"])
+        envelope.meta["cf_queues"] = cf_meta
+        super().__init__(envelope)
+        self._queue = queue
+        self._message = message
+        self._lease_id = message["lease_id"]
+
+    async def ack(self) -> None:
+        await self._queue.stage_ack(self._lease_id)
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        delay = None if delay_s is None else max(0, int(delay_s))
+        await self._queue.stage_retry(self._lease_id, delay_seconds=delay)
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        if self._queue.on_fail == "ack":
+            await self._queue.stage_ack(self._lease_id)
+            return
+        if self._queue.on_fail == "retry":
+            await self._queue.stage_retry(self._lease_id, delay_seconds=None)
+        # on_fail == "leave": do nothing; visibility_timeout re-delivers later.
+
+    async def release_unstarted(self) -> None:
+        # Immediately return the message to the queue instead of waiting for the
+        # visibility timeout to expire.
+        await self._queue.stage_retry(self._lease_id, delay_seconds=0)
+        await self._queue.flush_acks()
+
+@dataclass
+class CFQueuesConnector:
+    account_id: str
+    api_token: str
+    base_url: str = _DEFAULT_BASE_URL
+    timeout_s: float = 10.0
+    client: Any | None = None
+    _client: Any | None = field(default=None, init=False, repr=False)
+
+    def _secret_tokens(self) -> list[str]:
+        """Secret-bearing config tokens used to scrub error messages."""
+        return collect_sensitive_tokens(
+            self.api_token,
+            {"authorization": f"Bearer {self.api_token}"},
+        )
+
+    def queue(
+        self,
+        queue_id: str,
+        *,
+        batch_size: int = 5,
+        visibility_timeout_ms: int | None = None,
+        poll_interval_s: float = 1.0,
+        on_fail: str = "leave",
+        ack_batch_size: int = 100,
+        ack_flush_interval_s: float = 0.5,
+    ) -> "CFQueue":
+        if on_fail not in {"leave", "retry", "ack"}:
+            raise ValueError("on_fail must be one of: leave, retry, ack")
+        return CFQueue(
+            connector=self,
+            queue_id=queue_id,
+            batch_size=batch_size,
+            visibility_timeout_ms=visibility_timeout_ms,
+            poll_interval_s=poll_interval_s,
+            on_fail=on_fail,
+            ack_batch_size=ack_batch_size,
+            ack_flush_interval_s=ack_flush_interval_s,
+        )
+
+    def get_client(self) -> Any:
+        if self.client is not None:
+            return self.client
+        if self._client is None:
+            if httpx is None:
+                raise RuntimeError(
+                    "CFQueuesConnector requires httpx. Install onestep-cf-queues."
+                )
+            self._client = httpx.AsyncClient(timeout=self.timeout_s)
+        return self._client
+
+    def auth_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_token}",
+            "Content-Type": "application/json",
+        }
+
+    def queue_url(self, queue_id: str, action: str) -> str:
+        base = self.base_url.rstrip("/")
+        return f"{base}/accounts/{self.account_id}/queues/{queue_id}/messages/{action}"
+
+    async def close(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+
+class CFQueue(Source, Sink):
+    # Cloudflare pull is short-polling (returns immediately), so fetch is safe
+    # to cancel: no message is claimed until the HTTP response is parsed.
+    fetch_is_cancel_safe = True
+
+    def __init__(
+        self,
+        *,
+        connector: CFQueuesConnector,
+        queue_id: str,
+        batch_size: int,
+        visibility_timeout_ms: int | None,
+        poll_interval_s: float,
+        on_fail: str,
+        ack_batch_size: int,
+        ack_flush_interval_s: float,
+    ) -> None:
+        Source.__init__(self, queue_id)
+        Sink.__init__(self, queue_id)
+        if batch_size < 1 or batch_size > _MAX_BATCH_SIZE:
+            raise ValueError(
+                f"batch_size must be between 1 and {_MAX_BATCH_SIZE} for Cloudflare Queues"
+            )
+        if ack_batch_size < 1 or ack_batch_size > _MAX_BATCH_SIZE:
+            raise ValueError(
+                f"ack_batch_size must be between 1 and {_MAX_BATCH_SIZE} for Cloudflare Queues"
+            )
+        if (
+            visibility_timeout_ms is not None
+            and not 0 <= visibility_timeout_ms <= _MAX_VISIBILITY_TIMEOUT_MS
+        ):
+            raise ValueError(
+                "visibility_timeout_ms must be between 0 and "
+                f"{_MAX_VISIBILITY_TIMEOUT_MS} (12 hours) for Cloudflare Queues"
+            )
+        self.connector = connector
+        self.queue_id = queue_id
+        self.batch_size = batch_size
+        self.visibility_timeout_ms = visibility_timeout_ms
+        self.poll_interval_s = poll_interval_s
+        self.on_fail = on_fail
+        self.ack_batch_size = ack_batch_size
+        self.ack_flush_interval_s = ack_flush_interval_s
+        self.client: Any | None = None
+        self._pending_acks: list[dict[str, str]] = []
+        self._pending_retries: list[dict[str, Any]] = []
+        self._ack_lock: asyncio.Lock | None = None
+        self._ack_flusher_task: asyncio.Task[None] | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    async def open(self) -> None:
+        try:
+            if self.client is None:
+                self.client = self.connector.get_client()
+            self._ensure_runtime_state()
+            if self._ack_flusher_task is None and self.ack_flush_interval_s > 0:
+                self._ack_flusher_task = asyncio.create_task(self._ack_flush_loop())
+        except Exception as exc:
+            raise self._normalize(ConnectorOperation.OPEN, exc) from None
+
+    async def close(self) -> None:
+        if self._ack_flusher_task is not None:
+            self._ack_flusher_task.cancel()
+            try:
+                await self._ack_flusher_task
+            except asyncio.CancelledError:
+                pass
+            self._ack_flusher_task = None
+        if self._ack_lock is not None:
+            async with self._ack_lock:
+                await self._flush_locked()
+        self.client = None
+
+    async def fetch(self, limit: int) -> list[Delivery]:
+        try:
+            await self.open()
+            body: dict[str, Any] = {
+                "batch_size": max(1, min(limit, self.batch_size, _MAX_BATCH_SIZE)),
+            }
+            if self.visibility_timeout_ms is not None:
+                body["visibility_timeout_ms"] = self.visibility_timeout_ms
+            payload = await self._request("pull", body)
+            result = payload.get("result") or {}
+            messages = result.get("messages") or []
+            return [CFQueuesDelivery(self, message) for message in messages]
+        except ConnectorOperationError:
+            raise
+        except Exception as exc:
+            raise self._normalize(ConnectorOperation.FETCH, exc) from None
+
+    async def send(self, envelope: Envelope) -> None:
+        try:
+            await self.open()
+            base = self.connector.base_url.rstrip("/")
+            url = (
+                f"{base}/accounts/{self.connector.account_id}"
+                f"/queues/{self.queue_id}/messages"
+            )
+            body = {"body": encode_envelope(envelope).decode("utf-8")}
+            await self._raw_request("POST", url, body)
+        except ConnectorOperationError:
+            raise
+        except Exception as exc:
+            raise self._normalize(ConnectorOperation.SEND, exc) from None
+
+    def control_plane_descriptor(self) -> dict[str, Any]:
+        """Stable, secret-free descriptor for the control-plane topology sync.
+
+        The account id and API token live on the connector and are never
+        included; only queue topology fields are reported.
+        """
+        return {
+            "kind": "cf_queue",
+            "name": self.name,
+            "config": {
+                "queue_id": self.queue_id,
+                "batch_size": self.batch_size,
+                "visibility_timeout_ms": self.visibility_timeout_ms,
+                "poll_interval_s": self.poll_interval_s,
+                "on_fail": self.on_fail,
+                "ack_batch_size": self.ack_batch_size,
+                "ack_flush_interval_s": self.ack_flush_interval_s,
+            },
+        }
+
+    async def stage_ack(self, lease_id: str) -> None:
+        await self.open()
+        lock = self._ensure_runtime_state()
+        async with lock:
+            self._pending_acks.append({"lease_id": lease_id})
+            if self._should_flush():
+                await self._flush_locked()
+
+    async def stage_retry(self, lease_id: str, *, delay_seconds: int | None) -> None:
+        await self.open()
+        lock = self._ensure_runtime_state()
+        async with lock:
+            entry: dict[str, Any] = {"lease_id": lease_id}
+            if delay_seconds is not None:
+                entry["delay_seconds"] = min(delay_seconds, _MAX_DELAY_SECONDS)
+            self._pending_retries.append(entry)
+            if self._should_flush():
+                await self._flush_locked()
+
+    async def flush_acks(self) -> None:
+        await self.open()
+        lock = self._ensure_runtime_state()
+        async with lock:
+            await self._flush_locked()
+
+    def _should_flush(self) -> bool:
+        total = len(self._pending_acks) + len(self._pending_retries)
+        return total >= self.ack_batch_size or self.ack_flush_interval_s <= 0
+
+    def _ensure_runtime_state(self) -> asyncio.Lock:
+        current_loop = asyncio.get_running_loop()
+        if self._ack_lock is None or self._loop is not current_loop:
+            self._ack_lock = asyncio.Lock()
+            self._loop = current_loop
+            self._pending_acks = []
+            self._pending_retries = []
+            self._ack_flusher_task = None
+        return self._ack_lock
+
+    async def _ack_flush_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self.ack_flush_interval_s)
+            try:
+                await self.flush_acks()
+            except Exception:
+                # Keep the flusher alive; the fetch/ack path surfaces errors.
+                continue
+
+    async def _flush_locked(self) -> None:
+        while self._pending_acks or self._pending_retries:
+            acks = self._pending_acks[: self.ack_batch_size]
+            remaining = self.ack_batch_size - len(acks)
+            retries = self._pending_retries[:remaining] if remaining > 0 else []
+            body = {"acks": list(acks), "retries": list(retries)}
+            await self._request("ack", body)
+            self._pending_acks = self._pending_acks[len(acks) :]
+            self._pending_retries = self._pending_retries[len(retries) :]
+
+    async def _request(self, action: str, body: dict[str, Any]) -> dict[str, Any]:
+        url = self.connector.queue_url(self.queue_id, action)
+        return await self._raw_request("POST", url, body)
+
+    async def _raw_request(
+        self, method: str, url: str, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        response = await self.client.request(
+            method,
+            url,
+            headers=self.connector.auth_headers(),
+            content=json.dumps(body).encode("utf-8"),
+        )
+        if response.status_code >= 400:
+            raise CFQueuesHTTPError(response.status_code, response.text)
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {}
+        if isinstance(payload, dict) and payload.get("success") is False:
+            errors = payload.get("errors") or []
+            message = json.dumps(errors) if errors else "request was not successful"
+            raise CFQueuesHTTPError(response.status_code, message)
+        return payload if isinstance(payload, dict) else {}
+
+    def _normalize(
+        self, operation: ConnectorOperation, exc: Exception
+    ) -> ConnectorOperationError:
+        connector_error = as_cf_connector_operation_error(
+            operation=operation,
+            exc=exc,
+            source_name=self.name,
+            retry_delay_s=max(self.poll_interval_s, 1.0),
+            secrets=self.connector._secret_tokens(),
+        )
+        if connector_error is None:
+            raise exc
+        return connector_error

--- a/plugins/onestep-cf-queues/src/onestep_cf_queues/connector.py
+++ b/plugins/onestep-cf-queues/src/onestep_cf_queues/connector.py
@@ -12,18 +12,12 @@ from onestep.connectors.codec import decode_envelope, encode_envelope
 from onestep.envelope import Envelope
 from onestep.resilience import ConnectorOperation, ConnectorOperationError
 
-from .resilience import (
-    CFQueuesHTTPError,
-    as_cf_connector_operation_error,
-    collect_sensitive_tokens,
-)
+from .resilience import as_cf_connector_operation_error, collect_sensitive_tokens
 
 try:  # pragma: no cover - optional dependency
-    import httpx
+    from cloudflare import AsyncCloudflare
 except ImportError:  # pragma: no cover - optional dependency
-    httpx = None
-
-_DEFAULT_BASE_URL = "https://api.cloudflare.com/client/v4"
+    AsyncCloudflare = None
 
 # Cloudflare Queues limits (see docs/platform/limits).
 _MAX_BATCH_SIZE = 100
@@ -63,26 +57,38 @@ def _decode_message_body(raw: Any) -> Envelope:
     return decode_envelope(raw)
 
 
+def _message_field(message: Any, key: str) -> Any:
+    """Read a field from an SDK model or a plain mapping."""
+    if isinstance(message, dict):
+        return message.get(key)
+    return getattr(message, key, None)
+
+
 class CFQueuesDelivery(Delivery):
-    def __init__(self, queue: "CFQueue", message: dict[str, Any]) -> None:
-        envelope = _decode_message_body(message.get("body"))
+    def __init__(self, queue: "CFQueue", message: Any) -> None:
+        body = _message_field(message, "body")
+        envelope = _decode_message_body(body)
         existing_meta = envelope.meta.get("cf_queues")
         cf_meta = dict(existing_meta) if isinstance(existing_meta, dict) else {}
         for key in ("id", "timestamp_ms", "attempts", "metadata"):
             cf_meta.pop(key, None)
-        if "id" in message:
-            cf_meta["id"] = message["id"]
-        if "timestamp_ms" in message:
-            cf_meta["timestamp_ms"] = message["timestamp_ms"]
-        if "attempts" in message:
-            cf_meta["attempts"] = message["attempts"]
-        if isinstance(message.get("metadata"), dict):
-            cf_meta["metadata"] = dict(message["metadata"])
+        message_id = _message_field(message, "id")
+        if message_id is not None:
+            cf_meta["id"] = message_id
+        timestamp_ms = _message_field(message, "timestamp_ms")
+        if timestamp_ms is not None:
+            cf_meta["timestamp_ms"] = timestamp_ms
+        attempts = _message_field(message, "attempts")
+        if attempts is not None:
+            cf_meta["attempts"] = attempts
+        metadata = _message_field(message, "metadata")
+        if isinstance(metadata, dict):
+            cf_meta["metadata"] = dict(metadata)
         envelope.meta["cf_queues"] = cf_meta
         super().__init__(envelope)
         self._queue = queue
         self._message = message
-        self._lease_id = message["lease_id"]
+        self._lease_id = _message_field(message, "lease_id")
 
     async def ack(self) -> None:
         await self._queue.stage_ack(self._lease_id)
@@ -105,11 +111,12 @@ class CFQueuesDelivery(Delivery):
         await self._queue.stage_retry(self._lease_id, delay_seconds=0)
         await self._queue.flush_acks()
 
+
 @dataclass
 class CFQueuesConnector:
     account_id: str
     api_token: str
-    base_url: str = _DEFAULT_BASE_URL
+    base_url: str | None = None
     timeout_s: float = 10.0
     client: Any | None = None
     _client: Any | None = field(default=None, init=False, repr=False)
@@ -149,32 +156,29 @@ class CFQueuesConnector:
         if self.client is not None:
             return self.client
         if self._client is None:
-            if httpx is None:
+            if AsyncCloudflare is None:
                 raise RuntimeError(
-                    "CFQueuesConnector requires httpx. Install onestep-cf-queues."
+                    "CFQueuesConnector requires the cloudflare SDK. "
+                    "Install onestep-cf-queues."
                 )
-            self._client = httpx.AsyncClient(timeout=self.timeout_s)
+            kwargs: dict[str, Any] = {
+                "api_token": self.api_token,
+                "timeout": self.timeout_s,
+            }
+            if self.base_url is not None:
+                kwargs["base_url"] = self.base_url
+            self._client = AsyncCloudflare(**kwargs)
         return self._client
-
-    def auth_headers(self) -> dict[str, str]:
-        return {
-            "Authorization": f"Bearer {self.api_token}",
-            "Content-Type": "application/json",
-        }
-
-    def queue_url(self, queue_id: str, action: str) -> str:
-        base = self.base_url.rstrip("/")
-        return f"{base}/accounts/{self.account_id}/queues/{queue_id}/messages/{action}"
 
     async def close(self) -> None:
         if self._client is not None:
-            await self._client.aclose()
+            await self._client.close()
             self._client = None
 
 
 class CFQueue(Source, Sink):
     # Cloudflare pull is short-polling (returns immediately), so fetch is safe
-    # to cancel: no message is claimed until the HTTP response is parsed.
+    # to cancel: no message is claimed until the response is parsed.
     fetch_is_cancel_safe = True
 
     def __init__(
@@ -248,14 +252,14 @@ class CFQueue(Source, Sink):
     async def fetch(self, limit: int) -> list[Delivery]:
         try:
             await self.open()
-            body: dict[str, Any] = {
+            params: dict[str, Any] = {
+                "account_id": self.connector.account_id,
                 "batch_size": max(1, min(limit, self.batch_size, _MAX_BATCH_SIZE)),
             }
             if self.visibility_timeout_ms is not None:
-                body["visibility_timeout_ms"] = self.visibility_timeout_ms
-            payload = await self._request("pull", body)
-            result = payload.get("result") or {}
-            messages = result.get("messages") or []
+                params["visibility_timeout_ms"] = self.visibility_timeout_ms
+            response = await self.client.queues.messages.pull(self.queue_id, **params)
+            messages = getattr(response, "messages", None) or []
             return [CFQueuesDelivery(self, message) for message in messages]
         except ConnectorOperationError:
             raise
@@ -265,13 +269,12 @@ class CFQueue(Source, Sink):
     async def send(self, envelope: Envelope) -> None:
         try:
             await self.open()
-            base = self.connector.base_url.rstrip("/")
-            url = (
-                f"{base}/accounts/{self.connector.account_id}"
-                f"/queues/{self.queue_id}/messages"
+            await self.client.queues.messages.push(
+                self.queue_id,
+                account_id=self.connector.account_id,
+                body=encode_envelope(envelope).decode("utf-8"),
+                content_type="text",
             )
-            body = {"body": encode_envelope(envelope).decode("utf-8")}
-            await self._raw_request("POST", url, body)
         except ConnectorOperationError:
             raise
         except Exception as exc:
@@ -350,35 +353,14 @@ class CFQueue(Source, Sink):
             acks = self._pending_acks[: self.ack_batch_size]
             remaining = self.ack_batch_size - len(acks)
             retries = self._pending_retries[:remaining] if remaining > 0 else []
-            body = {"acks": list(acks), "retries": list(retries)}
-            await self._request("ack", body)
+            await self.client.queues.messages.ack(
+                self.queue_id,
+                account_id=self.connector.account_id,
+                acks=list(acks),
+                retries=list(retries),
+            )
             self._pending_acks = self._pending_acks[len(acks) :]
             self._pending_retries = self._pending_retries[len(retries) :]
-
-    async def _request(self, action: str, body: dict[str, Any]) -> dict[str, Any]:
-        url = self.connector.queue_url(self.queue_id, action)
-        return await self._raw_request("POST", url, body)
-
-    async def _raw_request(
-        self, method: str, url: str, body: dict[str, Any]
-    ) -> dict[str, Any]:
-        response = await self.client.request(
-            method,
-            url,
-            headers=self.connector.auth_headers(),
-            content=json.dumps(body).encode("utf-8"),
-        )
-        if response.status_code >= 400:
-            raise CFQueuesHTTPError(response.status_code, response.text)
-        try:
-            payload = response.json()
-        except ValueError:
-            payload = {}
-        if isinstance(payload, dict) and payload.get("success") is False:
-            errors = payload.get("errors") or []
-            message = json.dumps(errors) if errors else "request was not successful"
-            raise CFQueuesHTTPError(response.status_code, message)
-        return payload if isinstance(payload, dict) else {}
 
     def _normalize(
         self, operation: ConnectorOperation, exc: Exception

--- a/plugins/onestep-cf-queues/src/onestep_cf_queues/resilience.py
+++ b/plugins/onestep-cf-queues/src/onestep_cf_queues/resilience.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import httpx
+
+from onestep.resilience import (
+    ConnectorErrorKind,
+    ConnectorOperation,
+    ConnectorOperationError,
+)
+
+_REDACTED = "<redacted>"
+_MAX_MESSAGE_LENGTH = 500
+_SECRET_OPTION_KEYS = frozenset(
+    {
+        "password",
+        "secret",
+        "token",
+        "api_token",
+        "access_token",
+        "api_key",
+        "apikey",
+        "credentials",
+        "authorization",
+        "bearer_token",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CFQueuesErrorCause(Exception):
+    message: str
+
+    def __str__(self) -> str:
+        return f"cloudflare queues error: {self.message}"
+
+
+def collect_sensitive_tokens(*config_values: object) -> list[str]:
+    """Collect secret substrings that may surface in Cloudflare error messages."""
+    tokens: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        if value is None:
+            return
+        text = str(value)
+        if text and text not in seen:
+            seen.add(text)
+            tokens.append(text)
+
+    for value in config_values:
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                if str(key).lower() in _SECRET_OPTION_KEYS:
+                    add(item)
+            continue
+        add(value)
+    return tokens
+
+
+def _redact_message(message: str, tokens: list[str]) -> str:
+    redacted = message
+    for token in sorted(tokens, key=len, reverse=True):
+        if token:
+            redacted = redacted.replace(token, _REDACTED)
+    return redacted[:_MAX_MESSAGE_LENGTH]
+
+
+def redacted_cf_cause(
+    exc: BaseException, *, secrets: list[str] | None = None
+) -> CFQueuesErrorCause:
+    return CFQueuesErrorCause(_redact_message(str(exc), secrets or []))
+
+
+def classify_cf_status(status: int) -> ConnectorErrorKind:
+    """Map a Cloudflare API HTTP status to a connector error kind."""
+    if status == 429:
+        return ConnectorErrorKind.THROTTLED
+    if status in {500, 502, 503, 504}:
+        return ConnectorErrorKind.TRANSIENT
+    if status in {401, 403, 404}:
+        return ConnectorErrorKind.MISCONFIGURED
+    return ConnectorErrorKind.PERMANENT
+
+
+def classify_cf_exception(exc: BaseException) -> ConnectorErrorKind | None:
+    if isinstance(exc, httpx.ConnectTimeout):
+        return ConnectorErrorKind.DISCONNECTED
+    if isinstance(exc, httpx.ConnectError):
+        return ConnectorErrorKind.DISCONNECTED
+    if isinstance(exc, (httpx.ReadTimeout, httpx.WriteError, httpx.ReadError)):
+        return ConnectorErrorKind.UNCERTAIN
+    if isinstance(exc, httpx.TimeoutException):
+        return ConnectorErrorKind.UNCERTAIN
+    if isinstance(exc, (ConnectionError, OSError, TimeoutError)):
+        return ConnectorErrorKind.DISCONNECTED
+    return None
+
+
+def classify_cf_error(exc: BaseException) -> ConnectorErrorKind | None:
+    """Classify an exception raised while talking to the Cloudflare API.
+
+    ``CFQueuesHTTPError`` carries the response status and is mapped through
+    :func:`classify_cf_status`. Transport-level exceptions are mapped through
+    :func:`classify_cf_exception`.
+    """
+    if isinstance(exc, CFQueuesHTTPError):
+        return classify_cf_status(exc.status)
+    return classify_cf_exception(exc)
+
+
+class CFQueuesHTTPError(Exception):
+    """Raised when the Cloudflare Queues API returns a non-success response."""
+
+    def __init__(self, status: int, message: str) -> None:
+        self.status = status
+        self.message = message
+        super().__init__(f"cloudflare queues API returned HTTP {status}: {message[:200]}")
+
+
+def as_cf_connector_operation_error(
+    *,
+    operation: ConnectorOperation,
+    exc: BaseException,
+    source_name: str | None = None,
+    retry_delay_s: float | None = None,
+    secrets: list[str] | None = None,
+    backend: str = "cf_queues",
+) -> ConnectorOperationError | None:
+    kind = classify_cf_error(exc)
+    if kind is None:
+        return None
+    return ConnectorOperationError(
+        backend=backend,
+        operation=operation,
+        kind=kind,
+        source_name=source_name,
+        retry_delay_s=retry_delay_s,
+        cause=redacted_cf_cause(exc, secrets=secrets),
+    )

--- a/plugins/onestep-cf-queues/src/onestep_cf_queues/resilience.py
+++ b/plugins/onestep-cf-queues/src/onestep_cf_queues/resilience.py
@@ -3,13 +3,22 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
-import httpx
-
 from onestep.resilience import (
     ConnectorErrorKind,
     ConnectorOperation,
     ConnectorOperationError,
 )
+
+try:  # pragma: no cover - optional dependency
+    from cloudflare import (
+        APIConnectionError,
+        APIStatusError,
+        APITimeoutError,
+    )
+except ImportError:  # pragma: no cover - optional dependency
+    APIConnectionError = None
+    APIStatusError = None
+    APITimeoutError = None
 
 _REDACTED = "<redacted>"
 _MAX_MESSAGE_LENGTH = 500
@@ -85,39 +94,23 @@ def classify_cf_status(status: int) -> ConnectorErrorKind:
     return ConnectorErrorKind.PERMANENT
 
 
-def classify_cf_exception(exc: BaseException) -> ConnectorErrorKind | None:
-    if isinstance(exc, httpx.ConnectTimeout):
-        return ConnectorErrorKind.DISCONNECTED
-    if isinstance(exc, httpx.ConnectError):
-        return ConnectorErrorKind.DISCONNECTED
-    if isinstance(exc, (httpx.ReadTimeout, httpx.WriteError, httpx.ReadError)):
+def classify_cf_error(exc: BaseException) -> ConnectorErrorKind | None:
+    """Classify an exception raised by the official ``cloudflare`` SDK.
+
+    ``APIStatusError`` carries a response ``status_code`` and is mapped through
+    :func:`classify_cf_status`. ``APITimeoutError`` / ``APIConnectionError`` are
+    transport-level failures. Plain socket/OS errors are also treated as
+    disconnects so the runtime can degrade and retry the source loop.
+    """
+    if APITimeoutError is not None and isinstance(exc, APITimeoutError):
         return ConnectorErrorKind.UNCERTAIN
-    if isinstance(exc, httpx.TimeoutException):
-        return ConnectorErrorKind.UNCERTAIN
+    if APIStatusError is not None and isinstance(exc, APIStatusError):
+        return classify_cf_status(exc.status_code)
+    if APIConnectionError is not None and isinstance(exc, APIConnectionError):
+        return ConnectorErrorKind.DISCONNECTED
     if isinstance(exc, (ConnectionError, OSError, TimeoutError)):
         return ConnectorErrorKind.DISCONNECTED
     return None
-
-
-def classify_cf_error(exc: BaseException) -> ConnectorErrorKind | None:
-    """Classify an exception raised while talking to the Cloudflare API.
-
-    ``CFQueuesHTTPError`` carries the response status and is mapped through
-    :func:`classify_cf_status`. Transport-level exceptions are mapped through
-    :func:`classify_cf_exception`.
-    """
-    if isinstance(exc, CFQueuesHTTPError):
-        return classify_cf_status(exc.status)
-    return classify_cf_exception(exc)
-
-
-class CFQueuesHTTPError(Exception):
-    """Raised when the Cloudflare Queues API returns a non-success response."""
-
-    def __init__(self, status: int, message: str) -> None:
-        self.status = status
-        self.message = message
-        super().__init__(f"cloudflare queues API returned HTTP {status}: {message[:200]}")
 
 
 def as_cf_connector_operation_error(

--- a/plugins/onestep-cf-queues/src/onestep_cf_queues/resources.py
+++ b/plugins/onestep-cf-queues/src/onestep_cf_queues/resources.py
@@ -46,7 +46,6 @@ _CF_QUEUES_CATALOG = ResourceCatalogEntry(
         ResourceCatalogField(
             "base_url",
             "string",
-            default="https://api.cloudflare.com/client/v4",
         ),
         ResourceCatalogField("timeout_s", "number", default=10.0),
     ),
@@ -101,7 +100,7 @@ def _build_cf_queues(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> CFQu
     return CFQueuesConnector(
         account_id=ctx.require_string(spec, "account_id"),
         api_token=ctx.require_string(spec, "api_token"),
-        base_url=spec.get("base_url", "https://api.cloudflare.com/client/v4"),
+        base_url=spec.get("base_url"),
         timeout_s=spec.get("timeout_s", 10.0),
     )
 

--- a/plugins/onestep-cf-queues/src/onestep_cf_queues/resources.py
+++ b/plugins/onestep-cf-queues/src/onestep_cf_queues/resources.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from onestep.resource_registry import (
+    ResourceBuildContext,
+    ResourceCatalogEntry,
+    ResourceCatalogField,
+    ResourceRegistry,
+    ResourceSpecHandler,
+)
+
+from .connector import CFQueuesConnector
+
+_CF_QUEUES_FIELDS = frozenset(
+    {
+        "type",
+        "account_id",
+        "api_token",
+        "base_url",
+        "timeout_s",
+    }
+)
+_CF_QUEUE_FIELDS = frozenset(
+    {
+        "type",
+        "name",
+        "queue_id",
+        "connector",
+        "batch_size",
+        "visibility_timeout_ms",
+        "poll_interval_s",
+        "on_fail",
+        "ack_batch_size",
+        "ack_flush_interval_s",
+    }
+)
+_CF_QUEUES_CATALOG = ResourceCatalogEntry(
+    type="cf_queues",
+    roles=("connector",),
+    label="Cloudflare Queues",
+    fields=(
+        ResourceCatalogField("account_id", "string", required=True),
+        ResourceCatalogField("api_token", "string", required=True, secret=True),
+        ResourceCatalogField(
+            "base_url",
+            "string",
+            default="https://api.cloudflare.com/client/v4",
+        ),
+        ResourceCatalogField("timeout_s", "number", default=10.0),
+    ),
+)
+_CF_QUEUE_CATALOG = ResourceCatalogEntry(
+    type="cf_queue",
+    roles=("source", "sink"),
+    label="Cloudflare Queue",
+    connector_types=("cf_queues",),
+    fields=(
+        ResourceCatalogField("name", "string"),
+        ResourceCatalogField("queue_id", "string", required=True),
+        ResourceCatalogField("connector", "ref", required=True),
+        ResourceCatalogField("batch_size", "integer", default=5),
+        ResourceCatalogField("visibility_timeout_ms", "integer"),
+        ResourceCatalogField("poll_interval_s", "number", default=1.0),
+        ResourceCatalogField(
+            "on_fail", "string", default="leave", options=("leave", "retry", "ack")
+        ),
+        ResourceCatalogField("ack_batch_size", "integer", default=100),
+        ResourceCatalogField("ack_flush_interval_s", "number", default=0.5),
+    ),
+    topology_fields=(
+        "queue_id",
+        "batch_size",
+        "visibility_timeout_ms",
+        "poll_interval_s",
+    ),
+)
+
+
+def register_resources(registry: ResourceRegistry) -> None:
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="cf_queues",
+            catalog=_CF_QUEUES_CATALOG,
+            allowed_fields=_CF_QUEUES_FIELDS,
+            build=_build_cf_queues,
+        )
+    )
+    registry.register_resource_type(
+        ResourceSpecHandler(
+            type="cf_queue",
+            catalog=_CF_QUEUE_CATALOG,
+            allowed_fields=_CF_QUEUE_FIELDS,
+            build=_build_cf_queue,
+        )
+    )
+
+
+def _build_cf_queues(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> CFQueuesConnector:
+    return CFQueuesConnector(
+        account_id=ctx.require_string(spec, "account_id"),
+        api_token=ctx.require_string(spec, "api_token"),
+        base_url=spec.get("base_url", "https://api.cloudflare.com/client/v4"),
+        timeout_s=spec.get("timeout_s", 10.0),
+    )
+
+
+def _build_cf_queue(ctx: ResourceBuildContext, spec: Mapping[str, Any]) -> Any:
+    connector = ctx.resolve_dependency(spec, "connector")
+    if not hasattr(connector, "queue"):
+        raise TypeError(f"resource {spec['connector']!r} cannot build cf_queue")
+    return connector.queue(
+        ctx.require_string(spec, "queue_id"),
+        batch_size=spec.get("batch_size", 5),
+        visibility_timeout_ms=spec.get("visibility_timeout_ms"),
+        poll_interval_s=spec.get("poll_interval_s", 1.0),
+        on_fail=spec.get("on_fail", "leave"),
+        ack_batch_size=spec.get("ack_batch_size", 100),
+        ack_flush_interval_s=spec.get("ack_flush_interval_s", 0.5),
+    )

--- a/plugins/onestep-cf-queues/tests/test_cf_queues_connector.py
+++ b/plugins/onestep-cf-queues/tests/test_cf_queues_connector.py
@@ -9,84 +9,99 @@ from onestep_cf_queues import CFQueuesConnector
 from onestep_cf_queues.connector import _decode_message_body
 
 
-class FakeResponse:
-    def __init__(self, status_code: int, payload: dict | None = None, text: str = "") -> None:
-        self.status_code = status_code
-        self._payload = payload
-        self.text = text or (json.dumps(payload) if payload is not None else "")
+class SDKMessage:
+    """Mimics cloudflare.types.queues.MessagePullResponse.Message."""
 
-    def json(self):
-        if self._payload is None:
-            raise ValueError("no json body")
-        return self._payload
+    def __init__(self, **kwargs) -> None:
+        self.id = kwargs.get("id")
+        self.body = kwargs.get("body")
+        self.lease_id = kwargs.get("lease_id")
+        self.timestamp_ms = kwargs.get("timestamp_ms")
+        self.attempts = kwargs.get("attempts")
+        self.metadata = kwargs.get("metadata")
+
+
+class SDKPullResponse:
+    def __init__(self, messages) -> None:
+        self.messages = messages
+        self.message_backlog_count = 0
+        self.metadata = None
+
+
+class FakeMessages:
+    """Stand-in for client.queues.messages.* on the async SDK."""
+
+    def __init__(self, parent: "FakeCFClient") -> None:
+        self._p = parent
+
+    async def pull(self, queue_id, *, account_id, batch_size=5, visibility_timeout_ms=None):
+        self._p.pull_calls.append(
+            {
+                "queue_id": queue_id,
+                "account_id": account_id,
+                "batch_size": batch_size,
+                "visibility_timeout_ms": visibility_timeout_ms,
+            }
+        )
+        messages = []
+        while self._p.available and len(messages) < batch_size:
+            message = self._p.available.pop(0)
+            self._p.inflight[message.lease_id] = message
+            messages.append(message)
+        return SDKPullResponse(messages)
+
+    async def ack(self, queue_id, *, account_id, acks=None, retries=None):
+        for entry in acks or []:
+            lease_id = entry["lease_id"]
+            self._p.acked.append(lease_id)
+            self._p.inflight.pop(lease_id, None)
+        for entry in retries or []:
+            self._p.retried.append(entry)
+            message = self._p.inflight.pop(entry["lease_id"], None)
+            if message is not None:
+                self._p.available.append(message)
+        return None
+
+    async def push(self, queue_id, *, account_id, body=None, content_type=None, delay_seconds=None):
+        self._p.sent.append({"body": body, "content_type": content_type})
+        return None
+
+
+class FakeQueues:
+    def __init__(self, parent: "FakeCFClient") -> None:
+        self.messages = FakeMessages(parent)
 
 
 class FakeCFClient:
-    """Minimal stand-in for the Cloudflare Queues HTTP API over httpx."""
+    """Minimal stand-in for cloudflare.AsyncCloudflare."""
 
     def __init__(self) -> None:
-        self.available: list[dict] = []
-        self.inflight: dict[str, dict] = {}
+        self.available: list[SDKMessage] = []
+        self.inflight: dict[str, SDKMessage] = {}
         self.acked: list[str] = []
         self.retried: list[dict] = []
         self.sent: list[dict] = []
         self.pull_calls: list[dict] = []
         self._counter = 0
         self.closed = False
+        self.queues = FakeQueues(self)
 
     def enqueue(self, body, *, lease_prefix: str = "lease") -> str:
         self._counter += 1
         lease_id = f"{lease_prefix}-{self._counter}"
-        message = {
-            "body": body,
-            "id": f"id-{self._counter}",
-            "timestamp_ms": 1689615013586,
-            "attempts": 1,
-            "metadata": {"CF-Content-Type": "json"},
-            "lease_id": lease_id,
-        }
-        self.available.append(message)
+        self.available.append(
+            SDKMessage(
+                id=f"id-{self._counter}",
+                body=body,
+                timestamp_ms=1689615013586,
+                attempts=1,
+                metadata={"CF-Content-Type": "json"},
+                lease_id=lease_id,
+            )
+        )
         return lease_id
 
-    async def request(self, method, url, *, headers=None, content=None):
-        body = json.loads(content.decode("utf-8")) if content else {}
-        if url.endswith("/messages/pull"):
-            self.pull_calls.append(body)
-            take = body.get("batch_size", 5)
-            messages = []
-            while self.available and len(messages) < take:
-                message = self.available.pop(0)
-                self.inflight[message["lease_id"]] = message
-                messages.append(message)
-            return FakeResponse(
-                200,
-                {
-                    "success": True,
-                    "errors": [],
-                    "messages": [],
-                    "result": {
-                        "message_backlog_count": len(self.available),
-                        "messages": messages,
-                    },
-                },
-            )
-        if url.endswith("/messages/ack"):
-            for entry in body.get("acks", []):
-                lease_id = entry["lease_id"]
-                self.acked.append(lease_id)
-                self.inflight.pop(lease_id, None)
-            for entry in body.get("retries", []):
-                self.retried.append(entry)
-                message = self.inflight.pop(entry["lease_id"], None)
-                if message is not None:
-                    self.available.append(message)
-            return FakeResponse(200, {"success": True, "errors": [], "result": {}})
-        if url.endswith("/messages"):
-            self.sent.append(body)
-            return FakeResponse(200, {"success": True, "errors": []})
-        return FakeResponse(404, {"success": False, "errors": ["not found"]})
-
-    async def aclose(self):
+    async def close(self):
         self.closed = True
 
 
@@ -115,6 +130,24 @@ def test_cf_queue_pull_decodes_body_and_injects_metadata():
         assert cf_meta["metadata"] == {"CF-Content-Type": "json"}
         # lease_id must not leak onto the envelope metadata.
         assert "lease_id" not in cf_meta
+
+    asyncio.run(scenario())
+
+
+def test_cf_queue_pull_forwards_account_and_visibility():
+    async def scenario():
+        client = FakeCFClient()
+        client.enqueue('{"body": 1}')
+        queue = _connector(client).queue(
+            "q1", visibility_timeout_ms=45000, ack_flush_interval_s=0
+        )
+
+        await queue.fetch(5)
+
+        call = client.pull_calls[0]
+        assert call["account_id"] == "acct-1"
+        assert call["queue_id"] == "q1"
+        assert call["visibility_timeout_ms"] == 45000
 
     asyncio.run(scenario())
 
@@ -253,15 +286,14 @@ def test_decode_message_body_handles_structured_dict():
     assert envelope.attempts == 3
 
 
-def test_cf_queue_http_error_is_normalized():
+def test_cf_queue_sdk_status_error_is_normalized():
     async def scenario():
-        class ErrorClient(FakeCFClient):
-            async def request(self, method, url, *, headers=None, content=None):
-                if url.endswith("/messages/pull"):
-                    return FakeResponse(429, text="rate limited")
-                return await super().request(method, url, headers=headers, content=content)
+        class ErrorMessages(FakeMessages):
+            async def pull(self, queue_id, *, account_id, batch_size=5, visibility_timeout_ms=None):
+                raise ConnectionError("network down")
 
-        client = ErrorClient()
+        client = FakeCFClient()
+        client.queues.messages = ErrorMessages(client)
         queue = _connector(client).queue("q1", ack_flush_interval_s=0)
 
         try:

--- a/plugins/onestep-cf-queues/tests/test_cf_queues_connector.py
+++ b/plugins/onestep-cf-queues/tests/test_cf_queues_connector.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+
+from onestep import ConnectorOperation, ConnectorOperationError, Envelope
+from onestep_cf_queues import CFQueuesConnector
+from onestep_cf_queues.connector import _decode_message_body
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload: dict | None = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text or (json.dumps(payload) if payload is not None else "")
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json body")
+        return self._payload
+
+
+class FakeCFClient:
+    """Minimal stand-in for the Cloudflare Queues HTTP API over httpx."""
+
+    def __init__(self) -> None:
+        self.available: list[dict] = []
+        self.inflight: dict[str, dict] = {}
+        self.acked: list[str] = []
+        self.retried: list[dict] = []
+        self.sent: list[dict] = []
+        self.pull_calls: list[dict] = []
+        self._counter = 0
+        self.closed = False
+
+    def enqueue(self, body, *, lease_prefix: str = "lease") -> str:
+        self._counter += 1
+        lease_id = f"{lease_prefix}-{self._counter}"
+        message = {
+            "body": body,
+            "id": f"id-{self._counter}",
+            "timestamp_ms": 1689615013586,
+            "attempts": 1,
+            "metadata": {"CF-Content-Type": "json"},
+            "lease_id": lease_id,
+        }
+        self.available.append(message)
+        return lease_id
+
+    async def request(self, method, url, *, headers=None, content=None):
+        body = json.loads(content.decode("utf-8")) if content else {}
+        if url.endswith("/messages/pull"):
+            self.pull_calls.append(body)
+            take = body.get("batch_size", 5)
+            messages = []
+            while self.available and len(messages) < take:
+                message = self.available.pop(0)
+                self.inflight[message["lease_id"]] = message
+                messages.append(message)
+            return FakeResponse(
+                200,
+                {
+                    "success": True,
+                    "errors": [],
+                    "messages": [],
+                    "result": {
+                        "message_backlog_count": len(self.available),
+                        "messages": messages,
+                    },
+                },
+            )
+        if url.endswith("/messages/ack"):
+            for entry in body.get("acks", []):
+                lease_id = entry["lease_id"]
+                self.acked.append(lease_id)
+                self.inflight.pop(lease_id, None)
+            for entry in body.get("retries", []):
+                self.retried.append(entry)
+                message = self.inflight.pop(entry["lease_id"], None)
+                if message is not None:
+                    self.available.append(message)
+            return FakeResponse(200, {"success": True, "errors": [], "result": {}})
+        if url.endswith("/messages"):
+            self.sent.append(body)
+            return FakeResponse(200, {"success": True, "errors": []})
+        return FakeResponse(404, {"success": False, "errors": ["not found"]})
+
+    async def aclose(self):
+        self.closed = True
+
+
+def _connector(client: FakeCFClient) -> CFQueuesConnector:
+    return CFQueuesConnector(account_id="acct-1", api_token="secret-token", client=client)
+
+
+def test_cf_queue_fetch_is_cancel_safe():
+    queue = _connector(FakeCFClient()).queue("q1")
+    assert queue.fetch_is_cancel_safe is True
+
+
+def test_cf_queue_pull_decodes_body_and_injects_metadata():
+    async def scenario():
+        client = FakeCFClient()
+        client.enqueue('{"body": {"value": 1}}')
+        queue = _connector(client).queue("q1", ack_flush_interval_s=0)
+
+        deliveries = await queue.fetch(5)
+        assert len(deliveries) == 1
+        delivery = deliveries[0]
+        assert delivery.payload == {"value": 1}
+        cf_meta = delivery.envelope.meta["cf_queues"]
+        assert cf_meta["id"] == "id-1"
+        assert cf_meta["attempts"] == 1
+        assert cf_meta["metadata"] == {"CF-Content-Type": "json"}
+        # lease_id must not leak onto the envelope metadata.
+        assert "lease_id" not in cf_meta
+
+    asyncio.run(scenario())
+
+
+def test_cf_queue_ack_acknowledges_lease():
+    async def scenario():
+        client = FakeCFClient()
+        client.enqueue('{"body": 1}')
+        queue = _connector(client).queue("q1", ack_flush_interval_s=0)
+
+        delivery = (await queue.fetch(5))[0]
+        await delivery.ack()
+
+        assert client.acked == ["lease-1"]
+
+    asyncio.run(scenario())
+
+
+def test_cf_queue_retry_marks_lease_with_delay():
+    async def scenario():
+        client = FakeCFClient()
+        client.enqueue('{"body": 1}')
+        queue = _connector(client).queue("q1", ack_flush_interval_s=0)
+
+        delivery = (await queue.fetch(5))[0]
+        await delivery.retry(delay_s=600)
+
+        assert client.retried == [{"lease_id": "lease-1", "delay_seconds": 600}]
+
+    asyncio.run(scenario())
+
+
+def test_cf_queue_release_unstarted_retries_immediately():
+    async def scenario():
+        client = FakeCFClient()
+        client.enqueue('{"body": 1}')
+        queue = _connector(client).queue("q1", ack_flush_interval_s=0)
+
+        delivery = (await queue.fetch(5))[0]
+        await delivery.release_unstarted()
+
+        assert client.retried == [{"lease_id": "lease-1", "delay_seconds": 0}]
+
+    asyncio.run(scenario())
+
+
+def test_cf_queue_fail_leave_does_nothing():
+    async def scenario():
+        client = FakeCFClient()
+        client.enqueue('{"body": 1}')
+        queue = _connector(client).queue("q1", on_fail="leave", ack_flush_interval_s=0)
+
+        delivery = (await queue.fetch(5))[0]
+        await delivery.fail(RuntimeError("boom"))
+
+        assert client.acked == []
+        assert client.retried == []
+
+    asyncio.run(scenario())
+
+
+def test_cf_queue_fail_ack_drops_message():
+    async def scenario():
+        client = FakeCFClient()
+        client.enqueue('{"body": 1}')
+        queue = _connector(client).queue("q1", on_fail="ack", ack_flush_interval_s=0)
+
+        delivery = (await queue.fetch(5))[0]
+        await delivery.fail(RuntimeError("boom"))
+
+        assert client.acked == ["lease-1"]
+
+    asyncio.run(scenario())
+
+
+def test_cf_queue_send_publishes_encoded_envelope():
+    async def scenario():
+        client = FakeCFClient()
+        queue = _connector(client).queue("q1", ack_flush_interval_s=0)
+
+        await queue.send(Envelope(body={"job": 1}))
+
+        assert len(client.sent) == 1
+        published = client.sent[0]
+        decoded = json.loads(published["body"])
+        assert decoded["body"] == {"job": 1}
+
+    asyncio.run(scenario())
+
+
+def test_cf_queue_batches_acks_into_single_request():
+    async def scenario():
+        client = FakeCFClient()
+        for _ in range(3):
+            client.enqueue('{"body": 1}')
+        queue = _connector(client).queue("q1", ack_flush_interval_s=0.05)
+
+        deliveries = await queue.fetch(5)
+        for delivery in deliveries:
+            await delivery.ack()
+        await queue.flush_acks()
+
+        assert sorted(client.acked) == ["lease-1", "lease-2", "lease-3"]
+
+    asyncio.run(scenario())
+
+
+def test_cf_queue_rejects_invalid_batch_size():
+    connector = _connector(FakeCFClient())
+    for invalid in (0, 101):
+        try:
+            connector.queue("q1", batch_size=invalid)
+        except ValueError:
+            continue
+        raise AssertionError(f"batch_size={invalid} should be rejected")
+
+
+def test_cf_queue_rejects_invalid_on_fail():
+    connector = _connector(FakeCFClient())
+    try:
+        connector.queue("q1", on_fail="explode")
+    except ValueError:
+        return
+    raise AssertionError("invalid on_fail should be rejected")
+
+
+def test_decode_message_body_handles_base64_json():
+    encoded = base64.b64encode(b'{"body": {"a": 1}}').decode("ascii")
+    envelope = _decode_message_body(encoded)
+    assert envelope.body == {"a": 1}
+
+
+def test_decode_message_body_handles_structured_dict():
+    envelope = _decode_message_body({"body": {"a": 1}, "attempts": 3})
+    assert envelope.body == {"a": 1}
+    assert envelope.attempts == 3
+
+
+def test_cf_queue_http_error_is_normalized():
+    async def scenario():
+        class ErrorClient(FakeCFClient):
+            async def request(self, method, url, *, headers=None, content=None):
+                if url.endswith("/messages/pull"):
+                    return FakeResponse(429, text="rate limited")
+                return await super().request(method, url, headers=headers, content=content)
+
+        client = ErrorClient()
+        queue = _connector(client).queue("q1", ack_flush_interval_s=0)
+
+        try:
+            await queue.fetch(5)
+        except ConnectorOperationError as exc:
+            assert exc.operation is ConnectorOperation.FETCH
+            assert exc.backend == "cf_queues"
+            return
+        raise AssertionError("expected ConnectorOperationError")
+
+    asyncio.run(scenario())

--- a/plugins/onestep-cf-queues/tests/test_cf_queues_plugin.py
+++ b/plugins/onestep-cf-queues/tests/test_cf_queues_plugin.py
@@ -6,9 +6,9 @@ from typing import Any
 from onestep_cf_queues import CFQueue, CFQueuesConnector, register
 from onestep_cf_queues.resilience import (
     CFQueuesErrorCause,
-    CFQueuesHTTPError,
     as_cf_connector_operation_error,
     classify_cf_error,
+    classify_cf_status,
 )
 
 from onestep.config import load_app_config
@@ -101,15 +101,17 @@ def test_cf_queues_plugin_normalizes_transport_errors() -> None:
 
 
 def test_cf_queues_status_classification() -> None:
-    assert classify_cf_error(CFQueuesHTTPError(429, "too many")) is ConnectorErrorKind.THROTTLED
-    assert classify_cf_error(CFQueuesHTTPError(503, "down")) is ConnectorErrorKind.TRANSIENT
-    assert classify_cf_error(CFQueuesHTTPError(403, "denied")) is ConnectorErrorKind.MISCONFIGURED
-    assert classify_cf_error(CFQueuesHTTPError(400, "bad")) is ConnectorErrorKind.PERMANENT
+    from onestep.resilience import ConnectorErrorKind as Kind
+
+    assert classify_cf_status(429) is Kind.THROTTLED
+    assert classify_cf_status(503) is Kind.TRANSIENT
+    assert classify_cf_status(403) is Kind.MISCONFIGURED
+    assert classify_cf_status(400) is Kind.PERMANENT
 
 
 def test_cf_queues_error_does_not_leak_api_token() -> None:
     secret = "cf-token-super-secret-value"
-    exc = CFQueuesHTTPError(403, f"denied for Bearer {secret}")
+    exc = ConnectionError(f"connect failed for Bearer {secret}")
 
     normalized = as_cf_connector_operation_error(
         operation=ConnectorOperation.FETCH,

--- a/plugins/onestep-cf-queues/tests/test_cf_queues_plugin.py
+++ b/plugins/onestep-cf-queues/tests/test_cf_queues_plugin.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from importlib import metadata as importlib_metadata
+from typing import Any
+
+from onestep_cf_queues import CFQueue, CFQueuesConnector, register
+from onestep_cf_queues.resilience import (
+    CFQueuesErrorCause,
+    CFQueuesHTTPError,
+    as_cf_connector_operation_error,
+    classify_cf_error,
+)
+
+from onestep.config import load_app_config
+from onestep.resilience import (
+    ConnectorErrorKind,
+    ConnectorOperation,
+    ConnectorOperationError,
+)
+from onestep.resource_registry import ResourceRegistry
+
+
+def test_package_exposes_onestep_resource_entry_point() -> None:
+    entry_points = _entry_points_for_group("onestep.resources")
+
+    assert any(
+        entry_point.name == "cf_queues"
+        and entry_point.value == "onestep_cf_queues:register"
+        for entry_point in entry_points
+    )
+
+
+def test_cf_queues_plugin_registers_catalog_metadata() -> None:
+    registry = ResourceRegistry()
+    register(registry)
+    catalog = {entry.type: entry for entry in registry.catalog_entries()}
+    connector_fields = {field.name: field for field in catalog["cf_queues"].fields}
+    queue_fields = {field.name: field for field in catalog["cf_queue"].fields}
+
+    assert catalog["cf_queues"].roles == ("connector",)
+    assert connector_fields["api_token"].secret is True
+    assert connector_fields["api_token"].required is True
+    assert catalog["cf_queue"].roles == ("source", "sink")
+    assert catalog["cf_queue"].connector_types == ("cf_queues",)
+    assert queue_fields["queue_id"].required is True
+
+
+def test_yaml_builds_cf_queue_resources_via_plugin_entry_point() -> None:
+    app = load_app_config(
+        {
+            "apiVersion": "onestep/v1alpha1",
+            "kind": "App",
+            "app": {"name": "cf-queues-plugin"},
+            "resources": {
+                "cf": {
+                    "type": "cf_queues",
+                    "account_id": "acct-123",
+                    "api_token": "token-abc",
+                },
+                "jobs": {
+                    "type": "cf_queue",
+                    "connector": "cf",
+                    "queue_id": "queue-xyz",
+                    "batch_size": 25,
+                    "on_fail": "retry",
+                },
+            },
+            "tasks": [],
+        },
+        strict=True,
+    )
+
+    assert isinstance(app.resources["cf"], CFQueuesConnector)
+    assert app.resources["cf"].account_id == "acct-123"
+    assert app.resources["cf"].api_token == "token-abc"
+    assert isinstance(app.resources["jobs"], CFQueue)
+    assert app.resources["jobs"].connector is app.resources["cf"]
+    assert app.resources["jobs"].queue_id == "queue-xyz"
+    assert app.resources["jobs"].batch_size == 25
+    assert app.resources["jobs"].on_fail == "retry"
+
+
+def test_cf_queues_plugin_normalizes_transport_errors() -> None:
+    timeout = TimeoutError("timeout")
+
+    assert classify_cf_error(timeout) is ConnectorErrorKind.DISCONNECTED
+    normalized = as_cf_connector_operation_error(
+        operation=ConnectorOperation.SEND,
+        exc=timeout,
+        source_name="jobs",
+        retry_delay_s=3.0,
+    )
+
+    assert isinstance(normalized, ConnectorOperationError)
+    assert normalized.backend == "cf_queues"
+    assert normalized.operation is ConnectorOperation.SEND
+    assert normalized.kind is ConnectorErrorKind.DISCONNECTED
+    assert normalized.source_name == "jobs"
+    assert normalized.retry_delay_s == 3.0
+    assert isinstance(normalized.cause, CFQueuesErrorCause)
+
+
+def test_cf_queues_status_classification() -> None:
+    assert classify_cf_error(CFQueuesHTTPError(429, "too many")) is ConnectorErrorKind.THROTTLED
+    assert classify_cf_error(CFQueuesHTTPError(503, "down")) is ConnectorErrorKind.TRANSIENT
+    assert classify_cf_error(CFQueuesHTTPError(403, "denied")) is ConnectorErrorKind.MISCONFIGURED
+    assert classify_cf_error(CFQueuesHTTPError(400, "bad")) is ConnectorErrorKind.PERMANENT
+
+
+def test_cf_queues_error_does_not_leak_api_token() -> None:
+    secret = "cf-token-super-secret-value"
+    exc = CFQueuesHTTPError(403, f"denied for Bearer {secret}")
+
+    normalized = as_cf_connector_operation_error(
+        operation=ConnectorOperation.FETCH,
+        exc=exc,
+        source_name="jobs",
+        secrets=[secret, f"Bearer {secret}"],
+    )
+
+    assert normalized is not None
+    cause = str(normalized.cause)
+    assert secret not in cause
+    assert "<redacted>" in cause
+
+
+def _entry_points_for_group(group: str) -> tuple[Any, ...]:
+    entry_points = importlib_metadata.entry_points()
+    if hasattr(entry_points, "select"):
+        return tuple(entry_points.select(group=group))
+    return tuple(entry_points.get(group, ()))

--- a/plugins/onestep-cf-queues/tests/test_cf_queues_runtime_contract.py
+++ b/plugins/onestep-cf-queues/tests/test_cf_queues_runtime_contract.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 
 from onestep import OneStepApp
 from onestep.testing import (
@@ -14,36 +13,50 @@ from onestep.testing import (
 from onestep_cf_queues import CFQueuesConnector
 
 
-class FakeResponse:
-    def __init__(self, status_code: int, payload: dict) -> None:
-        self.status_code = status_code
-        self._payload = payload
-        self.text = json.dumps(payload)
+class SDKMessage:
+    def __init__(self, **kwargs) -> None:
+        self.id = kwargs.get("id")
+        self.body = kwargs.get("body")
+        self.lease_id = kwargs.get("lease_id")
+        self.timestamp_ms = kwargs.get("timestamp_ms")
+        self.attempts = kwargs.get("attempts")
+        self.metadata = kwargs.get("metadata")
 
-    def json(self):
-        return self._payload
+
+class SDKPullResponse:
+    def __init__(self, messages) -> None:
+        self.messages = messages
+        self.message_backlog_count = 0
+        self.metadata = None
+
+
+class BlockingSendMessages:
+    """messages.* where push (publish) blocks until released."""
+
+    def __init__(self, parent) -> None:
+        self._p = parent
+
+    async def pull(self, queue_id, *, account_id, batch_size=5, visibility_timeout_ms=None):
+        return SDKPullResponse([])
+
+    async def ack(self, queue_id, *, account_id, acks=None, retries=None):
+        return None
+
+    async def push(self, queue_id, *, account_id, body=None, content_type=None, delay_seconds=None):
+        self._p.send_started.set()
+        await self._p.release_send.wait()
+        self._p.sent.append({"body": body})
+        return None
 
 
 class BlockingSendClient:
-    """Client that blocks on the publish (POST /messages) request."""
-
     def __init__(self) -> None:
         self.send_started = asyncio.Event()
         self.release_send = asyncio.Event()
         self.sent: list[dict] = []
+        self.queues = type("Q", (), {"messages": BlockingSendMessages(self)})()
 
-    async def request(self, method, url, *, headers=None, content=None):
-        body = json.loads(content.decode("utf-8")) if content else {}
-        if url.endswith("/messages/ack") or url.endswith("/messages/pull"):
-            return FakeResponse(200, {"success": True, "errors": [], "result": {}})
-        if url.endswith("/messages"):
-            self.send_started.set()
-            await self.release_send.wait()
-            self.sent.append(body)
-            return FakeResponse(200, {"success": True, "errors": []})
-        return FakeResponse(404, {"success": False, "errors": ["not found"]})
-
-    async def aclose(self):
+    async def close(self):
         return None
 
 
@@ -65,45 +78,49 @@ def test_runtime_ack_follows_cf_queues_publish_acknowledgement() -> None:
     asyncio.run(scenario())
 
 
-class BlockingPullClient:
-    """Client that blocks on the pull request until released."""
+class BlockingPullMessages:
+    """messages.* where pull blocks until released, then serves one message."""
 
+    def __init__(self, parent) -> None:
+        self._p = parent
+
+    async def pull(self, queue_id, *, account_id, batch_size=5, visibility_timeout_ms=None):
+        self._p.pull_started.set()
+        await self._p.release_pull.wait()
+        if self._p.served:
+            return SDKPullResponse([])
+        self._p.served = True
+        return SDKPullResponse(
+            [
+                SDKMessage(
+                    id="id-1",
+                    body='{"body": {"value": 1}}',
+                    timestamp_ms=1,
+                    attempts=1,
+                    metadata={},
+                    lease_id="lease-1",
+                )
+            ]
+        )
+
+    async def ack(self, queue_id, *, account_id, acks=None, retries=None):
+        for entry in retries or []:
+            self._p.retried.append(entry)
+        return None
+
+    async def push(self, queue_id, *, account_id, body=None, content_type=None, delay_seconds=None):
+        return None
+
+
+class BlockingPullClient:
     def __init__(self) -> None:
         self.pull_started = asyncio.Event()
         self.release_pull = asyncio.Event()
         self.retried: list[dict] = []
-        self._served = False
+        self.served = False
+        self.queues = type("Q", (), {"messages": BlockingPullMessages(self)})()
 
-    async def request(self, method, url, *, headers=None, content=None):
-        body = json.loads(content.decode("utf-8")) if content else {}
-        if url.endswith("/messages/pull"):
-            self.pull_started.set()
-            await self.release_pull.wait()
-            if self._served:
-                messages: list[dict] = []
-            else:
-                self._served = True
-                messages = [
-                    {
-                        "body": '{"body": {"value": 1}}',
-                        "id": "id-1",
-                        "timestamp_ms": 1,
-                        "attempts": 1,
-                        "metadata": {},
-                        "lease_id": "lease-1",
-                    }
-                ]
-            return FakeResponse(
-                200,
-                {"success": True, "errors": [], "result": {"messages": messages}},
-            )
-        if url.endswith("/messages/ack"):
-            for entry in body.get("retries", []):
-                self.retried.append(entry)
-            return FakeResponse(200, {"success": True, "errors": [], "result": {}})
-        return FakeResponse(404, {"success": False, "errors": ["not found"]})
-
-    async def aclose(self):
+    async def close(self):
         return None
 
 
@@ -114,8 +131,8 @@ def test_stop_controls_release_fetched_unstarted_cf_delivery() -> None:
             account_id="acct-1", api_token="secret-token", client=client
         )
         source = connector.queue("q-in", ack_flush_interval_s=0)
-        # This queue reports a cancel-safe fetch; the claimed-source contract
-        # verifies the release path when intake stops before handling.
+        # The claimed-source contract verifies the release path when intake
+        # stops before handling; force the non-cancel-safe branch to exercise it.
         source.fetch_is_cancel_safe = False
 
         harness = ClaimedSourceHarness(

--- a/plugins/onestep-cf-queues/tests/test_cf_queues_runtime_contract.py
+++ b/plugins/onestep-cf-queues/tests/test_cf_queues_runtime_contract.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from onestep import OneStepApp
+from onestep.testing import (
+    AcknowledgedSinkHarness,
+    ClaimedSourceHarness,
+    StopControl,
+    run_acknowledged_sink_contract,
+    run_claimed_source_stop_contract,
+)
+from onestep_cf_queues import CFQueuesConnector
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload: dict) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class BlockingSendClient:
+    """Client that blocks on the publish (POST /messages) request."""
+
+    def __init__(self) -> None:
+        self.send_started = asyncio.Event()
+        self.release_send = asyncio.Event()
+        self.sent: list[dict] = []
+
+    async def request(self, method, url, *, headers=None, content=None):
+        body = json.loads(content.decode("utf-8")) if content else {}
+        if url.endswith("/messages/ack") or url.endswith("/messages/pull"):
+            return FakeResponse(200, {"success": True, "errors": [], "result": {}})
+        if url.endswith("/messages"):
+            self.send_started.set()
+            await self.release_send.wait()
+            self.sent.append(body)
+            return FakeResponse(200, {"success": True, "errors": []})
+        return FakeResponse(404, {"success": False, "errors": ["not found"]})
+
+    async def aclose(self):
+        return None
+
+
+def test_runtime_ack_follows_cf_queues_publish_acknowledgement() -> None:
+    async def scenario() -> None:
+        client = BlockingSendClient()
+        connector = CFQueuesConnector(
+            account_id="acct-1", api_token="secret-token", client=client
+        )
+        sink = connector.queue("q-out", ack_flush_interval_s=0)
+
+        harness = AcknowledgedSinkHarness(
+            sink=sink,
+            wait_for_send_started=client.send_started.wait,
+            release_send=client.release_send.set,
+        )
+        await run_acknowledged_sink_contract(harness, body={"value": 1})
+
+    asyncio.run(scenario())
+
+
+class BlockingPullClient:
+    """Client that blocks on the pull request until released."""
+
+    def __init__(self) -> None:
+        self.pull_started = asyncio.Event()
+        self.release_pull = asyncio.Event()
+        self.retried: list[dict] = []
+        self._served = False
+
+    async def request(self, method, url, *, headers=None, content=None):
+        body = json.loads(content.decode("utf-8")) if content else {}
+        if url.endswith("/messages/pull"):
+            self.pull_started.set()
+            await self.release_pull.wait()
+            if self._served:
+                messages: list[dict] = []
+            else:
+                self._served = True
+                messages = [
+                    {
+                        "body": '{"body": {"value": 1}}',
+                        "id": "id-1",
+                        "timestamp_ms": 1,
+                        "attempts": 1,
+                        "metadata": {},
+                        "lease_id": "lease-1",
+                    }
+                ]
+            return FakeResponse(
+                200,
+                {"success": True, "errors": [], "result": {"messages": messages}},
+            )
+        if url.endswith("/messages/ack"):
+            for entry in body.get("retries", []):
+                self.retried.append(entry)
+            return FakeResponse(200, {"success": True, "errors": [], "result": {}})
+        return FakeResponse(404, {"success": False, "errors": ["not found"]})
+
+    async def aclose(self):
+        return None
+
+
+def test_stop_controls_release_fetched_unstarted_cf_delivery() -> None:
+    async def scenario() -> None:
+        client = BlockingPullClient()
+        connector = CFQueuesConnector(
+            account_id="acct-1", api_token="secret-token", client=client
+        )
+        source = connector.queue("q-in", ack_flush_interval_s=0)
+        # This queue reports a cancel-safe fetch; the claimed-source contract
+        # verifies the release path when intake stops before handling.
+        source.fetch_is_cancel_safe = False
+
+        harness = ClaimedSourceHarness(
+            source=source,
+            wait_for_fetch_started=client.pull_started.wait,
+            release_fetch=client.release_pull.set,
+            assert_released=lambda: _assert_released(client),
+        )
+        await run_claimed_source_stop_contract(harness, StopControl.SHUTDOWN)
+
+    asyncio.run(scenario())
+
+
+def _assert_released(client: BlockingPullClient) -> None:
+    assert any(entry.get("lease_id") == "lease-1" for entry in client.retried), (
+        "expected the unstarted delivery to be released via a retry"
+    )

--- a/plugins/onestep-control-plane/src/onestep_control_plane/reporter.py
+++ b/plugins/onestep-control-plane/src/onestep_control_plane/reporter.py
@@ -106,6 +106,7 @@ def _read_env(*names: str) -> str | None:
 
 
 _KIND_OVERRIDES = {
+    "CFQueue": "cf_queue",
     "CronSource": "cron",
     "HttpSink": "http_sink",
     "IncrementalTableSource": "mysql_incremental",

--- a/plugins/onestep-control-plane/tests/test_cf_queues_topology.py
+++ b/plugins/onestep-control-plane/tests/test_cf_queues_topology.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from control_plane_testkit import SenderRecorder, make_config
+from onestep import MemoryQueue, OneStepApp
+from onestep.connectors.base import Source
+from onestep.envelope import Envelope
+from onestep_control_plane import ControlPlaneReporter
+
+
+class CFQueue(Source):
+    """Minimal stand-in mirroring onestep_cf_queues.CFQueue's shape.
+
+    The reporter maps connectors by class name, so this avoids a hard
+    onestep-cf-queues test dependency while exercising the cf_queue descriptor
+    and its secret-free control_plane_descriptor.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("queue-xyz")
+        self.queue_id = "queue-xyz"
+        self.batch_size = 10
+        self.visibility_timeout_ms = 30000
+        self.poll_interval_s = 1.0
+        self.on_fail = "leave"
+        self.ack_batch_size = 100
+        self.ack_flush_interval_s = 0.5
+
+    async def fetch(self, limit: int):  # pragma: no cover - unused
+        return []
+
+    def control_plane_descriptor(self) -> dict:
+        return {
+            "kind": "cf_queue",
+            "name": self.name,
+            "config": {
+                "queue_id": self.queue_id,
+                "batch_size": self.batch_size,
+                "visibility_timeout_ms": self.visibility_timeout_ms,
+                "poll_interval_s": self.poll_interval_s,
+                "on_fail": self.on_fail,
+                "ack_batch_size": self.ack_batch_size,
+                "ack_flush_interval_s": self.ack_flush_interval_s,
+            },
+        }
+
+
+def test_reporter_describes_cf_queue_kind_and_config() -> None:
+    recorder = SenderRecorder()
+    app = OneStepApp("cf-consumer")
+    source = CFQueue()
+
+    @app.task(source=source, emit=MemoryQueue("processed"))
+    async def consume(ctx, payload):
+        return payload
+
+    reporter = ControlPlaneReporter(make_config(), sender=recorder)
+    reporter.attach(app)
+
+    asyncio.run(reporter.send_sync_now())
+
+    sync_payload = next(payload for channel, payload in recorder.calls if channel == "sync")
+    described_source = sync_payload["app"]["tasks"][0]["source"]
+    assert described_source == {
+        "kind": "cf_queue",
+        "name": "queue-xyz",
+        "config": {
+            "queue_id": "queue-xyz",
+            "batch_size": 10,
+            "visibility_timeout_ms": 30000,
+            "poll_interval_s": 1.0,
+            "on_fail": "leave",
+            "ack_batch_size": 100,
+            "ack_flush_interval_s": 0.5,
+        },
+    }
+    # The connector secrets (account_id, api_token) must never appear.
+    serialized = json.dumps(sync_payload["app"])
+    assert "api_token" not in serialized
+    assert "account_id" not in serialized

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ redis = [
 sqs = [
     "onestep-sqs>=0.2.2",
 ]
+cloudflare = [
+    "onestep-cf-queues>=0.1.0",
+]
 kafka = [
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
 ]
@@ -76,6 +79,7 @@ integration = [
     "onestep-redis>=0.2.1",
     "onestep-sql[mysql,postgres,sqlite]>=0.2.0",
     "onestep-sqs>=0.2.2",
+    "onestep-cf-queues>=0.1.0",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
     "onestep-clickhouse>=0.1.0",
@@ -88,6 +92,7 @@ all = [
     "onestep-redis>=0.2.1",
     "onestep-sql[mysql,postgres,sqlite]>=0.2.0",
     "onestep-sqs>=0.2.2",
+    "onestep-cf-queues>=0.1.0",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
     "onestep-clickhouse>=0.1.0",
@@ -102,6 +107,7 @@ dev = [
     "onestep-redis>=0.2.1",
     "onestep-sql[mysql,postgres,sqlite]>=0.2.0",
     "onestep-sqs>=0.2.2",
+    "onestep-cf-queues>=0.1.0",
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
     "onestep-elasticsearch>=0.1.0",
     "onestep-clickhouse>=0.1.0",
@@ -120,6 +126,7 @@ members = [
     "plugins/onestep-mysql",
     "plugins/onestep-postgres",
     "plugins/onestep-sqs",
+    "plugins/onestep-cf-queues",
     "plugins/onestep-elasticsearch",
     "plugins/onestep-clickhouse",
     "plugins/onestep-mongodb",
@@ -130,6 +137,7 @@ members = [
 onestep-mq = { workspace = true }
 onestep-redis = { workspace = true }
 onestep-sqs = { workspace = true }
+onestep-cf-queues = { workspace = true }
 onestep-control-plane = { workspace = true }
 onestep-kafka = { path = "plugins/onestep-kafka" }
 onestep-elasticsearch = { workspace = true }

--- a/scripts/run-reliability-checks.sh
+++ b/scripts/run-reliability-checks.sh
@@ -24,6 +24,7 @@ plugin_paths=(
   "plugins/onestep-rabbitmq/tests"
   "plugins/onestep-redis/tests"
   "plugins/onestep-sqs/tests"
+  "plugins/onestep-cf-queues/tests"
 )
 
 echo "==> Running plugin non-integration tests in isolated pytest processes"

--- a/tests/contract/test_official_connector_conformance.py
+++ b/tests/contract/test_official_connector_conformance.py
@@ -186,6 +186,23 @@ PROFILES = (
             ),
         },
     ),
+    ConnectorConformanceProfile(
+        name="cf-queues",
+        contracts={
+            Capability.BASIC_SOURCE: (
+                "plugins/onestep-cf-queues/tests/test_cf_queues_connector.py::test_cf_queue_pull_decodes_body_and_injects_metadata",
+            ),
+            Capability.CLAIMED_SOURCE: (
+                "plugins/onestep-cf-queues/tests/test_cf_queues_runtime_contract.py::test_stop_controls_release_fetched_unstarted_cf_delivery",
+            ),
+            Capability.ACKNOWLEDGED_SINK: (
+                "plugins/onestep-cf-queues/tests/test_cf_queues_runtime_contract.py::test_runtime_ack_follows_cf_queues_publish_acknowledgement",
+            ),
+            Capability.PUBLIC_ERRORS: (
+                "plugins/onestep-cf-queues/tests/test_cf_queues_plugin.py::test_cf_queues_error_does_not_leak_api_token",
+            ),
+        },
+    ),
 )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 [manifest]
 members = [
     "onestep",
+    "onestep-cf-queues",
     "onestep-clickhouse",
     "onestep-control-plane",
     "onestep-elasticsearch",
@@ -1336,6 +1337,7 @@ source = { editable = "." }
 
 [package.optional-dependencies]
 all = [
+    { name = "onestep-cf-queues" },
     { name = "onestep-clickhouse" },
     { name = "onestep-control-plane" },
     { name = "onestep-elasticsearch" },
@@ -1350,10 +1352,14 @@ all = [
 clickhouse = [
     { name = "onestep-clickhouse" },
 ]
+cloudflare = [
+    { name = "onestep-cf-queues" },
+]
 control-plane = [
     { name = "onestep-control-plane" },
 ]
 dev = [
+    { name = "onestep-cf-queues" },
     { name = "onestep-clickhouse" },
     { name = "onestep-control-plane" },
     { name = "onestep-elasticsearch" },
@@ -1373,6 +1379,7 @@ elasticsearch = [
     { name = "onestep-elasticsearch" },
 ]
 integration = [
+    { name = "onestep-cf-queues" },
     { name = "onestep-clickhouse" },
     { name = "onestep-elasticsearch" },
     { name = "onestep-kafka", marker = "python_full_version >= '3.10'" },
@@ -1427,6 +1434,10 @@ yaml = [
 
 [package.metadata]
 requires-dist = [
+    { name = "onestep-cf-queues", marker = "extra == 'all'", editable = "plugins/onestep-cf-queues" },
+    { name = "onestep-cf-queues", marker = "extra == 'cloudflare'", editable = "plugins/onestep-cf-queues" },
+    { name = "onestep-cf-queues", marker = "extra == 'dev'", editable = "plugins/onestep-cf-queues" },
+    { name = "onestep-cf-queues", marker = "extra == 'integration'", editable = "plugins/onestep-cf-queues" },
     { name = "onestep-clickhouse", marker = "extra == 'all'", editable = "plugins/onestep-clickhouse" },
     { name = "onestep-clickhouse", marker = "extra == 'clickhouse'", editable = "plugins/onestep-clickhouse" },
     { name = "onestep-clickhouse", marker = "extra == 'dev'", editable = "plugins/onestep-clickhouse" },
@@ -1477,7 +1488,41 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'test'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0" },
 ]
-provides-extras = ["control-plane", "yaml", "mysql", "postgres", "sql", "sqlite", "rabbitmq", "redis", "sqs", "kafka", "elasticsearch", "clickhouse", "mongodb", "test", "integration", "all", "dev"]
+provides-extras = ["control-plane", "yaml", "mysql", "postgres", "sql", "sqlite", "rabbitmq", "redis", "sqs", "cloudflare", "kafka", "elasticsearch", "clickhouse", "mongodb", "test", "integration", "all", "dev"]
+
+[[package]]
+name = "onestep-cf-queues"
+version = "0.1.0"
+source = { editable = "plugins/onestep-cf-queues" }
+dependencies = [
+    { name = "httpx" },
+    { name = "onestep" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+test = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "onestep", editable = "." },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
+]
+provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-clickhouse"
@@ -1516,7 +1561,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-control-plane"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "plugins/onestep-control-plane" }
 dependencies = [
     { name = "onestep" },
@@ -1861,7 +1906,7 @@ provides-extras = ["mysql", "postgres", "sqlite", "all", "test", "dev"]
 
 [[package]]
 name = "onestep-sqs"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "plugins/onestep-sqs" }
 dependencies = [
     { name = "boto3" },

--- a/uv.lock
+++ b/uv.lock
@@ -305,6 +305,31 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -713,12 +738,39 @@ async = [
 ]
 
 [[package]]
+name = "cloudflare"
+version = "5.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/4d/7b2fc58321193c562fd9a268fca060f024d8da9e730cb5ea8c96412ac041/cloudflare-5.6.0.tar.gz", hash = "sha256:b8c81586aecd0ce48f0daaa859cce554f7b975b01d312b60d1a91ad0ea4b67ff", size = 3319132, upload-time = "2026-07-22T21:09:53.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/48/94d69b80ded5a65d584944f3d8435956432c774b0c99ee25d90c9e207255/cloudflare-5.6.0-py3-none-any.whl", hash = "sha256:d3b5ab79a03bd858380c8a56cc09362d744b7c9e9abb27890206624a64887305", size = 7058535, upload-time = "2026-07-22T21:09:50.95Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -1495,7 +1547,7 @@ name = "onestep-cf-queues"
 version = "0.1.0"
 source = { editable = "plugins/onestep-cf-queues" }
 dependencies = [
-    { name = "httpx" },
+    { name = "cloudflare" },
     { name = "onestep" },
 ]
 
@@ -1515,7 +1567,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.27" },
+    { name = "cloudflare", specifier = ">=4,<6" },
     { name = "onestep", editable = "." },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
@@ -2262,6 +2314,153 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "annotated-types", version = "0.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-inspection", version = "0.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4", size = 2113146, upload-time = "2026-05-06T13:37:36.537Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5", size = 1949769, upload-time = "2026-05-06T13:37:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ba/bfb1d928fd5b49e1258935ff104ae356e9fd89384a55bf9f847e9193ad40/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba", size = 1974958, upload-time = "2026-05-06T13:37:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/74/76223bfb117b64af743c9b6670d1364516f5c0604f96b48f3272f6af6cc6/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b", size = 2042118, upload-time = "2026-05-06T13:36:55.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/848732968bc8f48f3187542f08358b9d842db564147b256669426ebb1652/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c", size = 2222876, upload-time = "2026-05-06T13:38:25.455Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2f/e90b63ee2e14bd8d3db8f705a6d75d64e6ee1b7c2c8833747ce706e1e0ce/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50", size = 2286703, upload-time = "2026-05-06T13:37:53.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1e/acc4d70f88a0a277e4a1fa77ebb985ceabaf900430f875bf9338e11c9420/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd", size = 2092042, upload-time = "2026-05-06T13:38:46.981Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/da/0a422b57bf8504102bf3c4ccea9c41bab5a5cee6a54650acf8faf67f5a24/pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01", size = 2117231, upload-time = "2026-05-06T13:39:23.146Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2a/2ac13c3af305843e23c5078c53d135656b3f05a2fd78cb7bbbb12e97b473/pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d", size = 2168388, upload-time = "2026-05-06T13:40:08.06Z" },
+    { url = "https://files.pythonhosted.org/packages/72/04/2beacf7e1607e93eefe4aed1b4709f079b905fb77530179d4f7c71745f22/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4", size = 2184769, upload-time = "2026-05-06T13:38:13.901Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/29/d2b9fd9f539133548eaf622c06a4ce176cb46ac59f32d0359c4abc0de047/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f", size = 2319312, upload-time = "2026-05-06T13:39:08.24Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/0f7a5b85fec6075bea96e3ef9187de38fccced0de92c1e7feda8d5cc7bb9/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39", size = 2361817, upload-time = "2026-05-06T13:38:43.2Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a4/73363fec545fd3ec025490bdda2743c56d0dd5b6266b1a53bbe9e4265375/pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d", size = 1987085, upload-time = "2026-05-06T13:39:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf", size = 2074311, upload-time = "2026-05-06T13:39:59.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/00/13a0c039569d1e583779ee1b8d7df6bfe275a0db83fcae14f01d6856c16e/pydantic_core-2.46.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:fd8b3d9fd264be37976686c7f65cd52a83f5e84f4bfd2adf9c1d469676bbb6ae", size = 2115337, upload-time = "2026-05-06T13:38:37.741Z" },
+    { url = "https://files.pythonhosted.org/packages/41/60/e70fa1ee03e243bdfd4b1fddf1e1f2a8fba681df3034b51b9376c0fb5bf5/pydantic_core-2.46.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9f444c499b3eefd3a92e348059471ea0c3a6e303d9c1cec09fa748fd9f895201", size = 1957976, upload-time = "2026-05-06T13:37:33.478Z" },
+    { url = "https://files.pythonhosted.org/packages/11/9a/78fb5f2ea849f767ea802de8b4e8f5a0c4a48ddbe4bc66bd19ac2f55a01c/pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3447661d99f75a3683a4cf5c87da72f2161964611864dbbeac7fbb118bb4bfc0", size = 1979390, upload-time = "2026-05-06T13:36:52.419Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7d/3acfdcd000bad9735de0430a88355948469781f62cb841fd63e8a307e80e/pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8b9bab013d1c7a79d3501ff86d0bc9c31bf587db4551677b96bec07df78c6b15", size = 2043263, upload-time = "2026-05-06T13:39:54.798Z" },
+    { url = "https://files.pythonhosted.org/packages/35/60/1325e5a8d7f9697416481c7f7c1c304738d6b961a7fd1ea0f054ce0f14fb/pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d995260fdf4e1db774581b4900e0f832abe3c7c84996726bbc161b19c8f29e76", size = 2225708, upload-time = "2026-05-06T13:40:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b0/9ec8c38f33b26db0b612cb7fd165bb0a370773710432a2a74fa31287b430/pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13a646d65d09fbf1bc6b3a9635d30095c8e7e5cc419ff35ecc563c5fd04cd49", size = 2288494, upload-time = "2026-05-06T13:38:00.091Z" },
+    { url = "https://files.pythonhosted.org/packages/65/05/497446a9586d1b2d24ee25ebe208beb15388f1875d783e1e014055d150ac/pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432c179df7874eeb73307aad2df0755e1ae0efa61ff0ea89b93e194411ae3928", size = 2095629, upload-time = "2026-05-06T13:38:23.632Z" },
+    { url = "https://files.pythonhosted.org/packages/93/d9/cd5fa98f9d94f9294c15459396c8a2383c164469e679ac178d6d42cfee6b/pydantic_core-2.46.4-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:e68b7a074f65a2fd746c52a7ce6142ab7006074ac269ace0c25cd8ba171f8066", size = 2119309, upload-time = "2026-05-06T13:39:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1b/64cec655451ddbf3976df5dc9706b240df4fdaebdeebeadd4f59a8dab926/pydantic_core-2.46.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4a05d69cba51d852c5c3e92758653245a50c0b646ced0cf05bd793ed592839d6", size = 2170216, upload-time = "2026-05-06T13:39:14.561Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/21/fe9f039138c9ea3be10ccdb6ec490acb54dcbef5a5e96dbdf1411f82b929/pydantic_core-2.46.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:228ee9bae8bef5b1e97ec58302f80357c37199e0d0a99174e138d28e6957b9d9", size = 2186726, upload-time = "2026-05-06T13:37:51.597Z" },
+    { url = "https://files.pythonhosted.org/packages/44/cb/19ca0da64821d1aefcef65f253aa9ecbdd0dde360f607d0f9b3d95db2b4e/pydantic_core-2.46.4-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:10e17cbb10a330363733efc4d7c4d0dd827ac0909b8f6a6542298fed1ea62f29", size = 2320400, upload-time = "2026-05-06T13:39:36.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/14/fe3fbf6e845bf2080dc2f282d75085ddf79d037b35634ecde68f33c217b4/pydantic_core-2.46.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:91a06d2e259ecfbd8c901d70c3c507900458498142b3026a296b7de4d1322cc9", size = 2363318, upload-time = "2026-05-06T13:38:53.039Z" },
+    { url = "https://files.pythonhosted.org/packages/62/88/60b110889507a426eecf626f7536566cb290ada71147eff49b6e2724ca62/pydantic_core-2.46.4-cp39-cp39-win32.whl", hash = "sha256:d80ee3d731373b24cebbc10d689ca4ee1875caf0d5703a245db18efd4dd37fc1", size = 1988880, upload-time = "2026-05-06T13:39:16.572Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d6/8ede2f98f17e1e4e127d37be0eced4eee931a511c62cd68af50e1b25bfa9/pydantic_core-2.46.4-cp39-cp39-win_amd64.whl", hash = "sha256:3be77f45df024d789a672ae34f8b06fb346c4f9f46ea714956660ea4862e89ac", size = 2079257, upload-time = "2026-05-06T13:39:38.498Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2586,6 +2785,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.48"
 source = { registry = "https://pypi.org/simple" }
@@ -2720,6 +2928,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
+]
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds the `onestep-cf-queues` plugin — a Cloudflare Queues connector that consumes and publishes over the [HTTP pull-consumer REST API](https://developers.cloudflare.com/queues/configuration/pull-consumers/), so it runs from any environment outside Cloudflare Workers.

Cloudflare Queues uses Cloudflare's own REST protocol (Bearer-token auth, `/messages/pull`, `/messages/ack`, `/messages`, `lease_id`), which is **neither the AWS SQS protocol nor AMQP/RabbitMQ**, so it ships as a new package rather than extending `onestep-sqs` or `onestep-mq`.

### What's included
- `CFQueue(Source, Sink)`: short-polling pull (`fetch_is_cancel_safe=True`), batched lease ack/retry flushing (up to 100 per `/ack`), base64 body decoding for the `json`/`bytes` content types, and an `on_fail` policy (`leave`/`retry`/`ack`).
- YAML resource types `cf_queues` (connector) and `cf_queue` (source + sink) via the `onestep.resources` entry point.
- Root `cloudflare` extra + `all`/`dev`/`integration`, uv workspace wiring.
- README, `docs/broker/cf-queues.md` + sidebar, CHANGELOG.

### Control-plane coordination
This adds new resource types/fields, so it touches control-plane topology. Handled in the same PR:
- `CFQueue.control_plane_descriptor` reports only queue topology fields; the connector's `account_id`/`api_token` are never included.
- `CFQueue` kind override added to the reporter.
- New `test_cf_queues_topology.py` asserts the `cf_queue` descriptor shape and that `account_id`/`api_token` never leak into the sync payload.

> Note: if the control-plane **backend/frontend** uses strict schemas, field allowlists, or per-type UI rendering for resource kinds, the new `cf_queue` kind may need a matching plane-side update. The reporter payload is additive and secret-free.

### Key behavioral differences from SQS
- **Short polling** (not long polling): `fetch` returns immediately; empty when no messages.
- **No lease-renewal (heartbeat) endpoint**: long handlers must set `visibility_timeout_ms` large enough (max 12h) since the lease cannot be extended mid-processing.

### Testing
- `plugins/onestep-cf-queues/tests`: 22 passed (connector, plugin/YAML registration, runtime claimed-source + acknowledged-sink contracts).
- `test_cf_queues_topology.py`: control-plane descriptor + secret-leak assertion.
- `tests/contract/test_official_connector_conformance.py`: new `cf-queues` profile (BASIC_SOURCE / CLAIMED_SOURCE / ACKNOWLEDGED_SINK / PUBLIC_ERRORS); 53 passed.
- `onestep check --strict` passes for a sample `cf_queue` YAML app.

at-least-once delivery is unchanged — handlers should be idempotent when duplicates matter.