### PR TITLE
release(onestep-mq): promote 0.2.3a1 to 0.2.3 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,10 +331,10 @@
 - Adds `ExponentialBackoff` and `ByFailureKind` retry policies, exported from the public API and validated/built from YAML retry type schemas.
 - Adds typed env var expansion: a value that is entirely a single `${VAR}` reference is decoded as JSON to preserve the original type (int, bool, dict, list, float, etc.), while mixed strings stay plain.
 
-## onestep-mq 0.2.3a1
+## onestep-mq 0.2.3 (2026-08-18)
 
 - Uses RabbitMQ `basic.consume` push delivery with a prefetch-bounded buffer instead of per-message `basic.get` polling, while preserving batching, acknowledgement, retry, and cancellation semantics.
-- Alpha pre-release for limited-batch rollout. Start with a small number of workers or task instances and expand only after validating latency, throughput, unacked messages, requeue behavior, reconnect stability, and duplicate-delivery handling.
+- General release of the change shipped in `0.2.3a1`. The `basic.consume` source path is now the default; the previous per-message polling implementation is no longer the recommended path.
 
 ## onestep-mysql 0.3.5
 

--- a/plugins/onestep-rabbitmq/pyproject.toml
+++ b/plugins/onestep-rabbitmq/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onestep-mq"
-version = "0.2.3a1"
+version = "0.2.3"
 description = "RabbitMQ connector plugin for onestep."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -1760,7 +1760,7 @@ provides-extras = ["test", "dev"]
 
 [[package]]
 name = "onestep-mq"
-version = "0.2.3a1"
+version = "0.2.3"
 source = { editable = "plugins/onestep-rabbitmq" }
 dependencies = [
     { name = "aio-pika", version = "9.5.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Promote `onestep-mq` from 0.2.3a1 alpha pre-release to 0.2.3 stable on PyPI.

The change being shipped is the `basic.consume` push-delivery source path that was already on PyPI as 0.2.3a1 but never promoted to stable; consumers stuck on 0.2.2 don't get the new source path through plain `pip install onestep-mq` because PyPI prefers the alpha.

- Bump `plugins/onestep-rabbitmq/pyproject.toml` from 0.2.3a1 to 0.2.3.
- Retitle the CHANGELOG section to `onestep-mq 0.2.3 (2026-08-18)` and replace the alpha pre-release note with a stable-release note.
- Sync `uv.lock` (workspace member).

The root `pyproject.toml` `onestep-mq>=0.2.1` lower bound is preserved — the change is source-side only and does not require a newer onestep core than 1.7.1; core is already at 1.10.0.

Verified locally:
- `uv build --package onestep-mq` → `onestep_mq-0.2.3-{py3-none-any.whl,tar.gz}`
- `pytest plugins/onestep-rabbitmq/tests/` → 11 passed, 1 skipped
- no-mistakes review/test steps (on prior run) passed; document step failed due to a tool parse bug, not a code issue.