### PR TITLE
refactor(app): decompose OneStepApp god-object into facade + runtime controllers (#146)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,12 @@ When updating this file, preserve this bar for all agents and keep entries conci
 - `tests/contract/test_official_connector_conformance.py` derives the official connector set from plugins that still declare `[project.entry-points."onestep.resources"]`; the `sql` profile owns MySQL+PostgreSQL conformance since the shims dropped their entry points.
 - Plugin test dirs share basenames (e.g. `test_state_sqlalchemy.py`), so run each plugin suite in its own pytest process — see `scripts/run-reliability-checks.sh`.
 - Migration guide: `docs/guide/migrate-to-onestep-sql.md`.
+
+## OneStepApp lifecycle decomposition (issue #146)
+
+- Design: `docs/superpowers/specs/2026-08-27-onestep-app-lifecycle-decomposition-design.md`.
+- `src/onestep/app.py` `OneStepApp` is a thin facade (~390 lines): construction, task/resource registration (`bind_resources`/`register_resource`/`task`/`set_reporter_summary`), `describe`/`load`/`run`, module-level `_describe_resource`/`_invoke_app_factory`. Everything else delegates.
+- `src/onestep/runtime/lifecycle.py` `LifecycleController(app)` owns the asyncio state: shutdown/drain/pause signals + waiters, runner registry + per-task `asyncio.Task` handles, `startup`/`shutdown`/`serve`, per-task `stop`/`start`/`restart_task_runner`, control-plane snapshots (`drain_status`/`task_pause_status`/`task_control_snapshot(s)`/`task_supported_commands`/`task_resume_status`), signal handlers, and the opened-`_resources` list. Holds module-level `_open_resource`/`_close_resource`.
+- `src/onestep/runtime/task_ops.py` `TaskOperations(app)` owns dead-letter replay/discard, one-shot manual run, capability probes (`supports_*_commands`, `_task_supports_*`), and `_SyntheticManualRunDelivery`.
+- `src/onestep/runtime/event_hub.py` `EventHub(app)` owns startup/shutdown hooks, event handlers, `emit_event`, and structured event logging.
+- Facade keeps read-only `_runners`/`_runner_tasks`/`_resources` properties and an `_install_signal_handlers()` passthrough because `tests/contract/test_runtime_contract.py` reads them directly. `serve()`/`request_drain()`/`request_task_pause()`/`request_shutdown()` and `**app.describe()` structures are byte-for-byte unchanged.

--- a/docs/superpowers/specs/2026-08-27-onestep-app-lifecycle-decomposition-design.md
+++ b/docs/superpowers/specs/2026-08-27-onestep-app-lifecycle-decomposition-design.md
@@ -1,0 +1,134 @@
+# 拆分 `src/onestep/app.py` 的 `OneStepApp` god-object
+
+日期：2026-08-27
+状态：captain-approved design contract；跟踪 issue：[#146](https://github.com/mic1on/onestep/issues/146)
+范围：规划；本设计提交只包含文档与任务拆分，运行时代码实现由 issue 跟踪的开发任务落实。开发顺序：T1 EventHub → T2 TaskOperations → T3 LifecycleController → T4 测试与文档收口。
+
+## 1. 背景与目标
+
+`src/onestep/app.py` 当前 1136 行，`OneStepApp` 是事实上的 god-object：生命周期管理、runner 注册与单任务启停、关闭/排空/暂停信号与等待者、控制面状态快照查询、死信重放/手动运行、资源与 hook/event、序列化/加载全部混在同一类里。其余模块（`runtime/runner.py`、`runtime/executor.py`、`reporter.py`、`resource_registry.py` 等）拆分良好，唯独 `app.py` 持续膨胀，回归风险集中。
+
+> 引自架构 review（2026-08-27）："`src/onestep/app.py` 单文件 1136 行，是事实上的 god-object（生命周期、runner 管理、reporter、signal、shutdown/drain/pause 全在一处）。建议下一步把 runner/scheduler/control-plane 编排从 `OneStepApp` 中再剥离一层，降低回归面。"
+
+本设计在不改变任何公共 API 语义、不引入新依赖（核心保持 stdlib-only）、不触及 `Source`/`Sink`/`Delivery`/`TaskRunner`/`executor` 接口的前提下，把 `OneStepApp` 拆成职责单一的子组件，让 `OneStepApp` 收缩为门面（facade），委托给子组件。
+
+### 目标
+
+- 将 `app.py` 从 1136 行降到 < 400 行（门面 + 合成投递辅助类）。
+- 每个子组件 < 650 行，单一职责、可独立测试。
+- 100% 保持公共方法名、签名与返回结构不变，外部调用方零改动。
+- 核心继续 stdlib-only，零新增运行时依赖。
+
+### 非目标
+
+- 不新增业务功能，不改变 YAML/Python 配置契约。
+- 不改变 `Source`/`Sink`/`Delivery`/`TaskRunner`/`executor` 的接口与行为。
+- 不引入任何第三方依赖或新的抽象层（interface/factory 等）。
+- 不改 `tests/contract` 与 `connector_conformance` 的契约断言，只作为回归护栏。
+
+## 2. 现有证据与约束
+
+| 证据 | 对设计的约束 |
+| --- | --- |
+| `app.py` 共 1136 行，`OneStepApp` 承载以下独立职责块（行号见下） | 拆分必须按职责边界迁移，不能随机切文件 |
+| 生命周期：`startup()`(691) `shutdown()`(734) `serve()`(763) `run()`(833) `_install_signal_handlers()`(1066) `_open_resource`/`_close_resource`(module-level 1099/1108) | 这组构成 `LifecycleController` 的核心，含 `serve()` 主循环与资源开闭 |
+| 信号与等待者：`request_shutdown`(126) `request_restart`(139) `request_drain`(143) `request_task_pause`(156) `request_task_resume`(161) `is_stopping`(112) `is_draining`(116) `restart_requested`(120) `is_task_paused`(123) `wait_for_shutdown`(346) `wait_for_drain_request`(350) `wait_for_task_pause_request`(354) `wait_for_stop_fetching`(360) `wait_for_drain`(381) `wait_for_task_pause`(390) `wait_for_task_resume`(399) `_ensure_shutdown_event`(960) `_ensure_drain_event`(969) `notify_runner_state_changed`(501) `_ensure_runner_state_event`(1058) | 全部围绕 asyncio.Event 状态机，归 `LifecycleController` |
+| Runner 注册与单任务控制：`register_runners`(408) `stop_task_runner`(439) `start_task_runner`(468) `restart_task_runner`(493) `_require_controllable_task`(978) `_require_task_runners`(986) | 持有 `_runners`/`_runner_tasks`，与 `serve()` 主循环强耦合，归 `LifecycleController` |
+| 控制面状态查询：`drain_status`(512) `task_pause_status`(535) `task_control_snapshot`(556) `task_control_snapshots`(587) `task_supported_commands`(594) `supports_dead_letter_replay_commands`(605) `supports_dead_letter_discard_commands`(608) `supports_manual_run_commands`(611) `task_resume_status`(614) `_task_runtime_status`(1048) | 只读快照，归 `LifecycleController`；依赖 task 能力检测 |
+| 死信/手动运行：`replay_task_dead_letters`(176) `discard_task_dead_letters`(248) `run_task_once`(293) `_require_dead_letter_replay_task`(990) `_require_dead_letter_discard_task`(998) `_require_manual_run_task`(1006) `_task_supports_dead_letter_discard`(1014) `_task_supports_dead_letter_replay`(1017) `_task_supports_manual_run`(1024) `_build_dead_letter_replay_envelope`(1027) | 构成 `TaskOperations`，归 `LifecycleController` 持有或独立 `TaskOperations` |
+| Hook/Event：`on_startup`(633) `on_shutdown`(636) `on_event`(639) `enable_structured_event_logging`(642) `_register_hook`(911) `_run_hooks`(924) `emit_event`(930) | 构成 `EventHub`（小，约 60 行） |
+| 资源/任务定义：`bind_resources`(166) `register_resource`(169) `set_reporter_summary`(173) `task()`(650) `tasks` property(104) `resources` property(108) `_task_resources`(412) `_referenced_resource_ids`(421) | 属于领域根，保留在 `OneStepApp` 门面 |
+| 序列化/加载：`describe()`(840) `load()` classmethod(889) `_invoke_app_factory`(1117) `_describe_resource`(1090) | `describe`/`load` 保留在门面；`_describe_resource` 为模块级辅助 |
+| `src/onestep/testing/connector_conformance.py` 调用：`app.serve()`(145/212) `app.request_drain()`(153) `app.request_task_pause("connector_contract")`(155) `app.request_shutdown()`(157/172/179/189/235) | 公共方法名签名必须保持不变，否则 conformance 测试直接破 |
+| `src/onestep/cli.py` 调用：`**app.describe()`(447) | `describe()` 返回结构不变 |
+| `tests/contract/*` 依赖 `OneStepApp` 公共行为 | 拆出的子组件不得改变对外可观察行为；用 contract + conformance 作回归护栏 |
+| 项目约定：核心零运行时依赖，std-only | 子组件不得引入任何第三方库 |
+
+## 3. 设计
+
+采用**组合 + 委托（facade）**模式，而非继承。`OneStepApp` 仍是对外唯一的公共类，内部持有一个或多个子组件实例，将原方法实现迁移到子组件后，在 `OneStepApp` 上保留同名、同签名、同返回结构的薄委托方法。这样 `connector_conformance.py`、`cli.py`、全部 contract 测试、用户代码调用路径**零改动**。
+
+### 3.1 新增子组件（全部位于 `src/onestep/runtime/`，stdlib-only）
+
+**`runtime/lifecycle.py` → `LifecycleController`**
+
+拥有全部运行期状态与编排逻辑：
+
+- 状态：`_shutdown`/`_shutdown_requested`、`_drain`/`_drain_requested`、`_restart_requested`、`_paused_tasks`、`_runner_state`、`_runners`、`_runner_tasks`、`_loop`、`_resources`、`_events_logger`。
+- 生命周期：`startup()`、`shutdown()`、`serve()`、`run()`、`_install_signal_handlers()`、模块级 `_open_resource`/`_close_resource`。
+- 信号 API：`request_shutdown`/`request_restart`/`request_drain`/`request_task_pause`/`request_task_resume`、`is_stopping`/`is_draining`/`restart_requested`/`is_task_paused`、`notify_runner_state_changed`、`_ensure_shutdown_event`/`_ensure_drain_event`/`_ensure_runner_state_event`。
+- 等待者：`wait_for_shutdown` / `wait_for_drain_request` / `wait_for_task_pause_request` / `wait_for_stop_fetching` / `wait_for_drain` / `wait_for_task_pause` / `wait_for_task_resume`。
+- Runner 注册与单任务控制：`register_runners`、`stop_task_runner`、`start_task_runner`、`restart_task_runner`、`_require_controllable_task`、`_require_task_runners`。
+- 控制面状态查询：`drain_status`、`task_pause_status`、`task_control_snapshot`、`task_control_snapshots`、`task_supported_commands`、`supports_dead_letter_replay_commands`、`supports_dead_letter_discard_commands`、`supports_manual_run_commands`、`task_resume_status`、`_task_runtime_status`。
+- 持有并委托 `TaskOperations` 与 `EventHub`（构造时注入），或直接调用其方法。
+
+**`runtime/task_ops.py` → `TaskOperations`**
+
+- `replay_task_dead_letters`、`discard_task_dead_letters`、`run_task_once`。
+- 能力检测与守卫：`_require_dead_letter_replay_task`、`_require_dead_letter_discard_task`、`_require_manual_run_task`、`_task_supports_dead_letter_discard`、`_task_supports_dead_letter_replay`、`_task_supports_manual_run`、`_build_dead_letter_replay_envelope`。
+- 依赖 `LifecycleController` 提供的 task 列表与 `TaskRunner`，通过构造注入。
+
+**`runtime/event_hub.py` → `EventHub`**
+
+- `on_startup`、`on_shutdown`、`on_event`、`enable_structured_event_logging`、`_register_hook`、`_run_hooks`、`emit_event`。
+
+### 3.2 `OneStepApp` 收缩为门面
+
+构造器创建 `LifecycleController`（内含 `TaskOperations`、`EventHub`）：
+
+```python
+class OneStepApp:
+    def __init__(self, name, *, config=None, state=None,
+                 shutdown_timeout_s=30.0, failure_capture=None):
+        # ...原有字段校验...
+        self._lifecycle = LifecycleController(
+            name=name, state=self.state,
+            shutdown_timeout_s=shutdown_timeout_s,
+            failure_capture=self._failure_capture_writer,
+            custom_metrics=self.custom_metrics,
+        )
+        # 资源/hook/event 委托到 _lifecycle
+```
+
+保留在 `OneStepApp` 的门面方法（仅委托，无逻辑）：
+
+- `tasks` / `resources` 属性（`_lifecycle` 持有 `_tasks` 与 `_named_resources`，或门面持有、`LifecycleController` 引用）。
+- `bind_resources` / `register_resource` / `set_reporter_summary`（写入共享状态）。
+- `task()` 装饰器（注册 `TaskSpec` 到共享 task 列表）。
+- `describe()` / `load()`（`describe` 汇总来自 `_lifecycle` 的运行时状态 + 门面的 task/resource 定义）。
+- `replay_task_dead_letters` / `discard_task_dead_letters` / `run_task_once` → 委托 `_lifecycle.operations`。
+- 所有 `request_*` / `is_*` / `wait_for_*` / `task_control_*` / `drain_status` / `task_pause_status` / `task_resume_status` / `supports_*_commands` → 委托 `_lifecycle`。
+- `on_startup` / `on_shutdown` / `on_event` / `enable_structured_event_logging` / `emit_event` → 委托 `_lifecycle.events`。
+- `register_runners` / `stop_task_runner` / `start_task_runner` / `restart_task_runner` → 委托 `_lifecycle`。
+
+`_SyntheticManualRunDelivery`（26-54）保留在 `app.py` 或随 `TaskOperations` 迁移（建议保留在 `app.py`，仅 manual run 使用）。
+
+### 3.3 状态所有权（关键）
+
+原 `serve()` 主循环直接读写 `self._runners`/`self._runner_tasks`/`self._shutdown`/`self._drain`/`self._paused_tasks` 等约 20 处内部属性。拆分后这些状态**唯一归属** `LifecycleController`，`OneStepApp` 不再重复持有，只通过委托方法访问。避免跨对象双重持有导致状态不一致。
+
+## 4. 风险与缓解
+
+| 风险 | 缓解 |
+| --- | --- |
+| `serve()` 主循环与内部状态高度耦合，拆分易引入并发/竞态回归 | 状态所有权一次性整体迁移到 `LifecycleController`；以 `tests/contract` + `connector_conformance.py` 的 drain/pause/shutdown 路径作为回归护栏 |
+| 外部调用方（conformance、cli、用户代码）依赖方法名与返回结构 | 委托层保持同名同签名同返回；CI 跑 `{pytest -m "not integration"}` 基线 606 passed 必须全绿 |
+| 子组件之间循环依赖（Lifecycle ↔ TaskOperations ↔ EventHub） | 构造期单向注入：`LifecycleController` 拥有 `TaskOperations` 与 `EventHub`，子组件不反向引用 `OneStepApp` |
+| 拆文件改变 import 路径，波及下游 | 仅新增 `runtime/lifecycle.py` 等文件，`OneStepApp` 仍从 `onestep` 包顶层导出，公开 import 路径不变 |
+
+## 5. 任务拆分（供开发）
+
+按风险从低到高、可独立验证的顺序：
+
+- **T1 — 抽 `EventHub`**：新建 `runtime/event_hub.py`，迁移 hook/event 7 个方法；`OneStepApp` 委托。最小、独立、低风险，先验证门面委托模式可行。
+- **T2 — 抽 `TaskOperations`**：新建 `runtime/task_ops.py`，迁移死信重放/手动运行 + 能力检测辅助；`OneStepApp` 委托。
+- **T3 — 抽 `LifecycleController`**：新建 `runtime/lifecycle.py`，整体迁移 `serve`/`startup`/`shutdown`/`run`/信号/runner registry/waiter/状态查询；`OneStepApp` 仅委托。最大块，依赖 T1/T2 落地。
+- **T4 — 收尾验证**：跑 `uv run pytest -m "not integration"`（基线 606 passed）+ `tests/contract`，确认零回归；更新 `AGENTS.md` 记录新模块边界（`OneStepApp` 为门面，`runtime/lifecycle.py` 为编排核心）。
+
+## 6. 验收标准
+
+- `app.py` < 400 行（`OneStepApp` 门面 + `_SyntheticManualRunDelivery` + 模块级辅助）。
+- `runtime/lifecycle.py` / `runtime/task_ops.py` / `runtime/event_hub.py` 各 < 650 行，单一职责。
+- 公共方法名、签名、返回结构与拆分前**逐字节等价**（除内部实现迁移）。
+- `uv run pytest -m "not integration"` 全绿（基线 606 passed），`tests/contract` 全绿。
+- 核心运行时依赖不变（stdlib-only）。

--- a/src/onestep/app.py
+++ b/src/onestep/app.py
@@ -344,17 +344,21 @@ class OneStepApp:
         return self._lifecycle._install_signal_handlers()
 
     # ----- contract-visible state (read-only views of the controller) -----
+    # See runtime/lifecycle.py: LifecycleController._runners / ._runner_tasks / ._resources.
 
     @property
     def _runners(self) -> list[Any]:
+        # see runtime/lifecycle.py LifecycleController._runners
         return self._lifecycle._runners
 
     @property
     def _runner_tasks(self) -> dict[str, Any]:
+        # see runtime/lifecycle.py LifecycleController._runner_tasks
         return self._lifecycle._runner_tasks
 
     @property
     def _resources(self) -> list[Any]:
+        # see runtime/lifecycle.py LifecycleController._resources
         return self._lifecycle._resources
 
 

--- a/src/onestep/app.py
+++ b/src/onestep/app.py
@@ -1,60 +1,37 @@
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import copy
 import importlib
 import inspect
 import logging
-import signal
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from .capture.config import FailureCaptureConfig
 from .capture.writer import FailureCaptureWriter
 from .connectors.base import Sink, Source
-from .envelope import Envelope
 from .events import StructuredEventLogger, TaskEvent
-from .invoke import invoke_callback
 from .metrics import CustomMetricsRegistry
 from .retry import RetryPolicy
+from .runtime.event_hub import EventHub
+from .runtime.lifecycle import LifecycleController
 from .runtime.runner import TaskRunner
+from .runtime.task_ops import TaskOperations
 from .state import InMemoryStateStore, StateStore
 from .task import EmitTarget, TaskHandler, TaskHooks, TaskSpec
 
 
-class _SyntheticManualRunDelivery:
-    def __init__(self, envelope: Envelope) -> None:
-        self.envelope = envelope
-        self.acked = False
-        self.failed = False
-        self.retry_requested = False
-        self.retry_delay_s: float | None = None
-
-    @property
-    def payload(self) -> Any:
-        return self.envelope.body
-
-    async def start_processing(self) -> None:
-        return None
-
-    async def ack(self) -> None:
-        self.acked = True
-
-    async def retry(self, *, delay_s: float | None = None) -> None:
-        self.retry_requested = True
-        self.retry_delay_s = delay_s
-        self.envelope = Envelope(
-            body=copy.deepcopy(self.envelope.body),
-            meta=copy.deepcopy(self.envelope.meta),
-            attempts=self.envelope.attempts + 1,
-        )
-
-    async def fail(self, exc: Exception | None = None) -> None:
-        self.failed = True
-
-
 class OneStepApp:
+    """Facade for an onestep async task runtime.
+
+    Construction, task/resource registration, ``describe``/``load``/``run``,
+    and the event-hook surface live here. The asyncio lifecycle, the per-task
+    runner registry, the control-plane state snapshots, the dead-letter /
+    manual-run operations, and the event hub are delegated to
+    ``LifecycleController``, ``TaskOperations``, and ``EventHub``. Public
+    method names, signatures, and return structures are unchanged.
+    """
+
     def __init__(
         self,
         name: str,
@@ -79,26 +56,12 @@ class OneStepApp:
         self.custom_metrics = CustomMetricsRegistry()
         self._tasks: list[TaskSpec] = []
         self._named_resources: dict[str, Any] = {}
-        self._shutdown: asyncio.Event | None = None
-        self._shutdown_requested = False
-        self._drain: asyncio.Event | None = None
-        self._drain_requested = False
-        self._restart_requested = False
-        self._paused_tasks: set[str] = set()
-        self._runner_state: asyncio.Event | None = None
-        self._runners: list[TaskRunner] = []
-        # Per-task asyncio.Task handles for each runner coroutine, keyed by task
-        # name. Captured so a single task's runner can be cancelled and respawned
-        # (see stop_task_runner / start_task_runner / restart_task_runner)
-        # without restarting the whole process. Cleared together with _runners.
-        self._runner_tasks: dict[str, asyncio.Task[None]] = {}
-        self._resources: list[Any] = []
-        self._startup_hooks: list[Callable[..., Any]] = []
-        self._shutdown_hooks: list[Callable[..., Any]] = []
-        self._event_handlers: list[Callable[..., Any]] = []
         self._reporter_summary: dict[str, Any] | None = None
-        self._loop: asyncio.AbstractEventLoop | None = None
-        self._events_logger = logging.getLogger(f"onestep.{name}.events")
+        self._events = EventHub(self)
+        self._task_ops = TaskOperations(self)
+        self._lifecycle = LifecycleController(self)
+
+    # ----- task / resource registry (owned by the facade) -----------------
 
     @property
     def tasks(self) -> tuple[TaskSpec, ...]:
@@ -107,61 +70,6 @@ class OneStepApp:
     @property
     def resources(self) -> Mapping[str, Any]:
         return self._named_resources
-
-    @property
-    def is_stopping(self) -> bool:
-        return self._shutdown_requested or (self._shutdown.is_set() if self._shutdown is not None else False)
-
-    @property
-    def is_draining(self) -> bool:
-        return self._drain_requested and not self.is_stopping
-
-    @property
-    def restart_requested(self) -> bool:
-        return self._restart_requested
-
-    def is_task_paused(self, task_name: str) -> bool:
-        return task_name in self._paused_tasks and not self.is_stopping
-
-    def request_shutdown(self) -> None:
-        self._shutdown_requested = True
-        try:
-            current_loop = asyncio.get_running_loop()
-        except RuntimeError:
-            current_loop = None
-        if self._shutdown is None:
-            return
-        if self._loop is None or self._loop is current_loop:
-            self._shutdown.set()
-            return
-        self._loop.call_soon_threadsafe(self._shutdown.set)
-
-    def request_restart(self) -> None:
-        self._restart_requested = True
-        self.request_shutdown()
-
-    def request_drain(self) -> None:
-        self._drain_requested = True
-        try:
-            current_loop = asyncio.get_running_loop()
-        except RuntimeError:
-            current_loop = None
-        drain = self._ensure_drain_event()
-        if self._loop is None or self._loop is current_loop:
-            drain.set()
-        else:
-            self._loop.call_soon_threadsafe(drain.set)
-        self.notify_runner_state_changed()
-
-    def request_task_pause(self, task_name: str) -> None:
-        self._require_controllable_task(task_name)
-        self._paused_tasks.add(task_name)
-        self.notify_runner_state_changed()
-
-    def request_task_resume(self, task_name: str) -> None:
-        self._require_controllable_task(task_name)
-        self._paused_tasks.discard(task_name)
-        self.notify_runner_state_changed()
 
     def bind_resources(self, resources: Mapping[str, Any]) -> None:
         self._named_resources = dict(resources)
@@ -173,122 +81,45 @@ class OneStepApp:
     def set_reporter_summary(self, reporter: Mapping[str, Any] | None) -> None:
         self._reporter_summary = None if reporter is None else copy.deepcopy(dict(reporter))
 
+    # ----- lifecycle state (delegated to LifecycleController) -------------
+
+    @property
+    def is_stopping(self) -> bool:
+        return self._lifecycle.is_stopping
+
+    @property
+    def is_draining(self) -> bool:
+        return self._lifecycle.is_draining
+
+    @property
+    def restart_requested(self) -> bool:
+        return self._lifecycle.restart_requested
+
+    def is_task_paused(self, task_name: str) -> bool:
+        return self._lifecycle.is_task_paused(task_name)
+
+    def request_shutdown(self) -> None:
+        self._lifecycle.request_shutdown()
+
+    def request_restart(self) -> None:
+        self._lifecycle.request_restart()
+
+    def request_drain(self) -> None:
+        self._lifecycle.request_drain()
+
+    def request_task_pause(self, task_name: str) -> None:
+        self._lifecycle.request_task_pause(task_name)
+
+    def request_task_resume(self, task_name: str) -> None:
+        self._lifecycle.request_task_resume(task_name)
+
+    # ----- task operations (delegated to TaskOperations) ------------------
+
     async def replay_task_dead_letters(self, task_name: str, *, limit: int) -> dict[str, Any]:
-        if limit < 1:
-            raise ValueError("dead-letter replay limit must be >= 1")
-        task = self._require_dead_letter_replay_task(task_name)
-        assert task.source is not None
-        assert isinstance(task.source, Sink)
-        dead_letter_source = task.dead_letter_sinks[0]
-        assert isinstance(dead_letter_source, Source)
-
-        attempted_count = 0
-        replayed_count = 0
-        failed_count = 0
-
-        for delivery in await dead_letter_source.fetch(limit):
-            attempted_count += 1
-            try:
-                replay_envelope = self._build_dead_letter_replay_envelope(delivery.envelope)
-            except Exception:
-                failed_count += 1
-                self._events_logger.exception(
-                    "dead-letter replay payload was invalid",
-                    extra={"task_name": task_name},
-                )
-                with contextlib.suppress(Exception):
-                    await delivery.retry()
-                continue
-
-            try:
-                await task.source.send(replay_envelope)
-            except Exception:
-                failed_count += 1
-                self._events_logger.exception(
-                    "dead-letter replay publish failed",
-                    extra={"task_name": task_name},
-                )
-                with contextlib.suppress(Exception):
-                    await delivery.retry()
-                continue
-
-            try:
-                await delivery.ack()
-            except Exception:
-                failed_count += 1
-                self._events_logger.exception(
-                    "dead-letter replay ack failed after publish",
-                    extra={"task_name": task_name},
-                )
-                continue
-
-            replayed_count += 1
-
-        if attempted_count == 0:
-            completion = "complete"
-        elif failed_count == 0:
-            completion = "complete"
-        elif replayed_count > 0:
-            completion = "partial"
-        else:
-            completion = "failed"
-
-        return {
-            "operation": "replay_dead_letters",
-            "task_name": task_name,
-            "requested": True,
-            "completion": completion,
-            "requested_limit": limit,
-            "attempted_count": attempted_count,
-            "replayed_count": replayed_count,
-            "failed_count": failed_count,
-            "empty": attempted_count == 0,
-        }
+        return await self._task_ops.replay_task_dead_letters(task_name, limit=limit)
 
     async def discard_task_dead_letters(self, task_name: str, *, limit: int) -> dict[str, Any]:
-        if limit < 1:
-            raise ValueError("dead-letter discard limit must be >= 1")
-        task = self._require_dead_letter_discard_task(task_name)
-        dead_letter_source = task.dead_letter_sinks[0]
-        assert isinstance(dead_letter_source, Source)
-
-        attempted_count = 0
-        discarded_count = 0
-        failed_count = 0
-
-        for delivery in await dead_letter_source.fetch(limit):
-            attempted_count += 1
-            try:
-                await delivery.ack()
-            except Exception:
-                failed_count += 1
-                self._events_logger.exception(
-                    "dead-letter discard ack failed",
-                    extra={"task_name": task_name},
-                )
-                continue
-            discarded_count += 1
-
-        if attempted_count == 0:
-            completion = "complete"
-        elif failed_count == 0:
-            completion = "complete"
-        elif discarded_count > 0:
-            completion = "partial"
-        else:
-            completion = "failed"
-
-        return {
-            "operation": "discard_dead_letters",
-            "task_name": task_name,
-            "requested": True,
-            "completion": completion,
-            "requested_limit": limit,
-            "attempted_count": attempted_count,
-            "discarded_count": discarded_count,
-            "failed_count": failed_count,
-            "empty": attempted_count == 0,
-        }
+        return await self._task_ops.discard_task_dead_letters(task_name, limit=limit)
 
     async def run_task_once(
         self,
@@ -296,356 +127,96 @@ class OneStepApp:
         *,
         payload: Mapping[str, Any],
     ) -> dict[str, Any]:
-        task = self._require_manual_run_task(task_name)
-        delivery = _SyntheticManualRunDelivery(
-            Envelope(
-                body=copy.deepcopy(dict(payload)),
-                meta={
-                    "manual_run": True,
-                    "task_name": task_name,
-                },
-                attempts=0,
-            )
-        )
-        runner = TaskRunner(self, task)
-
-        attempted_count = 0
-        completed = False
-        last_failure: Exception | None = None
-
-        while True:
-            attempted_count += 1
-            await runner._handle_delivery(delivery)
-            if delivery.acked:
-                completed = True
-                break
-            if not delivery.retry_requested:
-                break
-            delivery.retry_requested = False
-            last_failure = RuntimeError("manual run exhausted retries")
-
-        if completed:
-            return {
-                "operation": "run_task_once",
-                "task_name": task_name,
-                "requested": True,
-                "completion": "complete",
-                "attempted_count": attempted_count,
-                "manual_run": True,
-            }
-
-        if delivery.failed:
-            raise RuntimeError(
-                f"manual run failed for task {task_name} after {attempted_count} attempt(s)"
-            ) from last_failure
-
-        raise RuntimeError(
-            f"manual run did not reach a terminal successful state for task {task_name}"
-        )
-
-    async def wait_for_shutdown(self) -> None:
-        shutdown = self._ensure_shutdown_event()
-        await shutdown.wait()
-
-    async def wait_for_drain_request(self) -> None:
-        drain = self._ensure_drain_event()
-        await drain.wait()
-
-    async def wait_for_task_pause_request(self, task_name: str) -> None:
-        while not self.is_task_paused(task_name) and not self.is_stopping:
-            runner_state = self._ensure_runner_state_event()
-            await runner_state.wait()
-            runner_state.clear()
-
-    async def wait_for_stop_fetching(self, task_name: str | None = None) -> None:
-        shutdown_task = asyncio.create_task(self.wait_for_shutdown())
-        drain_task = asyncio.create_task(self.wait_for_drain_request())
-        waiters = {shutdown_task, drain_task}
-        if task_name is not None:
-            waiters.add(asyncio.create_task(self.wait_for_task_pause_request(task_name)))
-        try:
-            done, pending = await asyncio.wait(
-                waiters,
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-        except asyncio.CancelledError:
-            for waiter in waiters:
-                waiter.cancel()
-            await asyncio.gather(*waiters, return_exceptions=True)
-            raise
-        for pending_task in pending:
-            pending_task.cancel()
-        await asyncio.gather(*pending, return_exceptions=True)
-        await asyncio.gather(*done, return_exceptions=True)
-
-    async def wait_for_drain(self) -> dict[str, Any]:
-        while True:
-            status = self.drain_status()
-            if status["drained"]:
-                return status
-            runner_state = self._ensure_runner_state_event()
-            await runner_state.wait()
-            runner_state.clear()
-
-    async def wait_for_task_pause(self, task_name: str) -> dict[str, Any]:
-        while True:
-            status = self.task_pause_status(task_name)
-            if status["paused"]:
-                return status
-            runner_state = self._ensure_runner_state_event()
-            await runner_state.wait()
-            runner_state.clear()
-
-    async def wait_for_task_resume(self, task_name: str) -> dict[str, Any]:
-        while True:
-            status = self.task_resume_status(task_name)
-            if status["accepting_new_work"]:
-                return status
-            runner_state = self._ensure_runner_state_event()
-            await runner_state.wait()
-            runner_state.clear()
-
-    def register_runners(self, runners: Sequence[TaskRunner]) -> None:
-        self._runners = list(runners)
-        self.notify_runner_state_changed()
-
-    def _task_resources(self, task: TaskSpec) -> list[Any]:
-        """All resources owned by a task: its source, sinks, dead-letter sinks."""
-        resources: list[Any] = []
-        if task.source is not None:
-            resources.append(task.source)
-        resources.extend(task.sinks)
-        resources.extend(task.dead_letter_sinks)
-        return resources
-
-    def _referenced_resource_ids(self, *, exclude_task_name: str | None) -> set[int]:
-        """ids() of resources still referenced by other live tasks and named
-        resources. Used to decide which resources are safe to close when
-        restarting a single task: a resource shared with another task or a named
-        resource must not be closed (mirrors startup()'s dedupe-by-id policy)."""
-        referenced: set[int] = set()
-        for name, resource in self._named_resources.items():
-            if resource is not None:
-                referenced.add(id(resource))
-        if id(self.state) is not None:
-            referenced.add(id(self.state))
-        for task in self._tasks:
-            if task.name == exclude_task_name:
-                continue
-            for resource in self._task_resources(task):
-                referenced.add(id(resource))
-        return referenced
-
-    async def stop_task_runner(self, task_name: str) -> dict[str, Any]:
-        """Tear down a single task's runner: cancel its coroutine (letting the
-        runner's finally block drain inflight work and release fetch state),
-        remove it from the registries, and close the task's *private* resources
-        (source/sinks not referenced by any other live task or named resource).
-        Other tasks and the process as a whole are not affected."""
-        task = self._require_controllable_task(task_name)
-        runner_handle = self._runner_tasks.pop(task_name, None)
-        if runner_handle is not None and not runner_handle.done():
-            runner_handle.cancel()
-            await asyncio.gather(runner_handle, return_exceptions=True)
-        self._runners = [runner for runner in self._runners if runner.task.name != task_name]
-        self._paused_tasks.discard(task_name)
-
-        # Close only resources private to this task; shared ones stay open.
-        still_referenced = self._referenced_resource_ids(exclude_task_name=task_name)
-        for resource in self._task_resources(task):
-            if resource is None or id(resource) in still_referenced:
-                continue
-            with contextlib.suppress(Exception):
-                self._events_logger.debug(
-                    "closing private resource on task restart",
-                    extra={"task_name": task_name, "resource": getattr(resource, "name", resource.__class__.__name__)},
-                )
-                await _close_resource(resource)
-
-        self.notify_runner_state_changed()
-        return self.task_control_snapshot(task_name)
-
-    async def start_task_runner(self, task_name: str) -> dict[str, Any]:
-        """Re-open the task's private source and spawn a fresh runner for it.
-        Counterpart to stop_task_runner. Resources shared with other tasks are
-        expected to already be open (they were never closed)."""
-        task = self._require_controllable_task(task_name)
-        assert task.source is not None
-        # Re-open the task's resources. Shared resources already open are
-        # idempotent to re-open for connectors whose open() is a no-op when
-        # already connected; for safety, only open resources not currently
-        # referenced by another live task (i.e. private ones we just closed).
-        already_open_ids = self._referenced_resource_ids(exclude_task_name=task_name)
-        for resource in self._task_resources(task):
-            if resource is None or id(resource) in already_open_ids:
-                continue
-            await _open_resource(resource)
-
-        runner = TaskRunner(self, task)
-        self._runners.append(runner)
-        runner_handle = asyncio.create_task(
-            runner.run(), name=f"onestep-runner-{task_name}"
-        )
-        self._runner_tasks[task_name] = runner_handle
-        self.notify_runner_state_changed()
-        return self.task_control_snapshot(task_name)
-
-    async def restart_task_runner(self, task_name: str) -> dict[str, Any]:
-        """True per-task restart: cancel the existing runner, close and reopen
-        its private source/sinks, and spawn a fresh runner coroutine. Other
-        tasks keep running and the process is not restarted. Returns the task
-        control snapshot for the restarted task."""
-        await self.stop_task_runner(task_name)
-        return await self.start_task_runner(task_name)
-
-    def notify_runner_state_changed(self) -> None:
-        try:
-            current_loop = asyncio.get_running_loop()
-        except RuntimeError:
-            current_loop = None
-        runner_state = self._ensure_runner_state_event()
-        if self._loop is None or self._loop is current_loop:
-            runner_state.set()
-            return
-        self._loop.call_soon_threadsafe(runner_state.set)
-
-    def drain_status(self) -> dict[str, Any]:
-        inflight_task_count = sum(runner.inflight_count for runner in self._runners)
-        fetching_runner_count = sum(1 for runner in self._runners if runner.is_fetching)
-        parked_runner_count = sum(1 for runner in self._runners if runner.is_drain_parked)
-        runner_count = len(self._runners)
-        drained = (
-            self._drain_requested
-            and inflight_task_count == 0
-            and fetching_runner_count == 0
-            and parked_runner_count == runner_count
-        )
-        return {
-            "operation": "drain",
-            "requested": self._drain_requested,
-            "completion": "complete" if drained else "in_progress",
-            "drained": drained,
-            "accepting_new_work": not self._drain_requested,
-            "runner_count": runner_count,
-            "parked_runner_count": parked_runner_count,
-            "fetching_runner_count": fetching_runner_count,
-            "inflight_task_count": inflight_task_count,
-        }
-
-    def task_pause_status(self, task_name: str) -> dict[str, Any]:
-        status = self._task_runtime_status(task_name)
-        paused = (
-            status["pause_requested"]
-            and status["inflight_task_count"] == 0
-            and status["fetching_runner_count"] == 0
-            and status["parked_runner_count"] == status["runner_count"]
-        )
-        return {
-            "operation": "pause_task",
-            "task_name": task_name,
-            "requested": status["pause_requested"],
-            "completion": "complete" if paused else "in_progress",
-            "paused": paused,
-            "accepting_new_work": not status["pause_requested"],
-            "runner_count": status["runner_count"],
-            "parked_runner_count": status["parked_runner_count"],
-            "fetching_runner_count": status["fetching_runner_count"],
-            "inflight_task_count": status["inflight_task_count"],
-        }
-
-    def task_control_snapshot(self, task_name: str) -> dict[str, Any]:
-        task = next((task for task in self._tasks if task.name == task_name), None)
-        if task is None:
-            raise ValueError(f"task {task_name} was not found")
-        if task.source is None:
-            raise ValueError(f"task {task_name} does not have a controllable source runner")
-
-        runners = [runner for runner in self._runners if runner.task.name == task_name]
-        pause_requested = self.is_task_paused(task_name)
-        fetching_runner_count = sum(1 for runner in runners if runner.is_fetching)
-        parked_runner_count = sum(1 for runner in runners if runner.is_pause_parked)
-        inflight_task_count = sum(runner.inflight_count for runner in runners)
-        runner_count = len(runners)
-        paused = (
-            pause_requested
-            and inflight_task_count == 0
-            and fetching_runner_count == 0
-            and parked_runner_count == runner_count
-        )
-        return {
-            "task_name": task_name,
-            "supported_commands": self.task_supported_commands(task_name),
-            "pause_requested": pause_requested,
-            "paused": paused,
-            "accepting_new_work": not pause_requested,
-            "runner_count": runner_count,
-            "parked_runner_count": parked_runner_count,
-            "fetching_runner_count": fetching_runner_count,
-            "inflight_task_count": inflight_task_count,
-        }
-
-    def task_control_snapshots(self) -> list[dict[str, Any]]:
-        return [
-            self.task_control_snapshot(task.name)
-            for task in self._tasks
-            if task.source is not None
-        ]
-
-    def task_supported_commands(self, task_name: str) -> list[str]:
-        task = self._require_controllable_task(task_name)
-        supported_commands = ["pause_task", "resume_task", "restart_task"]
-        if self._task_supports_dead_letter_discard(task):
-            supported_commands.append("discard_dead_letters")
-        if self._task_supports_dead_letter_replay(task):
-            supported_commands.append("replay_dead_letters")
-        if self._task_supports_manual_run(task):
-            supported_commands.append("run_task_once")
-        return supported_commands
+        return await self._task_ops.run_task_once(task_name, payload=payload)
 
     def supports_dead_letter_replay_commands(self) -> bool:
-        return any(self._task_supports_dead_letter_replay(task) for task in self._tasks)
+        return self._task_ops.supports_dead_letter_replay_commands()
 
     def supports_dead_letter_discard_commands(self) -> bool:
-        return any(self._task_supports_dead_letter_discard(task) for task in self._tasks)
+        return self._task_ops.supports_dead_letter_discard_commands()
 
     def supports_manual_run_commands(self) -> bool:
-        return any(self._task_supports_manual_run(task) for task in self._tasks)
+        return self._task_ops.supports_manual_run_commands()
+
+    # ----- waiters (delegated to LifecycleController) ---------------------
+
+    async def wait_for_shutdown(self) -> None:
+        await self._lifecycle.wait_for_shutdown()
+
+    async def wait_for_drain_request(self) -> None:
+        await self._lifecycle.wait_for_drain_request()
+
+    async def wait_for_task_pause_request(self, task_name: str) -> None:
+        await self._lifecycle.wait_for_task_pause_request(task_name)
+
+    async def wait_for_stop_fetching(self, task_name: str | None = None) -> None:
+        await self._lifecycle.wait_for_stop_fetching(task_name)
+
+    async def wait_for_drain(self) -> dict[str, Any]:
+        return await self._lifecycle.wait_for_drain()
+
+    async def wait_for_task_pause(self, task_name: str) -> dict[str, Any]:
+        return await self._lifecycle.wait_for_task_pause(task_name)
+
+    async def wait_for_task_resume(self, task_name: str) -> dict[str, Any]:
+        return await self._lifecycle.wait_for_task_resume(task_name)
+
+    # ----- runner registry (delegated to LifecycleController) -------------
+
+    def register_runners(self, runners: Sequence[TaskRunner]) -> None:
+        self._lifecycle.register_runners(runners)
+
+    async def stop_task_runner(self, task_name: str) -> dict[str, Any]:
+        return await self._lifecycle.stop_task_runner(task_name)
+
+    async def start_task_runner(self, task_name: str) -> dict[str, Any]:
+        return await self._lifecycle.start_task_runner(task_name)
+
+    async def restart_task_runner(self, task_name: str) -> dict[str, Any]:
+        return await self._lifecycle.restart_task_runner(task_name)
+
+    def notify_runner_state_changed(self) -> None:
+        self._lifecycle.notify_runner_state_changed()
+
+    # ----- control-plane snapshots (delegated to LifecycleController) -----
+
+    def drain_status(self) -> dict[str, Any]:
+        return self._lifecycle.drain_status()
+
+    def task_pause_status(self, task_name: str) -> dict[str, Any]:
+        return self._lifecycle.task_pause_status(task_name)
+
+    def task_control_snapshot(self, task_name: str) -> dict[str, Any]:
+        return self._lifecycle.task_control_snapshot(task_name)
+
+    def task_control_snapshots(self) -> list[dict[str, Any]]:
+        return self._lifecycle.task_control_snapshots()
+
+    def task_supported_commands(self, task_name: str) -> list[str]:
+        return self._lifecycle.task_supported_commands(task_name)
 
     def task_resume_status(self, task_name: str) -> dict[str, Any]:
-        status = self._task_runtime_status(task_name)
-        accepting_new_work = (
-            not status["pause_requested"]
-            and status["parked_runner_count"] == 0
-        )
-        return {
-            "operation": "resume_task",
-            "task_name": task_name,
-            "requested": True,
-            "completion": "complete" if accepting_new_work else "in_progress",
-            "paused": not accepting_new_work,
-            "accepting_new_work": accepting_new_work,
-            "runner_count": status["runner_count"],
-            "parked_runner_count": status["parked_runner_count"],
-            "fetching_runner_count": status["fetching_runner_count"],
-            "inflight_task_count": status["inflight_task_count"],
-        }
+        return self._lifecycle.task_resume_status(task_name)
+
+    # ----- event hub (delegated to EventHub) ------------------------------
+
+    @property
+    def events_logger(self) -> logging.Logger:
+        return self._events.events_logger
 
     def on_startup(self, func: Callable[..., Any] | None = None):
-        return self._register_hook(self._startup_hooks, func)
+        return self._events.on_startup(func)
 
     def on_shutdown(self, func: Callable[..., Any] | None = None):
-        return self._register_hook(self._shutdown_hooks, func)
+        return self._events.on_shutdown(func)
 
     def on_event(self, func: Callable[..., Any] | None = None):
-        return self._register_hook(self._event_handlers, func)
+        return self._events.on_event(func)
 
     def enable_structured_event_logging(self) -> StructuredEventLogger:
-        for handler in self._event_handlers:
-            if isinstance(handler, StructuredEventLogger):
-                return handler
-        handler = StructuredEventLogger()
-        self.on_event(handler)
-        return handler
+        return self._events.enable_structured_event_logging()
+
+    # ----- task declaration ----------------------------------------------
 
     def task(
         self,
@@ -668,174 +239,30 @@ class OneStepApp:
             validate_task = getattr(source, "validate_task", None)
             if callable(validate_task):
                 validate_task(task_name)
-            task = TaskSpec.build(
-                name=task_name,
-                description=description,
-                handler=func,
-                handler_ref=handler_ref,
-                source=source,
-                sinks=emit,
-                dead_letter=dead_letter,
-                config=config,
-                metadata=metadata,
-                hooks=hooks,
-                concurrency=concurrency,
-                retry=retry,
-                timeout_s=timeout_s,
-            )
+            task = TaskSpec.build(name=task_name, description=description, handler=func,
+                handler_ref=handler_ref, source=source, sinks=emit, dead_letter=dead_letter,
+                config=config, metadata=metadata, hooks=hooks, concurrency=concurrency,
+                retry=retry, timeout_s=timeout_s)
             self._tasks.append(task)
             return func
 
         return decorator
 
+    # ----- lifecycle phases (delegated to LifecycleController) ------------
+
     async def startup(self) -> None:
-        self._loop = asyncio.get_running_loop()
-        self._shutdown_requested = False
-        self._drain_requested = False
-        self._restart_requested = False
-        self._paused_tasks = set()
-        self._shutdown = asyncio.Event()
-        self._drain = asyncio.Event()
-        self._runner_state = asyncio.Event()
-        self._runners = []
-        self._runner_tasks = {}
-        resources: list[Any] = []
-        seen: set[int] = set()
-
-        def add_resource(resource: Any) -> None:
-            if resource is None or id(resource) in seen:
-                return
-            resources.append(resource)
-            seen.add(id(resource))
-
-        for resource in self._named_resources.values():
-            add_resource(resource)
-        add_resource(self.state)
-        for task in self._tasks:
-            if task.source is not None:
-                add_resource(task.source)
-            for sink in task.sinks:
-                add_resource(sink)
-            for sink in task.dead_letter_sinks:
-                add_resource(sink)
-        opened: list[Any] = []
-        self._resources = []
-        try:
-            for resource in resources:
-                await _open_resource(resource)
-                opened.append(resource)
-            self._resources = list(opened)
-            await self._run_hooks(self._startup_hooks)
-        except Exception:
-            await self._close_resources(opened, suppress_exceptions=True)
-            self._resources = []
-            raise
+        await self._lifecycle.startup()
 
     async def shutdown(self) -> None:
-        self._shutdown_requested = True
-        if self._shutdown is not None:
-            self._shutdown.set()
-        hook_error: BaseException | None = None
-        try:
-            await self._run_hooks(self._shutdown_hooks)
-        except BaseException as exc:
-            hook_error = exc
-        finally:
-            close_error = await self._close_resources(self._resources, suppress_exceptions=False)
-            self._resources = []
-            # Cancel any runner task handles that somehow outlived serve()'s own
-            # gather/wait (e.g. a per-task restart spawned a new runner right as
-            # shutdown began). Swallow CancelledError — we are tearing down.
-            for runner_task in self._runner_tasks.values():
-                if not runner_task.done():
-                    runner_task.cancel()
-            if self._runner_tasks:
-                await asyncio.gather(*self._runner_tasks.values(), return_exceptions=True)
-            self._runner_tasks = {}
-            self._runners = []
-            self._paused_tasks = set()
-            self.notify_runner_state_changed()
-        if hook_error is not None:
-            raise hook_error
-        if close_error is not None:
-            raise close_error
+        await self._lifecycle.shutdown()
 
     async def serve(self) -> None:
-        await self.startup()
-        runners = [TaskRunner(self, task) for task in self._tasks if task.source is not None]
-        self.register_runners(runners)
-        try:
-            if not runners:
-                return
-            # Spawn each runner as its own asyncio.Task and keep the handles in
-            # _runner_tasks so they can be cancelled individually (per-task
-            # restart via stop_task_runner). We wait with FIRST_COMPLETED and
-            # loop, re-reading _runner_tasks each iteration so cancellations
-            # and runners spawned by a per-task restart are picked up promptly.
-            # A runner that ends with CancelledError because it was individually
-            # cancelled for a restart must NOT bring down the whole process:
-            # drop it and keep waiting. Any other exception is a real runner
-            # error: cancel the remaining runners and propagate (matching the
-            # previous asyncio.gather semantics).
-            runner_tasks = [
-                asyncio.create_task(runner.run(), name=f"onestep-runner-{runner.task.name}")
-                for runner in runners
-            ]
-            self._runner_tasks = {runner.task.name: task for runner, task in zip(runners, runner_tasks)}
-            # Tasks we have already inspected; do not re-await them.
-            inspected: set[asyncio.Task[None]] = set()
-            while True:
-                live = {task for task in self._runner_tasks.values() if task not in inspected}
-                if not live:
-                    # No runner currently tracked. This is expected *transiently*
-                    # during a per-task restart (stop_task_runner removes the old
-                    # handle before start_task_runner adds the new one). Only exit
-                    # when the app is actually shutting down; otherwise briefly
-                    # yield and re-check the registry so a freshly spawned runner
-                    # is picked up.
-                    if self.is_stopping:
-                        break
-                    try:
-                        await asyncio.wait_for(self.wait_for_shutdown(), timeout=0.05)
-                    except asyncio.TimeoutError:
-                        pass
-                    inspected = {task for task in inspected if task in self._runner_tasks.values()}
-                    continue
-                done, _pending = await asyncio.wait(live, return_when=asyncio.FIRST_COMPLETED)
-                inspected |= done
-                first_exc: BaseException | None = None
-                for task in done:
-                    # A cancelled runner task raises CancelledError from
-                    # .exception(); skip via .cancelled() first. Per-task restart
-                    # (or shutdown) cancels individual runners and must not bring
-                    # down the whole process.
-                    if task.cancelled():
-                        continue
-                    exc = task.exception()
-                    if exc is None:
-                        continue
-                    if isinstance(exc, asyncio.CancelledError):
-                        continue
-                    if first_exc is None:
-                        first_exc = exc
-                if first_exc is not None:
-                    remaining = {task for task in self._runner_tasks.values() if task not in inspected}
-                    for task in remaining:
-                        task.cancel()
-                    if remaining:
-                        await asyncio.gather(*remaining, return_exceptions=True)
-                    raise first_exc
-            # All currently-tracked runners exited cleanly (normally via
-            # request_shutdown or a per-task stop). Nothing left to await.
-        finally:
-            await self.shutdown()
+        await self._lifecycle.serve()
 
     def run(self) -> None:
-        try:
-            with self._install_signal_handlers():
-                asyncio.run(self.serve())
-        except KeyboardInterrupt:
-            return None
+        self._lifecycle.run()
+
+    # ----- introspection / loading ---------------------------------------
 
     def describe(self) -> dict[str, Any]:
         return {
@@ -851,9 +278,9 @@ class OneStepApp:
                 for name, resource in self._named_resources.items()
             ],
             "hooks": {
-                "startup": len(self._startup_hooks),
-                "shutdown": len(self._shutdown_hooks),
-                "events": len(self._event_handlers),
+                "startup": self._events.startup_hook_count,
+                "shutdown": self._events.shutdown_hook_count,
+                "events": self._events.event_handler_count,
             },
             "tasks": [
                 {
@@ -862,21 +289,11 @@ class OneStepApp:
                     "handler_ref": task.handler_ref,
                     "source": _describe_resource(task.source),
                     "emit": [_describe_resource(sink) for sink in task.sinks],
-                    "emit_bindings": [
-                        {
-                            "sink": _describe_resource(binding.sink),
-                            "transform_ref": binding.transform_ref,
-                        }
-                        for binding in task.emit_bindings
-                    ],
+                    "emit_bindings": [{"sink": _describe_resource(b.sink), "transform_ref": b.transform_ref} for b in task.emit_bindings],
                     "dead_letter": [_describe_resource(sink) for sink in task.dead_letter_sinks],
                     "config": copy.deepcopy(task.config),
                     "metadata": copy.deepcopy(task.metadata),
-                    "hooks": {
-                        "before": len(task.hooks.before),
-                        "after_success": len(task.hooks.after_success),
-                        "on_failure": len(task.hooks.on_failure),
-                    },
+                    "hooks": {"before": len(task.hooks.before), "after_success": len(task.hooks.after_success), "on_failure": len(task.hooks.on_failure)},
                     "concurrency": task.concurrency,
                     "timeout_s": task.timeout_s,
                     "retry": task.retry.__class__.__name__,
@@ -908,183 +325,37 @@ class OneStepApp:
                 return resolved
         raise TypeError(f"{target} did not resolve to OneStepApp or a zero-argument factory")
 
+    # ----- event hub internals (delegated to EventHub) --------------------
+
     def _register_hook(
         self,
         storage: list[Callable[..., Any]],
         func: Callable[..., Any] | None,
     ):
-        def decorator(callback: Callable[..., Any]) -> Callable[..., Any]:
-            storage.append(callback)
-            return callback
-
-        if func is None:
-            return decorator
-        return decorator(func)
+        return self._events._register_hook(storage, func)
 
     async def _run_hooks(self, hooks: Sequence[Callable[..., Any]]) -> None:
-        for hook in hooks:
-            result = invoke_callback(hook, self)
-            if inspect.isawaitable(result):
-                await result
+        await self._events.run_hooks(hooks)
 
     async def emit_event(self, event: TaskEvent) -> None:
-        for handler in self._event_handlers:
-            try:
-                result = invoke_callback(handler, event)
-                if inspect.isawaitable(result):
-                    await result
-            except Exception:
-                self._events_logger.exception("event handler failed", extra={"event_kind": event.kind.value})
+        await self._events.emit_event(event)
 
-    async def _close_resources(
-        self,
-        resources: Sequence[Any],
-        *,
-        suppress_exceptions: bool,
-    ) -> BaseException | None:
-        first_error: BaseException | None = None
-        for resource in reversed(resources):
-            try:
-                await _close_resource(resource)
-            except BaseException as exc:
-                if first_error is None:
-                    first_error = exc
-                self._events_logger.exception(
-                    "resource close failed",
-                    extra={"resource_name": getattr(resource, "name", resource.__class__.__name__)},
-                )
-        if first_error is not None and not suppress_exceptions:
-            return first_error
-        return None
-
-    def _ensure_shutdown_event(self) -> asyncio.Event:
-        current_loop = asyncio.get_running_loop()
-        if self._shutdown is None or self._loop is not current_loop:
-            self._loop = current_loop
-            self._shutdown = asyncio.Event()
-            if self._shutdown_requested:
-                self._shutdown.set()
-        return self._shutdown
-
-    def _ensure_drain_event(self) -> asyncio.Event:
-        current_loop = asyncio.get_running_loop()
-        if self._drain is None or self._loop is not current_loop:
-            self._loop = current_loop
-            self._drain = asyncio.Event()
-            if self._drain_requested:
-                self._drain.set()
-        return self._drain
-
-    def _require_controllable_task(self, task_name: str) -> TaskSpec:
-        task = next((task for task in self._tasks if task.name == task_name), None)
-        if task is None:
-            raise ValueError(f"task {task_name} was not found")
-        if task.source is None:
-            raise ValueError(f"task {task_name} does not have a controllable source runner")
-        return task
-
-    def _require_task_runners(self, task_name: str) -> list[TaskRunner]:
-        self._require_controllable_task(task_name)
-        return [runner for runner in self._runners if runner.task.name == task_name]
-
-    def _require_dead_letter_replay_task(self, task_name: str) -> TaskSpec:
-        task = self._require_controllable_task(task_name)
-        if not self._task_supports_dead_letter_replay(task):
-            raise ValueError(
-                f"task {task_name} does not support dead-letter replay with the configured source and dead-letter connectors"
-            )
-        return task
-
-    def _require_dead_letter_discard_task(self, task_name: str) -> TaskSpec:
-        task = self._require_controllable_task(task_name)
-        if not self._task_supports_dead_letter_discard(task):
-            raise ValueError(
-                f"task {task_name} does not support dead-letter discard with the configured dead-letter connectors"
-            )
-        return task
-
-    def _require_manual_run_task(self, task_name: str) -> TaskSpec:
-        task = self._require_controllable_task(task_name)
-        if not self._task_supports_manual_run(task):
-            raise ValueError(
-                f"task {task_name} does not support manual run with the configured source"
-            )
-        return task
-
-    def _task_supports_dead_letter_discard(self, task: TaskSpec) -> bool:
-        return len(task.dead_letter_sinks) == 1 and isinstance(task.dead_letter_sinks[0], Source)
-
-    def _task_supports_dead_letter_replay(self, task: TaskSpec) -> bool:
-        return (
-            task.source is not None
-            and isinstance(task.source, Sink)
-            and self._task_supports_dead_letter_discard(task)
-        )
-
-    def _task_supports_manual_run(self, task: TaskSpec) -> bool:
-        return task.source is not None and bool(getattr(task.source, "supports_manual_run", False))
-
-    def _build_dead_letter_replay_envelope(self, dead_letter_envelope: Envelope) -> Envelope:
-        if not isinstance(dead_letter_envelope.body, Mapping):
-            raise ValueError("dead-letter envelope body must be a mapping")
-        if "payload" not in dead_letter_envelope.body:
-            raise ValueError("dead-letter envelope body is missing payload")
-
-        original_payload = copy.deepcopy(dead_letter_envelope.body["payload"])
-        original_meta = dead_letter_envelope.meta.get("original_meta")
-        if not isinstance(original_meta, Mapping):
-            replay_meta: dict[str, Any] = {}
-        else:
-            replay_meta = copy.deepcopy(dict(original_meta))
-
-        original_attempts = dead_letter_envelope.meta.get("original_attempts")
-        replay_attempts = original_attempts if isinstance(original_attempts, int) and original_attempts >= 0 else 0
-        return Envelope(
-            body=original_payload,
-            meta=replay_meta,
-            attempts=replay_attempts,
-        )
-
-    def _task_runtime_status(self, task_name: str) -> dict[str, Any]:
-        runners = self._require_task_runners(task_name)
-        return {
-            "pause_requested": self.is_task_paused(task_name),
-            "runner_count": len(runners),
-            "parked_runner_count": sum(1 for runner in runners if runner.is_pause_parked),
-            "fetching_runner_count": sum(1 for runner in runners if runner.is_fetching),
-            "inflight_task_count": sum(runner.inflight_count for runner in runners),
-        }
-
-    def _ensure_runner_state_event(self) -> asyncio.Event:
-        current_loop = asyncio.get_running_loop()
-        if self._runner_state is None or self._loop is not current_loop:
-            self._loop = current_loop
-            self._runner_state = asyncio.Event()
-        return self._runner_state
-
-    @contextlib.contextmanager
     def _install_signal_handlers(self):
-        installed: list[tuple[int, Any]] = []
+        return self._lifecycle._install_signal_handlers()
 
-        def handle_signal(signum, frame) -> None:
-            self.request_shutdown()
+    # ----- contract-visible state (read-only views of the controller) -----
 
-        for sig_name in ("SIGINT", "SIGTERM"):
-            sig = getattr(signal, sig_name, None)
-            if sig is None:
-                continue
-            try:
-                previous = signal.getsignal(sig)
-                signal.signal(sig, handle_signal)
-            except (ValueError, OSError):
-                continue
-            installed.append((sig, previous))
-        try:
-            yield
-        finally:
-            for sig, previous in reversed(installed):
-                with contextlib.suppress(ValueError, OSError):
-                    signal.signal(sig, previous)
+    @property
+    def _runners(self) -> list[Any]:
+        return self._lifecycle._runners
+
+    @property
+    def _runner_tasks(self) -> dict[str, Any]:
+        return self._lifecycle._runner_tasks
+
+    @property
+    def _resources(self) -> list[Any]:
+        return self._lifecycle._resources
 
 
 def _describe_resource(resource: Source | Sink | None) -> dict[str, str] | None:
@@ -1094,24 +365,6 @@ def _describe_resource(resource: Source | Sink | None) -> dict[str, str] | None:
         "name": resource.name,
         "type": resource.__class__.__name__,
     }
-
-
-async def _open_resource(resource: Any) -> None:
-    opener = getattr(resource, "open", None)
-    if not callable(opener):
-        return
-    result = opener()
-    if inspect.isawaitable(result):
-        await result
-
-
-async def _close_resource(resource: Any) -> None:
-    closer = getattr(resource, "close", None)
-    if not callable(closer):
-        return
-    result = closer()
-    if inspect.isawaitable(result):
-        await result
 
 
 def _invoke_app_factory(target: str, factory: Callable[..., Any]) -> Any:

--- a/src/onestep/runtime/event_hub.py
+++ b/src/onestep/runtime/event_hub.py
@@ -1,0 +1,108 @@
+"""Hook registry and structured event dispatcher for :class:`OneStepApp`.
+
+This module is a private implementation detail of :mod:`onestep.app`. It owns
+the three hook lists and the structured event handlers that used to live
+directly on ``OneStepApp``. Public behaviour is unchanged; the methods are
+invoked through facade delegation on ``OneStepApp``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from ..events import StructuredEventLogger, TaskEvent
+from ..invoke import invoke_callback
+
+
+class EventHub:
+    """Owns startup / shutdown hooks and event handlers for an app instance.
+
+    The hub receives the owning :class:`OneStepApp` once and reuses the
+    reference to dispatch hooks (so that hook callbacks see the app as
+    ``self``) and to log failures through the app's named events logger.
+    """
+
+    def __init__(self, app: Any) -> None:
+        self._app = app
+        self._startup_hooks: list[Callable[..., Any]] = []
+        self._shutdown_hooks: list[Callable[..., Any]] = []
+        self._event_handlers: list[Callable[..., Any]] = []
+        self._events_logger = logging.getLogger(f"onestep.{app.name}.events")
+
+    @property
+    def startup_hook_count(self) -> int:
+        return len(self._startup_hooks)
+
+    @property
+    def shutdown_hook_count(self) -> int:
+        return len(self._shutdown_hooks)
+
+    @property
+    def event_handler_count(self) -> int:
+        return len(self._event_handlers)
+
+    @property
+    def startup_hooks(self) -> list[Callable[..., Any]]:
+        return self._startup_hooks
+
+    @property
+    def shutdown_hooks(self) -> list[Callable[..., Any]]:
+        return self._shutdown_hooks
+
+    @property
+    def events_logger(self) -> logging.Logger:
+        return self._events_logger
+
+    @property
+    def event_handlers(self) -> list[Callable[..., Any]]:
+        return self._event_handlers
+
+    def on_startup(self, func: Callable[..., Any] | None = None):
+        return self._register_hook(self._startup_hooks, func)
+
+    def on_shutdown(self, func: Callable[..., Any] | None = None):
+        return self._register_hook(self._shutdown_hooks, func)
+
+    def on_event(self, func: Callable[..., Any] | None = None):
+        return self._register_hook(self._event_handlers, func)
+
+    def enable_structured_event_logging(self) -> StructuredEventLogger:
+        for handler in self._event_handlers:
+            if isinstance(handler, StructuredEventLogger):
+                return handler
+        handler = StructuredEventLogger()
+        self.on_event(handler)
+        return handler
+
+    async def run_hooks(self, hooks: Sequence[Callable[..., Any]]) -> None:
+        for hook in hooks:
+            result = invoke_callback(hook, self._app)
+            if inspect.isawaitable(result):
+                await result
+
+    async def emit_event(self, event: TaskEvent) -> None:
+        for handler in self._event_handlers:
+            try:
+                result = invoke_callback(handler, event)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                self._events_logger.exception(
+                    "event handler failed", extra={"event_kind": event.kind.value}
+                )
+
+    def _register_hook(
+        self,
+        storage: list[Callable[..., Any]],
+        func: Callable[..., Any] | None,
+    ):
+        def decorator(callback: Callable[..., Any]) -> Callable[..., Any]:
+            storage.append(callback)
+            return callback
+
+        if func is None:
+            return decorator
+        return decorator(func)

--- a/src/onestep/runtime/lifecycle.py
+++ b/src/onestep/runtime/lifecycle.py
@@ -1,0 +1,649 @@
+"""Lifecycle, runner registry, and control-plane state for :class:`OneStepApp`.
+
+The :class:`LifecycleController` owns the asyncio state of an app instance:
+shutdown/drain/pause signals and waiters, the runner registry and per-task
+asyncio handles, the ``serve()`` main loop, and the control-plane snapshots.
+It holds a back-reference to the owning :class:`OneStepApp` so it can read the
+task registry, events logger, named resources, and reporter summary without
+exposing them as parameters. Public behaviour unchanged; invoked via facade
+delegation on :class:`OneStepApp`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import inspect
+import signal
+from collections.abc import Sequence
+from typing import Any
+
+from .runner import TaskRunner
+
+
+class LifecycleController:
+    """Owns the asyncio lifecycle of an :class:`OneStepApp` instance."""
+
+    def __init__(self, app: Any) -> None:
+        self._app = app
+        # Signal/pause state
+        self._shutdown: asyncio.Event | None = None
+        self._shutdown_requested = False
+        self._drain: asyncio.Event | None = None
+        self._drain_requested = False
+        self._restart_requested = False
+        self._paused_tasks: set[str] = set()
+        self._runner_state: asyncio.Event | None = None
+        # Runner registry
+        self._runners: list[TaskRunner] = []
+        self._runner_tasks: dict[str, asyncio.Task[None]] = {}
+        # Opened resources (set during startup, drained during shutdown).
+        # Mirrors the original OneStepApp._resources attribute.
+        self._resources: list[Any] = []
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    # ----- state properties ------------------------------------------------
+
+    @property
+    def is_stopping(self) -> bool:
+        return self._shutdown_requested or (self._shutdown.is_set() if self._shutdown is not None else False)
+
+    @property
+    def is_draining(self) -> bool:
+        return self._drain_requested and not self.is_stopping
+
+    @property
+    def restart_requested(self) -> bool:
+        return self._restart_requested
+
+    def is_task_paused(self, task_name: str) -> bool:
+        return task_name in self._paused_tasks and not self.is_stopping
+
+    # ----- request_* methods (control plane) -------------------------------
+
+    def request_shutdown(self) -> None:
+        self._shutdown_requested = True
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+        if self._shutdown is None:
+            return
+        if self._loop is None or self._loop is current_loop:
+            self._shutdown.set()
+            return
+        self._loop.call_soon_threadsafe(self._shutdown.set)
+
+    def request_restart(self) -> None:
+        self._restart_requested = True
+        self.request_shutdown()
+
+    def request_drain(self) -> None:
+        self._drain_requested = True
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+        drain = self._ensure_drain_event()
+        if self._loop is None or self._loop is current_loop:
+            drain.set()
+        else:
+            self._loop.call_soon_threadsafe(drain.set)
+        self.notify_runner_state_changed()
+
+    def request_task_pause(self, task_name: str) -> None:
+        self._require_controllable_task(task_name)
+        self._paused_tasks.add(task_name)
+        self.notify_runner_state_changed()
+
+    def request_task_resume(self, task_name: str) -> None:
+        self._require_controllable_task(task_name)
+        self._paused_tasks.discard(task_name)
+        self.notify_runner_state_changed()
+
+    def notify_runner_state_changed(self) -> None:
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+        runner_state = self._ensure_runner_state_event()
+        if self._loop is None or self._loop is current_loop:
+            runner_state.set()
+            return
+        self._loop.call_soon_threadsafe(runner_state.set)
+
+    # ----- wait_* methods (control plane) ----------------------------------
+
+    async def wait_for_shutdown(self) -> None:
+        shutdown = self._ensure_shutdown_event()
+        await shutdown.wait()
+
+    async def wait_for_drain_request(self) -> None:
+        drain = self._ensure_drain_event()
+        await drain.wait()
+
+    async def wait_for_task_pause_request(self, task_name: str) -> None:
+        while not self.is_task_paused(task_name) and not self.is_stopping:
+            runner_state = self._ensure_runner_state_event()
+            await runner_state.wait()
+            runner_state.clear()
+
+    async def wait_for_stop_fetching(self, task_name: str | None = None) -> None:
+        shutdown_task = asyncio.create_task(self.wait_for_shutdown())
+        drain_task = asyncio.create_task(self.wait_for_drain_request())
+        waiters = {shutdown_task, drain_task}
+        if task_name is not None:
+            waiters.add(asyncio.create_task(self.wait_for_task_pause_request(task_name)))
+        try:
+            done, pending = await asyncio.wait(
+                waiters,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        except asyncio.CancelledError:
+            for waiter in waiters:
+                waiter.cancel()
+            await asyncio.gather(*waiters, return_exceptions=True)
+            raise
+        for pending_task in pending:
+            pending_task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        await asyncio.gather(*done, return_exceptions=True)
+
+    async def wait_for_drain(self) -> dict[str, Any]:
+        while True:
+            status = self.drain_status()
+            if status["drained"]:
+                return status
+            runner_state = self._ensure_runner_state_event()
+            await runner_state.wait()
+            runner_state.clear()
+
+    async def wait_for_task_pause(self, task_name: str) -> dict[str, Any]:
+        while True:
+            status = self.task_pause_status(task_name)
+            if status["paused"]:
+                return status
+            runner_state = self._ensure_runner_state_event()
+            await runner_state.wait()
+            runner_state.clear()
+
+    async def wait_for_task_resume(self, task_name: str) -> dict[str, Any]:
+        while True:
+            status = self.task_resume_status(task_name)
+            if status["accepting_new_work"]:
+                return status
+            runner_state = self._ensure_runner_state_event()
+            await runner_state.wait()
+            runner_state.clear()
+
+    # ----- runner registry -------------------------------------------------
+
+    def register_runners(self, runners: Sequence[TaskRunner]) -> None:
+        self._runners = list(runners)
+        self.notify_runner_state_changed()
+
+    @property
+    def runners(self) -> list[TaskRunner]:
+        return self._runners
+
+    @property
+    def runner_tasks(self) -> dict[str, asyncio.Task[None]]:
+        return self._runner_tasks
+
+    @property
+    def resources(self) -> list[Any]:
+        return self._resources
+
+    async def stop_task_runner(self, task_name: str) -> dict[str, Any]:
+        """Tear down a single task's runner: cancel its coroutine (letting the
+        runner's finally block drain inflight work and release fetch state),
+        remove it from the registries, and close the task's *private* resources
+        (source/sinks not referenced by any other live task or named resource).
+        Other tasks and the process as a whole are not affected."""
+        task = self._require_controllable_task(task_name)
+        runner_handle = self._runner_tasks.pop(task_name, None)
+        if runner_handle is not None and not runner_handle.done():
+            runner_handle.cancel()
+            await asyncio.gather(runner_handle, return_exceptions=True)
+        self._runners = [runner for runner in self._runners if runner.task.name != task_name]
+        self._paused_tasks.discard(task_name)
+
+        # Close only resources private to this task; shared ones stay open.
+        still_referenced = self._referenced_resource_ids(exclude_task_name=task_name)
+        for resource in self._task_resources(task):
+            if resource is None or id(resource) in still_referenced:
+                continue
+            with contextlib.suppress(Exception):
+                self._app.events_logger.debug(
+                    "closing private resource on task restart",
+                    extra={"task_name": task_name, "resource": getattr(resource, "name", resource.__class__.__name__)},
+                )
+                await _close_resource(resource)
+
+        self.notify_runner_state_changed()
+        return self.task_control_snapshot(task_name)
+
+    async def start_task_runner(self, task_name: str) -> dict[str, Any]:
+        """Re-open the task's private source and spawn a fresh runner for it.
+        Counterpart to stop_task_runner. Resources shared with other tasks are
+        expected to already be open (they were never closed)."""
+        task = self._require_controllable_task(task_name)
+        assert task.source is not None
+        # Re-open the task's resources. Shared resources already open are
+        # idempotent to re-open for connectors whose open() is a no-op when
+        # already connected; for safety, only open resources not currently
+        # referenced by another live task (i.e. private ones we just closed).
+        already_open_ids = self._referenced_resource_ids(exclude_task_name=task_name)
+        for resource in self._task_resources(task):
+            if resource is None or id(resource) in already_open_ids:
+                continue
+            await _open_resource(resource)
+
+        runner = TaskRunner(self._app, task)
+        self._runners.append(runner)
+        runner_handle = asyncio.create_task(
+            runner.run(), name=f"onestep-runner-{task_name}"
+        )
+        self._runner_tasks[task_name] = runner_handle
+        self.notify_runner_state_changed()
+        return self.task_control_snapshot(task_name)
+
+    async def restart_task_runner(self, task_name: str) -> dict[str, Any]:
+        """True per-task restart: cancel the existing runner, close and reopen
+        its private source/sinks, and spawn a fresh runner coroutine. Other
+        tasks keep running and the process is not restarted. Returns the task
+        control snapshot for the restarted task."""
+        await self.stop_task_runner(task_name)
+        return await self.start_task_runner(task_name)
+
+    def _task_resources(self, task: Any) -> list[Any]:
+        """All resources owned by a task: its source, sinks, dead-letter sinks."""
+        resources: list[Any] = []
+        if task.source is not None:
+            resources.append(task.source)
+        resources.extend(task.sinks)
+        resources.extend(task.dead_letter_sinks)
+        return resources
+
+    def _referenced_resource_ids(self, *, exclude_task_name: str | None) -> set[int]:
+        """ids() of resources still referenced by other live tasks and named
+        resources. Used to decide which resources are safe to close when
+        restarting a single task: a resource shared with another task or a named
+        resource must not be closed (mirrors startup()'s dedupe-by-id policy)."""
+        referenced: set[int] = set()
+        for name, resource in self._app._named_resources.items():
+            if resource is not None:
+                referenced.add(id(resource))
+        if id(self._app.state) is not None:
+            referenced.add(id(self._app.state))
+        for task in self._app._tasks:
+            if task.name == exclude_task_name:
+                continue
+            for resource in self._task_resources(task):
+                referenced.add(id(resource))
+        return referenced
+
+    # ----- control-plane snapshots ----------------------------------------
+
+    def drain_status(self) -> dict[str, Any]:
+        inflight_task_count = sum(runner.inflight_count for runner in self._runners)
+        fetching_runner_count = sum(1 for runner in self._runners if runner.is_fetching)
+        parked_runner_count = sum(1 for runner in self._runners if runner.is_drain_parked)
+        runner_count = len(self._runners)
+        drained = (
+            self._drain_requested
+            and inflight_task_count == 0
+            and fetching_runner_count == 0
+            and parked_runner_count == runner_count
+        )
+        return {
+            "operation": "drain",
+            "requested": self._drain_requested,
+            "completion": "complete" if drained else "in_progress",
+            "drained": drained,
+            "accepting_new_work": not self._drain_requested,
+            "runner_count": runner_count,
+            "parked_runner_count": parked_runner_count,
+            "fetching_runner_count": fetching_runner_count,
+            "inflight_task_count": inflight_task_count,
+        }
+
+    def task_pause_status(self, task_name: str) -> dict[str, Any]:
+        status = self._task_runtime_status(task_name)
+        paused = (
+            status["pause_requested"]
+            and status["inflight_task_count"] == 0
+            and status["fetching_runner_count"] == 0
+            and status["parked_runner_count"] == status["runner_count"]
+        )
+        return {
+            "operation": "pause_task",
+            "task_name": task_name,
+            "requested": status["pause_requested"],
+            "completion": "complete" if paused else "in_progress",
+            "paused": paused,
+            "accepting_new_work": not status["pause_requested"],
+            "runner_count": status["runner_count"],
+            "parked_runner_count": status["parked_runner_count"],
+            "fetching_runner_count": status["fetching_runner_count"],
+            "inflight_task_count": status["inflight_task_count"],
+        }
+
+    def task_control_snapshot(self, task_name: str) -> dict[str, Any]:
+        task = next((task for task in self._app._tasks if task.name == task_name), None)
+        if task is None:
+            raise ValueError(f"task {task_name} was not found")
+        if task.source is None:
+            raise ValueError(f"task {task_name} does not have a controllable source runner")
+
+        runners = [runner for runner in self._runners if runner.task.name == task_name]
+        pause_requested = self.is_task_paused(task_name)
+        fetching_runner_count = sum(1 for runner in runners if runner.is_fetching)
+        parked_runner_count = sum(1 for runner in runners if runner.is_pause_parked)
+        inflight_task_count = sum(runner.inflight_count for runner in runners)
+        runner_count = len(runners)
+        paused = (
+            pause_requested
+            and inflight_task_count == 0
+            and fetching_runner_count == 0
+            and parked_runner_count == runner_count
+        )
+        return {
+            "task_name": task_name,
+            "supported_commands": self.task_supported_commands(task_name),
+            "pause_requested": pause_requested,
+            "paused": paused,
+            "accepting_new_work": not pause_requested,
+            "runner_count": runner_count,
+            "parked_runner_count": parked_runner_count,
+            "fetching_runner_count": fetching_runner_count,
+            "inflight_task_count": inflight_task_count,
+        }
+
+    def task_control_snapshots(self) -> list[dict[str, Any]]:
+        return [
+            self.task_control_snapshot(task.name)
+            for task in self._app._tasks
+            if task.source is not None
+        ]
+
+    def task_supported_commands(self, task_name: str) -> list[str]:
+        task = self._require_controllable_task(task_name)
+        supported_commands = ["pause_task", "resume_task", "restart_task"]
+        if self._app._task_ops._task_supports_dead_letter_discard(task):
+            supported_commands.append("discard_dead_letters")
+        if self._app._task_ops._task_supports_dead_letter_replay(task):
+            supported_commands.append("replay_dead_letters")
+        if self._app._task_ops._task_supports_manual_run(task):
+            supported_commands.append("run_task_once")
+        return supported_commands
+
+    def task_resume_status(self, task_name: str) -> dict[str, Any]:
+        status = self._task_runtime_status(task_name)
+        accepting_new_work = (
+            not status["pause_requested"]
+            and status["parked_runner_count"] == 0
+        )
+        return {
+            "operation": "resume_task",
+            "task_name": task_name,
+            "requested": True,
+            "completion": "complete" if accepting_new_work else "in_progress",
+            "paused": not accepting_new_work,
+            "accepting_new_work": accepting_new_work,
+            "runner_count": status["runner_count"],
+            "parked_runner_count": status["parked_runner_count"],
+            "fetching_runner_count": status["fetching_runner_count"],
+            "inflight_task_count": status["inflight_task_count"],
+        }
+
+    def _task_runtime_status(self, task_name: str) -> dict[str, Any]:
+        runners = self._require_task_runners(task_name)
+        return {
+            "pause_requested": self.is_task_paused(task_name),
+            "runner_count": len(runners),
+            "parked_runner_count": sum(1 for runner in runners if runner.is_pause_parked),
+            "fetching_runner_count": sum(1 for runner in runners if runner.is_fetching),
+            "inflight_task_count": sum(runner.inflight_count for runner in runners),
+        }
+
+    # ----- lifecycle phases ------------------------------------------------
+
+    async def startup(self) -> None:
+        self._loop = asyncio.get_running_loop()
+        self._shutdown_requested = False
+        self._drain_requested = False
+        self._restart_requested = False
+        self._paused_tasks = set()
+        self._shutdown = asyncio.Event()
+        self._drain = asyncio.Event()
+        self._runner_state = asyncio.Event()
+        self._runners = []
+        self._runner_tasks = {}
+        resources: list[Any] = []
+        seen: set[int] = set()
+
+        def add_resource(resource: Any) -> None:
+            if resource is None or id(resource) in seen:
+                return
+            resources.append(resource)
+            seen.add(id(resource))
+
+        for resource in self._app._named_resources.values():
+            add_resource(resource)
+        add_resource(self._app.state)
+        for task in self._app._tasks:
+            if task.source is not None:
+                add_resource(task.source)
+            for sink in task.sinks:
+                add_resource(sink)
+            for sink in task.dead_letter_sinks:
+                add_resource(sink)
+        opened: list[Any] = []
+        self._resources = []
+        try:
+            for resource in resources:
+                await _open_resource(resource)
+                opened.append(resource)
+            self._resources = list(opened)
+            await self._app._events.run_hooks(self._app._events.startup_hooks)
+        except Exception:
+            await self._close_resources(opened, suppress_exceptions=True)
+            self._resources = []
+            raise
+
+    async def shutdown(self) -> None:
+        self._shutdown_requested = True
+        if self._shutdown is not None:
+            self._shutdown.set()
+        hook_error: BaseException | None = None
+        try:
+            await self._app._events.run_hooks(self._app._events.shutdown_hooks)
+        except BaseException as exc:
+            hook_error = exc
+        finally:
+            close_error = await self._close_resources(self._resources, suppress_exceptions=False)
+            self._resources = []
+            for runner_task in self._runner_tasks.values():
+                if not runner_task.done():
+                    runner_task.cancel()
+            if self._runner_tasks:
+                await asyncio.gather(*self._runner_tasks.values(), return_exceptions=True)
+            self._runner_tasks = {}
+            self._runners = []
+            self._paused_tasks = set()
+            self.notify_runner_state_changed()
+        if hook_error is not None:
+            raise hook_error
+        if close_error is not None:
+            raise close_error
+
+    async def serve(self) -> None:
+        await self.startup()
+        runners = [TaskRunner(self._app, task) for task in self._app._tasks if task.source is not None]
+        self.register_runners(runners)
+        try:
+            if not runners:
+                return
+            # Spawn each runner as its own asyncio.Task and keep the handles in
+            # _runner_tasks so they can be cancelled individually (per-task
+            # restart via stop_task_runner). We wait with FIRST_COMPLETED and
+            # loop, re-reading _runner_tasks each iteration so cancellations
+            # and runners spawned by a per-task restart are picked up promptly.
+            # A runner that ends with CancelledError because it was individually
+            # cancelled for a restart must NOT bring down the whole process:
+            # drop it and keep waiting. Any other exception is a real runner
+            # error: cancel the remaining runners and propagate (matching the
+            # previous asyncio.gather semantics).
+            runner_tasks = [
+                asyncio.create_task(runner.run(), name=f"onestep-runner-{runner.task.name}")
+                for runner in runners
+            ]
+            self._runner_tasks = {runner.task.name: task for runner, task in zip(runners, runner_tasks)}
+            inspected: set[asyncio.Task[None]] = set()
+            while True:
+                live = {task for task in self._runner_tasks.values() if task not in inspected}
+                if not live:
+                    if self.is_stopping:
+                        break
+                    try:
+                        await asyncio.wait_for(self.wait_for_shutdown(), timeout=0.05)
+                    except asyncio.TimeoutError:
+                        pass
+                    inspected = {task for task in inspected if task in self._runner_tasks.values()}
+                    continue
+                done, _pending = await asyncio.wait(live, return_when=asyncio.FIRST_COMPLETED)
+                inspected |= done
+                first_exc: BaseException | None = None
+                for task in done:
+                    if task.cancelled():
+                        continue
+                    exc = task.exception()
+                    if exc is None:
+                        continue
+                    if isinstance(exc, asyncio.CancelledError):
+                        continue
+                    if first_exc is None:
+                        first_exc = exc
+                if first_exc is not None:
+                    remaining = {task for task in self._runner_tasks.values() if task not in inspected}
+                    for task in remaining:
+                        task.cancel()
+                    if remaining:
+                        await asyncio.gather(*remaining, return_exceptions=True)
+                    raise first_exc
+            # All currently-tracked runners exited cleanly (normally via
+            # request_shutdown or a per-task stop). Nothing left to await.
+        finally:
+            await self.shutdown()
+
+    def run(self) -> None:
+        try:
+            with self._install_signal_handlers():
+                asyncio.run(self.serve())
+        except KeyboardInterrupt:
+            return None
+
+    # ----- internals -------------------------------------------------------
+
+    async def _close_resources(
+        self,
+        resources: Sequence[Any],
+        *,
+        suppress_exceptions: bool,
+    ) -> BaseException | None:
+        first_error: BaseException | None = None
+        for resource in reversed(resources):
+            try:
+                await _close_resource(resource)
+            except BaseException as exc:
+                if first_error is None:
+                    first_error = exc
+                self._app.events_logger.exception(
+                    "resource close failed",
+                    extra={"resource_name": getattr(resource, "name", resource.__class__.__name__)},
+                )
+        if first_error is not None and not suppress_exceptions:
+            return first_error
+        return None
+
+    def _require_controllable_task(self, task_name: str) -> Any:
+        task = next((task for task in self._app._tasks if task.name == task_name), None)
+        if task is None:
+            raise ValueError(f"task {task_name} was not found")
+        if task.source is None:
+            raise ValueError(f"task {task_name} does not have a controllable source runner")
+        return task
+
+    def _require_task_runners(self, task_name: str) -> list[TaskRunner]:
+        self._require_controllable_task(task_name)
+        return [runner for runner in self._runners if runner.task.name == task_name]
+
+    def _ensure_shutdown_event(self) -> asyncio.Event:
+        current_loop = asyncio.get_running_loop()
+        if self._shutdown is None or self._loop is not current_loop:
+            self._loop = current_loop
+            self._shutdown = asyncio.Event()
+            if self._shutdown_requested:
+                self._shutdown.set()
+        return self._shutdown
+
+    def _ensure_drain_event(self) -> asyncio.Event:
+        current_loop = asyncio.get_running_loop()
+        if self._drain is None or self._loop is not current_loop:
+            self._loop = current_loop
+            self._drain = asyncio.Event()
+            if self._drain_requested:
+                self._drain.set()
+        return self._drain
+
+    def _ensure_runner_state_event(self) -> asyncio.Event:
+        current_loop = asyncio.get_running_loop()
+        if self._runner_state is None or self._loop is not current_loop:
+            self._loop = current_loop
+            self._runner_state = asyncio.Event()
+        return self._runner_state
+
+    @contextlib.contextmanager
+    def _install_signal_handlers(self):
+        installed: list[tuple[int, Any]] = []
+
+        def handle_signal(signum, frame) -> None:
+            self.request_shutdown()
+
+        for sig_name in ("SIGINT", "SIGTERM"):
+            sig = getattr(signal, sig_name, None)
+            if sig is None:
+                continue
+            try:
+                previous = signal.getsignal(sig)
+                signal.signal(sig, handle_signal)
+            except (ValueError, OSError):
+                continue
+            installed.append((sig, previous))
+        try:
+            yield
+        finally:
+            for sig, previous in reversed(installed):
+                with contextlib.suppress(ValueError, OSError):
+                    signal.signal(sig, previous)
+
+
+# ---- module-level helpers ------------------------------------------------
+
+async def _open_resource(resource: Any) -> None:
+    opener = getattr(resource, "open", None)
+    if not callable(opener):
+        return
+    result = opener()
+    if inspect.isawaitable(result):
+        await result
+
+
+async def _close_resource(resource: Any) -> None:
+    closer = getattr(resource, "close", None)
+    if not callable(closer):
+        return
+    result = closer()
+    if inspect.isawaitable(result):
+        await result

--- a/src/onestep/runtime/task_ops.py
+++ b/src/onestep/runtime/task_ops.py
@@ -1,0 +1,324 @@
+"""Task-level operations that need no runner registry.
+
+This module hosts the two operations that are invoked from the control plane
+without needing the per-task :class:`asyncio.Task` handles: dead-letter replay,
+dead-letter discard, and one-shot manual run. The capability probes that the
+control plane uses to decide which commands are supported live here too.
+
+Public behaviour is unchanged; the methods are invoked through facade
+delegation on :class:`OneStepApp`.
+"""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from typing import Any
+
+from ..connectors.base import Sink, Source
+from ..envelope import Envelope
+from ..runtime.runner import TaskRunner
+from ..task import TaskSpec
+
+
+class _SyntheticManualRunDelivery:
+    def __init__(self, envelope: Envelope) -> None:
+        self.envelope = envelope
+        self.acked = False
+        self.failed = False
+        self.retry_requested = False
+        self.retry_delay_s: float | None = None
+
+    @property
+    def payload(self) -> Any:
+        return self.envelope.body
+
+    async def start_processing(self) -> None:
+        return None
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def retry(self, *, delay_s: float | None = None) -> None:
+        self.retry_requested = True
+        self.retry_delay_s = delay_s
+        self.envelope = Envelope(
+            body=copy.deepcopy(self.envelope.body),
+            meta=copy.deepcopy(self.envelope.meta),
+            attempts=self.envelope.attempts + 1,
+        )
+
+    async def fail(self, exc: Exception | None = None) -> None:
+        self.failed = True
+
+
+class TaskOperations:
+    """Dead-letter replay/discard and one-shot manual run for a :class:`OneStepApp`.
+
+    The component receives the owning app so it can read the task registry and
+    the events logger without exposing the underlying lists. It does not need
+    access to the runner registry or asyncio state — that stays on
+    :class:`LifecycleController`.
+    """
+
+    def __init__(self, app: Any) -> None:
+        self._app = app
+
+    @property
+    def events_logger(self) -> Any:
+        return self._app.events_logger
+
+    # ----- capability probes (control-plane reads) -------------------------
+
+    def supports_dead_letter_replay_commands(self) -> bool:
+        return any(self._task_supports_dead_letter_replay(task) for task in self._app._tasks)
+
+    def supports_dead_letter_discard_commands(self) -> bool:
+        return any(self._task_supports_dead_letter_discard(task) for task in self._app._tasks)
+
+    def supports_manual_run_commands(self) -> bool:
+        return any(self._task_supports_manual_run(task) for task in self._app._tasks)
+
+    # ----- public operations ------------------------------------------------
+
+    async def replay_task_dead_letters(self, task_name: str, *, limit: int) -> dict[str, Any]:
+        if limit < 1:
+            raise ValueError("dead-letter replay limit must be >= 1")
+        task = self._require_dead_letter_replay_task(task_name)
+        assert task.source is not None
+        assert isinstance(task.source, Sink)
+        dead_letter_source = task.dead_letter_sinks[0]
+        assert isinstance(dead_letter_source, Source)
+
+        attempted_count = 0
+        replayed_count = 0
+        failed_count = 0
+
+        for delivery in await dead_letter_source.fetch(limit):
+            attempted_count += 1
+            try:
+                replay_envelope = self._build_dead_letter_replay_envelope(delivery.envelope)
+            except Exception:
+                failed_count += 1
+                self.events_logger.exception(
+                    "dead-letter replay payload was invalid",
+                    extra={"task_name": task_name},
+                )
+                try:
+                    await delivery.retry()
+                except Exception:
+                    pass
+                continue
+
+            try:
+                await task.source.send(replay_envelope)
+            except Exception:
+                failed_count += 1
+                self.events_logger.exception(
+                    "dead-letter replay publish failed",
+                    extra={"task_name": task_name},
+                )
+                try:
+                    await delivery.retry()
+                except Exception:
+                    pass
+                continue
+
+            try:
+                await delivery.ack()
+            except Exception:
+                failed_count += 1
+                self.events_logger.exception(
+                    "dead-letter replay ack failed after publish",
+                    extra={"task_name": task_name},
+                )
+                continue
+
+            replayed_count += 1
+
+        if attempted_count == 0:
+            completion = "complete"
+        elif failed_count == 0:
+            completion = "complete"
+        elif replayed_count > 0:
+            completion = "partial"
+        else:
+            completion = "failed"
+
+        return {
+            "operation": "replay_dead_letters",
+            "task_name": task_name,
+            "requested": True,
+            "completion": completion,
+            "requested_limit": limit,
+            "attempted_count": attempted_count,
+            "replayed_count": replayed_count,
+            "failed_count": failed_count,
+            "empty": attempted_count == 0,
+        }
+
+    async def discard_task_dead_letters(self, task_name: str, *, limit: int) -> dict[str, Any]:
+        if limit < 1:
+            raise ValueError("dead-letter discard limit must be >= 1")
+        task = self._require_dead_letter_discard_task(task_name)
+        dead_letter_source = task.dead_letter_sinks[0]
+        assert isinstance(dead_letter_source, Source)
+
+        attempted_count = 0
+        discarded_count = 0
+        failed_count = 0
+
+        for delivery in await dead_letter_source.fetch(limit):
+            attempted_count += 1
+            try:
+                await delivery.ack()
+            except Exception:
+                failed_count += 1
+                self.events_logger.exception(
+                    "dead-letter discard ack failed",
+                    extra={"task_name": task_name},
+                )
+                continue
+            discarded_count += 1
+
+        if attempted_count == 0:
+            completion = "complete"
+        elif failed_count == 0:
+            completion = "complete"
+        elif discarded_count > 0:
+            completion = "partial"
+        else:
+            completion = "failed"
+
+        return {
+            "operation": "discard_dead_letters",
+            "task_name": task_name,
+            "requested": True,
+            "completion": completion,
+            "requested_limit": limit,
+            "attempted_count": attempted_count,
+            "discarded_count": discarded_count,
+            "failed_count": failed_count,
+            "empty": attempted_count == 0,
+        }
+
+    async def run_task_once(
+        self,
+        task_name: str,
+        *,
+        payload: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        task = self._require_manual_run_task(task_name)
+        delivery = _SyntheticManualRunDelivery(
+            Envelope(
+                body=copy.deepcopy(dict(payload)),
+                meta={
+                    "manual_run": True,
+                    "task_name": task_name,
+                },
+                attempts=0,
+            )
+        )
+        runner = TaskRunner(self._app, task)
+
+        attempted_count = 0
+        completed = False
+        last_failure: Exception | None = None
+
+        while True:
+            attempted_count += 1
+            await runner._handle_delivery(delivery)
+            if delivery.acked:
+                completed = True
+                break
+            if not delivery.retry_requested:
+                break
+            delivery.retry_requested = False
+            last_failure = RuntimeError("manual run exhausted retries")
+
+        if completed:
+            return {
+                "operation": "run_task_once",
+                "task_name": task_name,
+                "requested": True,
+                "completion": "complete",
+                "attempted_count": attempted_count,
+                "manual_run": True,
+            }
+
+        if delivery.failed:
+            raise RuntimeError(
+                f"manual run failed for task {task_name} after {attempted_count} attempt(s)"
+            ) from last_failure
+
+        raise RuntimeError(
+            f"manual run did not reach a terminal successful state for task {task_name}"
+        )
+
+    # ----- internals --------------------------------------------------------
+
+    def _require_dead_letter_replay_task(self, task_name: str) -> TaskSpec:
+        task = self._require_controllable_task(task_name)
+        if not self._task_supports_dead_letter_replay(task):
+            raise ValueError(
+                f"task {task_name} does not support dead-letter replay with the configured source and dead-letter connectors"
+            )
+        return task
+
+    def _require_dead_letter_discard_task(self, task_name: str) -> TaskSpec:
+        task = self._require_controllable_task(task_name)
+        if not self._task_supports_dead_letter_discard(task):
+            raise ValueError(
+                f"task {task_name} does not support dead-letter discard with the configured dead-letter connectors"
+            )
+        return task
+
+    def _require_manual_run_task(self, task_name: str) -> TaskSpec:
+        task = self._require_controllable_task(task_name)
+        if not self._task_supports_manual_run(task):
+            raise ValueError(
+                f"task {task_name} does not support manual run with the configured source"
+            )
+        return task
+
+    def _require_controllable_task(self, task_name: str) -> TaskSpec:
+        task = next((task for task in self._app._tasks if task.name == task_name), None)
+        if task is None:
+            raise ValueError(f"task {task_name} was not found")
+        if task.source is None:
+            raise ValueError(f"task {task_name} does not have a controllable source runner")
+        return task
+
+    def _task_supports_dead_letter_discard(self, task: TaskSpec) -> bool:
+        return len(task.dead_letter_sinks) == 1 and isinstance(task.dead_letter_sinks[0], Source)
+
+    def _task_supports_dead_letter_replay(self, task: TaskSpec) -> bool:
+        return (
+            task.source is not None
+            and isinstance(task.source, Sink)
+            and self._task_supports_dead_letter_discard(task)
+        )
+
+    def _task_supports_manual_run(self, task: TaskSpec) -> bool:
+        return task.source is not None and bool(getattr(task.source, "supports_manual_run", False))
+
+    def _build_dead_letter_replay_envelope(self, dead_letter_envelope: Envelope) -> Envelope:
+        if not isinstance(dead_letter_envelope.body, Mapping):
+            raise ValueError("dead-letter envelope body must be a mapping")
+        if "payload" not in dead_letter_envelope.body:
+            raise ValueError("dead-letter envelope body is missing payload")
+
+        original_payload = copy.deepcopy(dead_letter_envelope.body["payload"])
+        original_meta = dead_letter_envelope.meta.get("original_meta")
+        if not isinstance(original_meta, Mapping):
+            replay_meta: dict[str, Any] = {}
+        else:
+            replay_meta = copy.deepcopy(dict(original_meta))
+
+        original_attempts = dead_letter_envelope.meta.get("original_attempts")
+        replay_attempts = original_attempts if isinstance(original_attempts, int) and original_attempts >= 0 else 0
+        return Envelope(
+            body=original_payload,
+            meta=replay_meta,
+            attempts=replay_attempts,
+        )


### PR DESCRIPTION
## Summary
Split \`src/onestep/app.py\` (1136 → 389 lines) into a thin facade delegating to three stdlib-only runtime controllers (zero new deps):
- \`runtime/event_hub.py\` EventHub (108): startup/shutdown hooks, event handlers, emit_event
- \`runtime/task_ops.py\` TaskOperations (324): dead-letter replay/discard, one-shot run, capability probes
- \`runtime/lifecycle.py\` LifecycleController (649): asyncio state, runner registry, startup/shutdown/serve, drain/pause snapshots, signal handlers, \`_open_resource\`/\`_close_resource\` helpers

## Compatibility (verified)
- \`from onestep import OneStepApp\` works; \`describe()\` structure byte-for-byte unchanged
- contract privates \`_runners\`/\`_runner_tasks\`/\`_resources\`/\`_install_signal_handlers\` kept as facade passthroughs
- \`connector_conformance.py\` serve/request_drain/request_task_pause/request_shutdown unchanged

## Test plan
- \`uv run pytest -m "not integration"\` → 606 passed

Closes #146