### PR TITLE
ci(release): auto-flag prerelease GitHub releases for a/b/rc/dev tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
       publish_worker_image: ${{ steps.resolve.outputs.publish_worker_image }}
       publish_pypi: ${{ steps.resolve.outputs.publish_pypi }}
       publish_github_release: ${{ steps.resolve.outputs.publish_github_release }}
+      prerelease: ${{ steps.resolve.outputs.prerelease }}
 
     steps:
       - name: Resolve checkout ref and publish targets
@@ -185,6 +186,15 @@ jobs:
             fi
           fi
 
+          PRERELEASE=false
+          if [ -n "$VERSION" ]; then
+            case "$VERSION" in
+              *[aA][0-9]*|*[bB][0-9]*|*[rR][cC][0-9]*|*.[dD][eE][vV][0-9]*|*-*)
+                PRERELEASE=true
+                ;;
+            esac
+          fi
+
           if [ "$PUBLISH_WORKER_IMAGE" = "true" ]; then
             if [ -n "$INPUT_WORKER_IMAGE_VERSION" ]; then
               if ! assign_version_fields "$INPUT_WORKER_IMAGE_VERSION" WORKER_IMAGE_VERSION WORKER_IMAGE_MAJOR_MINOR; then
@@ -212,6 +222,7 @@ jobs:
             echo "publish_worker_image=$PUBLISH_WORKER_IMAGE"
             echo "publish_pypi=$PUBLISH_PYPI"
             echo "publish_github_release=$PUBLISH_GITHUB_RELEASE"
+            echo "prerelease=$PRERELEASE"
           } >> "$GITHUB_OUTPUT"
 
   build:
@@ -306,6 +317,7 @@ jobs:
           tag_name: ${{ needs.prepare.outputs.checkout_ref }}
           files: dist/*
           generate_release_notes: true
+          prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
 
   worker-image:
     name: Publish worker image


### PR DESCRIPTION
## What
Make the Release workflow mark GitHub releases as **pre-release** automatically when the resolved version is a PEP 440 pre-release (`a`/`b`/`rc`/`.dev`, plus local/hyphen forms).

## Why
`v1.12.0a1` was published with `prerelease: false` because `action-gh-release` defaulted it to a full release. Alpha/beta/rc tags should not be presented as stable.

## How
- `prepare` job computes `PRERELEASE` from the resolved `VERSION` via a shell `case` and exposes it as `prepare.outputs.prerelease`.
- `github-release` job passes `prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}` to `softprops/action-gh-release@v2`.

## Verified
- Detection unit-checked: `1.11.0`/`2.0.0`/`1.2.62` → `false`; `1.12.0a1`/`1.12.0b2`/`1.12.0rc1`/`1.12.0.dev3`/`1.0.0-alpha`/`0.2.3a1` → `true`.
- YAML parses cleanly.
- Existing `v1.12.0a1` release already retro-fixed to `prerelease: true` via `gh release edit`; this PR prevents recurrence.