### PR TITLE
feat(observability): Prometheus /metrics + /healthz endpoints (onestep[metrics])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- Adds built-in Prometheus observability (`onestep[metrics]`, issue #153): a
+  dependency-free `PrometheusExporter` (`src/onestep/observability.py`)
+  consumes the `TaskEvent` stream and exposes `onestep_deliveries_fetched_total`,
+  `onestep_tasks_processed_total{status}`, `onestep_task_duration_seconds`
+  (histogram), `onestep_inflight_tasks`, `onestep_tasks_retried_total`,
+  `onestep_tasks_dead_lettered_total`, `onestep_tasks_cancelled_total`,
+  `onestep_task_failures_total{failure_kind}`, `onestep_build_info`, plus
+  every custom task metric from `CustomMetricsRegistry` — read through a new
+  non-destructive `snapshot()` so counters stay monotonic across the
+  control-plane reporter's `rotate_task()` window resets. The new
+  `onestep run --metrics-addr host:port` flag (or `install_metrics(app)`)
+  serves `/metrics` and a `/healthz` probe (runtime + per-source liveness,
+  usable as a K8s liveness/readiness endpoint) from a tiny asyncio HTTP
+  server coexisting with webhook sources. A ready-made monitoring stack
+  lives in `examples/prometheus/` (onestep + Prometheus + Grafana with a
+  provisioned dashboard).
+
 - Adds the `onestep-cf-queues` plugin: a Cloudflare Queues connector that
   wraps the official `cloudflare` Python SDK to consume and publish over the
   HTTP pull-consumer REST API (works outside Cloudflare Workers). Registers

--- a/examples/prometheus/docker-compose.yml
+++ b/examples/prometheus/docker-compose.yml
@@ -1,0 +1,61 @@
+# onestep + Prometheus + Grafana monitoring stack (issue #153 MVP)
+#
+# Usage:
+#   cd examples/prometheus
+#   docker compose up -d
+#   # Grafana:    http://localhost:3300  (anonymous admin, dashboard preloaded)
+#   # Prometheus: http://localhost:9090
+#   # onestep:    http://localhost:9100/metrics and /healthz
+#
+# The onestep service runs your worker image with --metrics-addr enabled.
+# Build one first, see docs/guide/worker-runtime-image.md, then point
+# ONESTEP_WORKER_IMAGE at it (or use the published ghcr image).
+
+services:
+  onestep:
+    image: ${ONESTEP_WORKER_IMAGE:-ghcr.io/mic1on/onestep-worker:1.11.0}
+    command:
+      [
+        "run",
+        "/app/onestep.yaml",
+        "--metrics-addr",
+        "0.0.0.0:9100",
+      ]
+    volumes:
+      - ./onestep.yaml:/app/onestep.yaml:ro
+      - ./handlers.py:/app/handlers.py:ro
+    ports:
+      - "9100:9100"
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:v2.53.0
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=15d
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.1.0
+    environment:
+      # Demo stack: anonymous admin access, no login wall.
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_BASIC_ENABLED=false
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/onestep.json
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "3300:3000"
+    restart: unless-stopped
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/examples/prometheus/grafana/dashboards/onestep.json
+++ b/examples/prometheus/grafana/dashboards/onestep.json
@@ -1,0 +1,160 @@
+{
+  "title": "onestep overview",
+  "uid": "onestep-overview",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "10s",
+  "time": { "from": "now-1h", "to": "now" },
+  "tags": ["onestep"],
+  "templating": {
+    "list": [
+      {
+        "name": "app",
+        "label": "App",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": "label_values(onestep_tasks_processed_total, app)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Task throughput by status",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum by (task, status) (rate(onestep_tasks_processed_total{app=~\"$app\"}[5m]))",
+          "legendFormat": "{{task}} / {{status}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ops", "custom": { "fillOpacity": 15 } },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": ".* / failed" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "title": "In-flight tasks",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum by (task) (onestep_inflight_tasks{app=~\"$app\"})",
+          "legendFormat": "{{task}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short", "custom": { "fillOpacity": 25 } },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "title": "Task duration p50 / p90 / p99",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (task, le) (rate(onestep_task_duration_seconds_bucket{app=~\"$app\"}[5m])))",
+          "legendFormat": "p50 {{task}}"
+        },
+        {
+          "expr": "histogram_quantile(0.9, sum by (task, le) (rate(onestep_task_duration_seconds_bucket{app=~\"$app\"}[5m])))",
+          "legendFormat": "p90 {{task}}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (task, le) (rate(onestep_task_duration_seconds_bucket{app=~\"$app\"}[5m])))",
+          "legendFormat": "p99 {{task}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "fillOpacity": 8 } },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "title": "Retries & dead letters",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum by (task) (rate(onestep_tasks_retried_total{app=~\"$app\"}[5m]))",
+          "legendFormat": "retried {{task}}"
+        },
+        {
+          "expr": "sum by (task) (rate(onestep_tasks_dead_lettered_total{app=~\"$app\"}[5m]))",
+          "legendFormat": "dead-lettered {{task}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ops", "custom": { "fillOpacity": 15 } },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "title": "Failures by kind",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum by (task, failure_kind) (rate(onestep_task_failures_total{app=~\"$app\"}[5m]))",
+          "legendFormat": "{{task}} / {{failure_kind}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ops", "custom": { "fillOpacity": 15 } },
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "title": "Source fetch throughput",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum by (task) (rate(onestep_deliveries_fetched_total{app=~\"$app\"}[5m]))",
+          "legendFormat": "{{task}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ops", "custom": { "fillOpacity": 15 } },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "title": "Runtime build info",
+      "type": "table",
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "onestep_build_info",
+          "format": "table",
+          "instant": true
+        }
+      ]
+    }
+  ]
+}

--- a/examples/prometheus/grafana/provisioning/dashboards/provider.yml
+++ b/examples/prometheus/grafana/provisioning/dashboards/provider.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: onestep
+    orgId: 1
+    folder: onestep
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/examples/prometheus/grafana/provisioning/datasources/prometheus.yml
+++ b/examples/prometheus/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/examples/prometheus/handlers.py
+++ b/examples/prometheus/handlers.py
@@ -1,0 +1,13 @@
+"""Demo handler for the Prometheus monitoring example.
+
+Mounted next to onestep.yaml (see docker-compose.yml) so
+``ref: handlers:heartbeat`` resolves when the worker starts.
+"""
+
+
+async def heartbeat(ctx, payload):
+    """A trivial task body: pretend to do work for ~50 ms."""
+    import asyncio
+
+    await asyncio.sleep(0.05)
+    return {"beat": True}

--- a/examples/prometheus/onestep.yaml
+++ b/examples/prometheus/onestep.yaml
@@ -1,0 +1,19 @@
+# Minimal worker config for the monitoring stack example: one interval task
+# writing to a memory sink, so Grafana has throughput/duration data to show.
+app:
+  name: metrics-demo
+
+resources:
+  tick:
+    type: interval
+    seconds: 5
+    immediate: true
+  seen:
+    type: memory
+
+tasks:
+  - name: heartbeat
+    source: tick
+    handler:
+      ref: handlers:heartbeat
+    emit: [seen]

--- a/examples/prometheus/prometheus.yml
+++ b/examples/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: onestep
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["onestep:9100"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ sqs = [
 cloudflare = [
     "onestep-cf-queues>=0.1.0",
 ]
+# Metrics/healthz exposure is dependency-free (built-in asyncio HTTP server);
+# the extra exists so `pip install 'onestep[metrics]'` is a stable opt-in path
+# for orchestrators and docs.
+metrics = []
 kafka = [
     "onestep-kafka>=0.1.3; python_version >= '3.10'",
 ]

--- a/src/onestep/app.py
+++ b/src/onestep/app.py
@@ -1100,18 +1100,31 @@ async def _open_resource(resource: Any) -> None:
     opener = getattr(resource, "open", None)
     if not callable(opener):
         return
-    result = opener()
-    if inspect.isawaitable(result):
-        await result
+    try:
+        result = opener()
+        if inspect.isawaitable(result):
+            await result
+    except BaseException:
+        if isinstance(resource, Source):
+            resource._set_open_state(False)
+        raise
+    if isinstance(resource, Source):
+        resource._set_open_state(True)
 
 
 async def _close_resource(resource: Any) -> None:
     closer = getattr(resource, "close", None)
     if not callable(closer):
+        if isinstance(resource, Source):
+            resource._set_open_state(False)
         return
-    result = closer()
-    if inspect.isawaitable(result):
-        await result
+    try:
+        result = closer()
+        if inspect.isawaitable(result):
+            await result
+    finally:
+        if isinstance(resource, Source):
+            resource._set_open_state(False)
 
 
 def _invoke_app_factory(target: str, factory: Callable[..., Any]) -> Any:

--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -58,6 +58,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Set the onestep logger level (default: target configuration or INFO)",
     )
     run_parser.add_argument(
+        "--metrics-addr",
+        dest="metrics_addr",
+        type=str,
+        default=None,
+        metavar="HOST:PORT",
+        help=(
+            "Expose Prometheus /metrics and /healthz on HOST:PORT "
+            "(use :PORT to bind all interfaces; e.g. :9100)"
+        ),
+    )
+    run_parser.add_argument(
         "--task-events",
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -319,6 +330,11 @@ def main(argv: list[str] | None = None) -> int:
         cli_logging_state = _configure_run_logging(explicit_level=args.log_level)
         if args.task_events:
             app.enable_structured_event_logging()
+        if args.metrics_addr:
+            host, port = _parse_metrics_addr(args.metrics_addr)
+            from .observability import install_metrics
+
+            install_metrics(app, host=host, port=port)
         app.run()
     except Exception as exc:
         print(f"onestep: {args.target} failed while running: {exc}", file=sys.stderr)
@@ -331,6 +347,27 @@ def main(argv: list[str] | None = None) -> int:
             root_logger.setLevel(previous_root_level)
             cli_handler.close()
     return 0
+
+
+def _parse_metrics_addr(value: str) -> tuple[str, int]:
+    """Parse ``HOST:PORT`` / ``:PORT`` / ``PORT`` for ``--metrics-addr``."""
+    text = value.strip()
+    if not text:
+        raise ValueError("--metrics-addr must not be empty")
+    if text.startswith(":"):
+        host_part, _, port_part = "", text[1:], ""
+    else:
+        host_part, sep, port_part = text.rpartition(":")
+        if not sep:
+            host_part, port_part = "", text
+    try:
+        port = int(port_part)
+    except ValueError as exc:
+        raise ValueError(f"invalid --metrics-addr port in {value!r}") from exc
+    if not 0 < port < 65536:
+        raise ValueError(f"invalid --metrics-addr port in {value!r}")
+    host = host_part.strip("[]") or "127.0.0.1"
+    return host, port
 
 
 def _configure_run_logging(

--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -325,13 +325,21 @@ def main(argv: list[str] | None = None) -> int:
         print(render_mermaid(app), end="")
         return 0
 
+    metrics_addr: tuple[str, int] | None = None
+    if args.metrics_addr:
+        try:
+            metrics_addr = _parse_metrics_addr(args.metrics_addr)
+        except ValueError as exc:
+            print(f"onestep: {exc}", file=sys.stderr)
+            return 2
+
     cli_logging_state: tuple[logging.Handler, int] | None = None
     try:
         cli_logging_state = _configure_run_logging(explicit_level=args.log_level)
         if args.task_events:
             app.enable_structured_event_logging()
-        if args.metrics_addr:
-            host, port = _parse_metrics_addr(args.metrics_addr)
+        if metrics_addr is not None:
+            host, port = metrics_addr
             from .observability import install_metrics
 
             install_metrics(app, host=host, port=port)
@@ -355,7 +363,7 @@ def _parse_metrics_addr(value: str) -> tuple[str, int]:
     if not text:
         raise ValueError("--metrics-addr must not be empty")
     if text.startswith(":"):
-        host_part, _, port_part = "", text[1:], ""
+        host_part, port_part = "", text[1:]
     else:
         host_part, sep, port_part = text.rpartition(":")
         if not sep:

--- a/src/onestep/connectors/base.py
+++ b/src/onestep/connectors/base.py
@@ -42,6 +42,15 @@ class Source(abc.ABC):
 
     def __init__(self, name: str) -> None:
         self.name = name
+        self._is_open = False
+
+    @property
+    def is_open(self) -> bool:
+        """Whether the runtime has successfully opened this source."""
+        return self._is_open
+
+    def _set_open_state(self, value: bool) -> None:
+        self._is_open = value
 
     async def open(self) -> None:
         return None

--- a/src/onestep/events.py
+++ b/src/onestep/events.py
@@ -31,6 +31,10 @@ class TaskEvent:
     duration_s: float | None = None
     failure: FailureInfo | None = None
     meta: dict[str, Any] = field(default_factory=dict)
+    # Runtime-only correlation for observability. It is intentionally not
+    # serialized into diagnostic/control-plane payloads, whose schemas remain
+    # unchanged.
+    attempt_id: str | None = None
 
 
 class InMemoryMetrics:

--- a/src/onestep/metrics.py
+++ b/src/onestep/metrics.py
@@ -35,6 +35,10 @@ class CustomMetricsRegistry:
         self._lock = Lock()
         self._values: dict[tuple[str, str, MetricKind, tuple[tuple[str, str], ...]], float] = {}
         self._known_kinds: dict[tuple[str, str, tuple[tuple[str, str], ...]], MetricKind] = {}
+        # Cumulative counter totals that survive rotate_task(). The control
+        # plane reads per-window deltas from _values (rotated), while
+        # Prometheus-style scrapers read monotonic totals from here.
+        self._cumulative: dict[tuple[str, str, MetricKind, tuple[tuple[str, str], ...]], float] = {}
 
     def for_task(self, task_name: str) -> "TaskMetrics":
         return TaskMetrics(self, task_name)
@@ -62,6 +66,7 @@ class CustomMetricsRegistry:
         )
         with self._lock:
             self._values[key] = self._values.get(key, 0.0) + normalized_amount
+            self._cumulative[key] = self._cumulative.get(key, 0.0) + normalized_amount
 
     def set_gauge(
         self,
@@ -103,6 +108,55 @@ class CustomMetricsRegistry:
                 )
         samples.sort(key=lambda sample: (sample.name, sample.kind, sorted(sample.labels.items())))
         return [sample.as_dict() for sample in samples]
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        """Non-destructive scrape snapshot with cumulative counter totals.
+
+        Unlike :meth:`rotate_task`, reading the snapshot never resets state:
+        counter values are cumulative across rotations, so Prometheus-style
+        scrapers observe monotonic counters while the control-plane reporter
+        keeps consuming per-window deltas from ``rotate_task``. Gauges report
+        their current value.
+        """
+        entries: list[dict[str, Any]] = []
+        with self._lock:
+            for key, value in self._cumulative.items():
+                series_task_name, name, kind, labels_tuple = key
+                if kind != "counter":
+                    continue
+                if value == 0:
+                    continue
+                entries.append(
+                    {
+                        "task": series_task_name,
+                        "name": name,
+                        "kind": kind,
+                        "value": _json_number(value),
+                        "labels": dict(labels_tuple),
+                    }
+                )
+            for key, value in self._values.items():
+                series_task_name, name, kind, labels_tuple = key
+                if kind != "gauge":
+                    continue
+                entries.append(
+                    {
+                        "task": series_task_name,
+                        "name": name,
+                        "kind": kind,
+                        "value": _json_number(value),
+                        "labels": dict(labels_tuple),
+                    }
+                )
+        entries.sort(
+            key=lambda entry: (
+                entry["name"],
+                entry["kind"],
+                sorted(entry["labels"].items()),
+                entry["task"],
+            )
+        )
+        return entries
 
     def _series_key(
         self,

--- a/src/onestep/observability.py
+++ b/src/onestep/observability.py
@@ -296,7 +296,13 @@ class PrometheusExporter:
             self._finish_attempt(event)
         elif kind is TaskEventKind.RETRIED:
             self._bump(self._counters, (*series, "retried"))
-            self._observe_duration(series, event.duration_s)
+            # A fresh RETRIED finds its attempt still open. The trailing
+            # RETRIED of the CANCELLED + RETRIED pair (same attempt, same
+            # duration_s; see DeliveryExecutor._handle_cancel) must not
+            # observe the duration a second time.
+            attempt_id = self._attempt_id(event)
+            if attempt_id is None or (*series, attempt_id) in self._open_attempts:
+                self._observe_duration(series, event.duration_s)
             self._finish_attempt(event)
         elif kind is TaskEventKind.FAILED:
             self._bump(self._processed, (*series, "failed"))
@@ -312,14 +318,7 @@ class PrometheusExporter:
         elif kind is TaskEventKind.CANCELLED:
             self._bump(self._counters, (*series, "cancelled"))
             self._observe_duration(series, event.duration_s)
-            attempt_id = self._attempt_id(event)
-            if attempt_id is None:
-                self._close_attempt(series)
-            else:
-                attempt_key = (*series, attempt_id)
-                if attempt_key in self._open_attempts:
-                    self._open_attempts.remove(attempt_key)
-                    self._close_attempt(series)
+            self._finish_attempt(event)
         # Unknown kinds are ignored, keeping the exporter forward-compatible
         # with new event kinds.
 

--- a/src/onestep/observability.py
+++ b/src/onestep/observability.py
@@ -170,9 +170,11 @@ class PrometheusExporter:
         self._failures: dict[tuple[str, str, str], float] = {}
         # (app, task) -> duration histogram accumulator
         self._histograms: dict[tuple[str, str], _Histogram] = {}
-        # (app, task) -> last attempt-scoped event kind; guards the
-        # CANCELLED -> RETRIED pair against double-close.
-        self._last_attempt_event: dict[tuple[str, str], TaskEventKind] = {}
+        # Attempt identity is carried in events. This avoids using a task-wide
+        # "last event" guard when attempts run concurrently. The set contains
+        # attempts which emitted STARTED and remain open.
+        self._open_attempts: set[tuple[str, str, str]] = set()
+
 
     def __call__(self, event: TaskEvent) -> None:
         with self._lock:
@@ -203,6 +205,7 @@ class PrometheusExporter:
                 "Deliveries fetched from sources",
                 counters,
                 _series_order(counters),
+                fixed_suffix="fetched",
             )
         )
         lines.extend(
@@ -284,23 +287,23 @@ class PrometheusExporter:
             self._bump(self._counters, (*series, "fetched"))
         elif kind is TaskEventKind.STARTED:
             self._inflight[series] = self._inflight.get(series, 0.0) + 1.0
+            attempt_id = self._attempt_id(event)
+            if attempt_id is not None:
+                self._open_attempts.add((*series, attempt_id))
         elif kind is TaskEventKind.SUCCEEDED:
             self._bump(self._processed, (*series, "succeeded"))
             self._observe_duration(series, event.duration_s)
-            self._close_attempt(series)
+            self._finish_attempt(event)
         elif kind is TaskEventKind.RETRIED:
             self._bump(self._counters, (*series, "retried"))
-            # RETRIED closes the attempt unless it trails CANCELLED, which
-            # already closed it (cancel-with-retry emits both events).
-            if self._last_attempt_event.get(series) is not TaskEventKind.CANCELLED:
-                self._observe_duration(series, event.duration_s)
-                self._close_attempt(series)
+            self._observe_duration(series, event.duration_s)
+            self._finish_attempt(event)
         elif kind is TaskEventKind.FAILED:
             self._bump(self._processed, (*series, "failed"))
             if event.failure is not None:
                 self._bump(self._failures, (*series, event.failure.kind.value))
             self._observe_duration(series, event.duration_s)
-            self._close_attempt(series)
+            self._finish_attempt(event)
         elif kind is TaskEventKind.DEAD_LETTERED:
             # DEAD_LETTERED is followed by FAILED on the terminal path; the
             # terminal outcome must count once, so only the dedicated counter
@@ -309,12 +312,16 @@ class PrometheusExporter:
         elif kind is TaskEventKind.CANCELLED:
             self._bump(self._counters, (*series, "cancelled"))
             self._observe_duration(series, event.duration_s)
-            self._close_attempt(series)
-        # Unknown kinds are recorded as the latest attempt event and otherwise
-        # ignored, keeping the exporter forward-compatible with new kinds.
-
-        if kind is not TaskEventKind.FETCHED:
-            self._last_attempt_event[series] = kind
+            attempt_id = self._attempt_id(event)
+            if attempt_id is None:
+                self._close_attempt(series)
+            else:
+                attempt_key = (*series, attempt_id)
+                if attempt_key in self._open_attempts:
+                    self._open_attempts.remove(attempt_key)
+                    self._close_attempt(series)
+        # Unknown kinds are ignored, keeping the exporter forward-compatible
+        # with new event kinds.
 
     def _bump(
         self,
@@ -334,6 +341,31 @@ class PrometheusExporter:
 
     def _close_attempt(self, series: tuple[str, str]) -> None:
         self._inflight[series] = max(0.0, self._inflight.get(series, 0.0) - 1.0)
+
+    def _finish_attempt(self, event: TaskEvent) -> None:
+        series = (event.app, event.task)
+        attempt_id = self._attempt_id(event)
+        if attempt_id is None:
+            self._close_attempt(series)
+            return
+        attempt_key = (*series, attempt_id)
+        if attempt_key in self._open_attempts:
+            self._open_attempts.remove(attempt_key)
+            self._close_attempt(series)
+
+    @staticmethod
+    def _attempt_id(event: TaskEvent) -> str | None:
+        if isinstance(event.attempt_id, str) and event.attempt_id:
+            return event.attempt_id
+        value = event.meta.get("onestep.attempt_id")
+        if isinstance(value, str) and value:
+            return value
+        execution = event.meta.get("onestep.execution")
+        if isinstance(execution, dict):
+            value = execution.get("attempt_id")
+            if isinstance(value, str) and value:
+                return value
+        return None
 
 
 # ----------------------------------------------------------------------
@@ -596,14 +628,17 @@ def _build_health_snapshot(
 ) -> dict[str, Any]:
     """Runtime + per-source liveness payload for ``/healthz``."""
     tasks: list[dict[str, Any]] = []
+    all_sources_alive = True
     for task in app.tasks:
         source = task.source
         source_info: dict[str, Any] | None = None
         if source is not None:
+            alive = bool(getattr(source, "is_open", False))
+            all_sources_alive = all_sources_alive and alive
             source_info = {
                 "name": getattr(source, "name", type(source).__name__),
                 "kind": type(source).__name__,
-                "alive": bool(getattr(source, "is_open", True)),
+                "alive": alive,
             }
         tasks.append(
             {
@@ -618,7 +653,7 @@ def _build_health_snapshot(
         )
 
     return {
-        "status": "ok",
+        "status": "ok" if all_sources_alive and not app.is_stopping else "degraded",
         "app": app.name,
         "version": _resolve_version(),
         "uptime_s": round(max(0.0, time.monotonic() - started_at_monotonic), 3),
@@ -678,14 +713,23 @@ def install_metrics(
         host=host,
         port=port,
     )
-    started_at_monotonic = time.monotonic()
+    started_at_monotonic: float | None = None
 
     def _health() -> dict[str, Any]:
-        return _build_health_snapshot(app, started_at_monotonic=started_at_monotonic)
+        return _build_health_snapshot(
+            app,
+            started_at_monotonic=(
+                started_at_monotonic
+                if started_at_monotonic is not None
+                else time.monotonic()
+            ),
+        )
 
     server._health_provider = _health
 
     async def _startup() -> None:
+        nonlocal started_at_monotonic
+        started_at_monotonic = time.monotonic()
         await server.start()
         logging.getLogger("onestep.observability").info(
             "metrics server listening on %s:%d", host, server.bound_port

--- a/src/onestep/observability.py
+++ b/src/onestep/observability.py
@@ -1,0 +1,700 @@
+"""Prometheus exposition for onestep runtime metrics.
+
+The exporter consumes the runtime :class:`TaskEvent` stream plus a
+non-destructive snapshot of :class:`CustomMetricsRegistry` and formats the
+Prometheus text exposition protocol directly — no third-party dependency is
+required.
+
+Design notes:
+
+- Prometheus counters must be monotonic. The control-plane reporter relies on
+  ``CustomMetricsRegistry.rotate_task()`` which resets per-task counters to
+  report per-window deltas, so the exporter never reads the live per-window
+  buffers; it reads :meth:`CustomMetricsRegistry.snapshot` which keeps
+  cumulative totals across rotations.
+- Inflight accounting follows the executor's attempt model: exactly one
+  ``STARTED`` per attempt, closed by exactly one of ``SUCCEEDED``, ``FAILED``,
+  ``CANCELLED`` or ``RETRIED``. The ``CANCELLED -> RETRIED`` pair (cancel with
+  retry re-queue) closes the attempt once: the guard on the previous event for
+  the series keeps the gauge from double-decrementing, and every decrement is
+  clamped at zero.
+- ``DEAD_LETTERED`` is always followed by ``FAILED`` in the failure path, so it
+  gets its own counter but does not touch ``processed_total`` or inflight —
+  that terminal outcome is counted exactly once, by ``FAILED``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import threading
+import time
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _distribution_version
+from typing import Any, Callable, Sequence
+
+from .app import OneStepApp
+from .events import TaskEvent, TaskEventKind
+from .metrics import CustomMetricsRegistry
+
+__all__ = ["MetricsHandle", "MetricsServer", "PrometheusExporter", "install_metrics"]
+
+_BUCKETS: tuple[float, ...] = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.075,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+)
+
+# Metric family names owned by the runtime exporter. Custom task metrics whose
+# normalized name collides with one of these are skipped during render so the
+# exposition never declares the same family twice.
+_RESERVED_FAMILIES = frozenset(
+    {
+        "onestep_tasks_processed_total",
+        "onestep_task_duration_seconds",
+        "onestep_task_duration_seconds_bucket",
+        "onestep_task_duration_seconds_count",
+        "onestep_task_duration_seconds_sum",
+        "onestep_inflight_tasks",
+        "onestep_tasks_retried_total",
+        "onestep_tasks_dead_lettered_total",
+        "onestep_tasks_cancelled_total",
+        "onestep_deliveries_fetched_total",
+        "onestep_task_failures_total",
+        "onestep_build_info",
+    }
+)
+
+
+def _escape_label_value(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _format_value(value: float) -> str:
+    if float(value).is_integer():
+        return str(int(value))
+    return repr(float(value))
+
+
+def _format_bucket(bound: float) -> str:
+    return "+Inf" if bound == float("inf") else f"{bound:g}"
+
+
+def _label_block(pairs: Sequence[tuple[str, str]]) -> str:
+    inner = ",".join(f'{key}="{_escape_label_value(value)}"' for key, value in pairs)
+    return "{" + inner + "}"
+
+
+def _resolve_version() -> str:
+    try:
+        return _distribution_version("onestep")
+    except PackageNotFoundError:  # pragma: no cover - source checkout fallback
+        return "dev"
+
+
+class _Histogram:
+    """Per-series histogram accumulator with cumulative-bucket rendering."""
+
+    __slots__ = ("count", "sum", "bucket_counts")
+
+    def __init__(self) -> None:
+        self.count = 0.0
+        self.sum = 0.0
+        self.bucket_counts = [0.0] * len(_BUCKETS)
+
+    def observe(self, value: float) -> None:
+        self.count += 1.0
+        self.sum += value
+        for index, bound in enumerate(_BUCKETS):
+            if value <= bound:
+                self.bucket_counts[index] += 1.0
+
+    def freeze(self) -> tuple[float, float, list[float]]:
+        return (self.count, self.sum, list(self.bucket_counts))
+
+    @staticmethod
+    def render(
+        name: str,
+        label_pairs: Sequence[tuple[str, str]],
+        data: tuple[float, float, list[float]],
+    ) -> list[str]:
+        count, total, bucket_counts = data
+        lines: list[str] = []
+        cumulative = 0.0
+        for bound, bucket_count in zip(_BUCKETS, bucket_counts):
+            cumulative += bucket_count
+            bucket_labels = (*label_pairs, ("le", _format_bucket(bound)))
+            lines.append(f"{name}_bucket{_label_block(bucket_labels)} {_format_value(cumulative)}")
+        inf_labels = (*label_pairs, ("le", "+Inf"))
+        lines.append(f"{name}_bucket{_label_block(inf_labels)} {_format_value(count)}")
+        lines.append(f"{name}_count{_label_block(label_pairs)} {_format_value(count)}")
+        lines.append(f"{name}_sum{_label_block(label_pairs)} {_format_value(total)}")
+        return lines
+
+
+class PrometheusExporter:
+    """TaskEvent consumer that renders a Prometheus exposition payload.
+
+    The instance is callable so it can be registered on the app's event
+    handlers (``app.event``) alongside the other event consumers.
+    """
+
+    def __init__(
+        self,
+        *,
+        app_name: str,
+        custom_metrics: CustomMetricsRegistry | None = None,
+    ) -> None:
+        self._app_name = app_name
+        self._custom_metrics = custom_metrics
+        self._lock = threading.Lock()
+        # (app, task) -> inflight gauge value (clamped >= 0)
+        self._inflight: dict[tuple[str, str], float] = {}
+        # (app, task, suffix) -> counter,
+        # suffix in {fetched, retried, dead_lettered, cancelled}
+        self._counters: dict[tuple[str, str, str], float] = {}
+        # (app, task, status) -> processed_total counter
+        self._processed: dict[tuple[str, str, str], float] = {}
+        # (app, task, failure_kind) -> counter
+        self._failures: dict[tuple[str, str, str], float] = {}
+        # (app, task) -> duration histogram accumulator
+        self._histograms: dict[tuple[str, str], _Histogram] = {}
+        # (app, task) -> last attempt-scoped event kind; guards the
+        # CANCELLED -> RETRIED pair against double-close.
+        self._last_attempt_event: dict[tuple[str, str], TaskEventKind] = {}
+
+    def __call__(self, event: TaskEvent) -> None:
+        with self._lock:
+            self._record(event)
+
+    def render(self) -> str:
+        # Read a consistent copy of the mutable state under the lock, then
+        # render outside it.
+        with self._lock:
+            inflight = dict(self._inflight)
+            counters = dict(self._counters)
+            processed = dict(self._processed)
+            failures = dict(self._failures)
+            histograms = {
+                series: histogram.freeze()
+                for series, histogram in self._histograms.items()
+            }
+        custom_samples = (
+            list(self._custom_metrics.snapshot())
+            if self._custom_metrics is not None
+            else []
+        )
+
+        lines: list[str] = []
+        lines.extend(
+            _counter_family(
+                "onestep_deliveries_fetched_total",
+                "Deliveries fetched from sources",
+                counters,
+                _series_order(counters),
+            )
+        )
+        lines.extend(
+            _counter_family(
+                "onestep_tasks_processed_total",
+                "Terminal task outcomes",
+                processed,
+                _series_order(processed),
+                extra_label="status",
+            )
+        )
+        lines.extend(
+            _histogram_family(
+                "onestep_task_duration_seconds",
+                "Task attempt duration in seconds",
+                histograms,
+            )
+        )
+        lines.extend(
+            _gauge_family(
+                "onestep_inflight_tasks",
+                "Task attempts currently in flight",
+                inflight,
+            )
+        )
+        lines.extend(
+            _counter_family(
+                "onestep_tasks_retried_total",
+                "Task attempts scheduled for retry",
+                counters,
+                _series_order(counters),
+                fixed_suffix="retried",
+            )
+        )
+        lines.extend(
+            _counter_family(
+                "onestep_tasks_dead_lettered_total",
+                "Deliveries published to dead-letter sinks",
+                counters,
+                _series_order(counters),
+                fixed_suffix="dead_lettered",
+            )
+        )
+        lines.extend(
+            _counter_family(
+                "onestep_tasks_cancelled_total",
+                "Task attempts cancelled",
+                counters,
+                _series_order(counters),
+                fixed_suffix="cancelled",
+            )
+        )
+        lines.extend(
+            _counter_family(
+                "onestep_task_failures_total",
+                "Task failures by failure kind",
+                failures,
+                _series_order(failures),
+                extra_label="failure_kind",
+            )
+        )
+        lines.append("# HELP onestep_build_info Build metadata")
+        lines.append("# TYPE onestep_build_info gauge")
+        lines.append(
+            f'onestep_build_info{{version="{_escape_label_value(_resolve_version())}"}} 1'
+        )
+        lines.extend(_render_custom_families(custom_samples))
+        return "\n".join(lines) + "\n"
+
+    # ------------------------------------------------------------------
+    # event accounting
+    # ------------------------------------------------------------------
+
+    def _record(self, event: TaskEvent) -> None:
+        series = (event.app, event.task)
+        kind = event.kind
+
+        if kind is TaskEventKind.FETCHED:
+            self._bump(self._counters, (*series, "fetched"))
+        elif kind is TaskEventKind.STARTED:
+            self._inflight[series] = self._inflight.get(series, 0.0) + 1.0
+        elif kind is TaskEventKind.SUCCEEDED:
+            self._bump(self._processed, (*series, "succeeded"))
+            self._observe_duration(series, event.duration_s)
+            self._close_attempt(series)
+        elif kind is TaskEventKind.RETRIED:
+            self._bump(self._counters, (*series, "retried"))
+            # RETRIED closes the attempt unless it trails CANCELLED, which
+            # already closed it (cancel-with-retry emits both events).
+            if self._last_attempt_event.get(series) is not TaskEventKind.CANCELLED:
+                self._observe_duration(series, event.duration_s)
+                self._close_attempt(series)
+        elif kind is TaskEventKind.FAILED:
+            self._bump(self._processed, (*series, "failed"))
+            if event.failure is not None:
+                self._bump(self._failures, (*series, event.failure.kind.value))
+            self._observe_duration(series, event.duration_s)
+            self._close_attempt(series)
+        elif kind is TaskEventKind.DEAD_LETTERED:
+            # DEAD_LETTERED is followed by FAILED on the terminal path; the
+            # terminal outcome must count once, so only the dedicated counter
+            # is bumped here.
+            self._bump(self._counters, (*series, "dead_lettered"))
+        elif kind is TaskEventKind.CANCELLED:
+            self._bump(self._counters, (*series, "cancelled"))
+            self._observe_duration(series, event.duration_s)
+            self._close_attempt(series)
+        # Unknown kinds are recorded as the latest attempt event and otherwise
+        # ignored, keeping the exporter forward-compatible with new kinds.
+
+        if kind is not TaskEventKind.FETCHED:
+            self._last_attempt_event[series] = kind
+
+    def _bump(
+        self,
+        target: dict[tuple[str, str, str], float],
+        key: tuple[str, str, str],
+    ) -> None:
+        target[key] = target.get(key, 0.0) + 1.0
+
+    def _observe_duration(self, series: tuple[str, str], duration_s: float | None) -> None:
+        if duration_s is None:
+            return
+        histogram = self._histograms.get(series)
+        if histogram is None:
+            histogram = _Histogram()
+            self._histograms[series] = histogram
+        histogram.observe(float(duration_s))
+
+    def _close_attempt(self, series: tuple[str, str]) -> None:
+        self._inflight[series] = max(0.0, self._inflight.get(series, 0.0) - 1.0)
+
+
+# ----------------------------------------------------------------------
+# family rendering helpers (pure functions over copied state)
+# ----------------------------------------------------------------------
+
+
+def _series_order(
+    target: dict[tuple[str, str, str], float],
+) -> list[tuple[str, str]]:
+    return sorted({(key[0], key[1]) for key in target})
+
+
+def _counter_family(
+    name: str,
+    help_text: str,
+    source: dict[tuple[str, str, str], float],
+    series: Sequence[tuple[str, ...]],
+    *,
+    extra_label: str | None = None,
+    fixed_suffix: str | None = None,
+) -> list[str]:
+    lines = [f"# HELP {name} {help_text}", f"# TYPE {name} counter"]
+    for series_key in series:
+        app, task = series_key[0], series_key[1]
+        if fixed_suffix is not None:
+            suffixes: list[tuple[str, ...]] = [(fixed_suffix,)]
+        else:
+            suffixes = sorted(
+                {key[2:] for key in source if key[0] == app and key[1] == task}
+            )
+        for suffix in suffixes:
+            value = source.get((app, task, suffix[0]))
+            if value is None:
+                # This family does not own a sample for this series (e.g. a
+                # task with only fetched events has no retried sample).
+                continue
+            labels: list[tuple[str, str]] = [("app", app), ("task", task)]
+            if extra_label is not None:
+                labels.append((extra_label, suffix[0]))
+            lines.append(f"{name}{_label_block(labels)} {_format_value(value)}")
+    return lines
+
+
+def _histogram_family(
+    name: str,
+    help_text: str,
+    histograms: dict[tuple[str, str], tuple[float, float, list[float]]],
+) -> list[str]:
+    lines = [f"# HELP {name} {help_text}", f"# TYPE {name} histogram"]
+    for (app, task) in sorted(histograms):
+        label_pairs = [("app", app), ("task", task)]
+        lines.extend(_Histogram.render(name, label_pairs, histograms[(app, task)]))
+    return lines
+
+
+def _gauge_family(
+    name: str,
+    help_text: str,
+    gauges: dict[tuple[str, str], float],
+) -> list[str]:
+    lines = [f"# HELP {name} {help_text}", f"# TYPE {name} gauge"]
+    for (app, task) in sorted(gauges):
+        labels = _label_block([("app", app), ("task", task)])
+        lines.append(f"{name}{labels} {_format_value(gauges[(app, task)])}")
+    return lines
+
+
+def _render_custom_families(samples: list[dict[str, Any]]) -> list[str]:
+    """Render custom metric families from ``CustomMetricsRegistry.snapshot()``.
+
+    Each snapshot entry is ``{"name", "kind", "value", "labels", "task"}``;
+    the task label is prepended, matching ``_RESERVED_LABEL_NAMES``'s rule
+    that user labels may never shadow it.
+    """
+    groups: dict[str, tuple[str, list[tuple[list[tuple[str, str]], float]]]] = {}
+    for sample in samples:
+        name = sample["name"]
+        if name in _RESERVED_FAMILIES:
+            continue
+        kind, entries = groups.get(name, (sample["kind"], []))
+        label_pairs = [("task", sample["task"])] + sorted(sample["labels"].items())
+        entries.append((label_pairs, float(sample["value"])))
+        groups[name] = (kind, entries)
+
+    lines: list[str] = []
+    for name in sorted(groups):
+        kind, entries = groups[name]
+        lines.append(f"# TYPE {name} {kind}")
+        for label_pairs, value in sorted(entries, key=lambda item: item[0]):
+            lines.append(f"{name}{_label_block(label_pairs)} {_format_value(value)}")
+    return lines
+
+
+# ----------------------------------------------------------------------
+# HTTP exposure: /metrics + /healthz
+# ----------------------------------------------------------------------
+
+
+class MetricsServer:
+    """Minimal asyncio HTTP server exposing the exporter and a health probe.
+
+    Shares the ``_WebhookSource`` server pattern (``asyncio.start_server`` with
+    hand-rolled request parsing) so the runtime gains one more tiny HTTP
+    listener without pulling in any web framework. ``port=0`` binds an
+    ephemeral port, which is what tests and embedded uses rely on.
+    """
+
+    def __init__(
+        self,
+        exporter: PrometheusExporter,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        health_provider: Callable[[], dict[str, Any]] | None = None,
+    ) -> None:
+        self._exporter = exporter
+        self.host = host
+        self.requested_port = port
+        self._health_provider = health_provider
+        self._server: asyncio.Server | None = None
+
+    @property
+    def bound_port(self) -> int:
+        if self._server is None or not self._server.sockets:
+            raise RuntimeError("metrics server is not started")
+        return int(self._server.sockets[0].getsockname()[1])
+
+    async def start(self) -> None:
+        if self._server is not None:
+            return
+        self._server = await asyncio.start_server(
+            self._handle_client, self.host, self.requested_port
+        )
+
+    async def stop(self) -> None:
+        if self._server is None:
+            return
+        server, self._server = self._server, None
+        server.close()
+        await server.wait_closed()
+
+    async def _handle_client(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            method, target, _headers = await self._read_request_line(reader)
+            if method not in {"GET", "HEAD"}:
+                await _write_http_response(
+                    writer,
+                    status=405,
+                    content_type="application/json",
+                    payload=b'{"error": "method_not_allowed"}',
+                    extra_headers={"Allow": "GET, HEAD"},
+                )
+                return
+            path = target.split("?", 1)[0]
+            if path == "/metrics":
+                body = self._exporter.render().encode("utf-8")
+                await _write_http_response(
+                    writer,
+                    status=200,
+                    content_type="text/plain; version=0.0.4; charset=utf-8",
+                    payload=body,
+                )
+            elif path == "/healthz":
+                await self._serve_healthz(writer)
+            else:
+                await _write_http_response(
+                    writer,
+                    status=404,
+                    content_type="application/json",
+                    payload=b'{"error": "not_found"}',
+                )
+        except Exception:
+            with contextlib.suppress(Exception):
+                await _write_http_response(
+                    writer,
+                    status=500,
+                    content_type="application/json",
+                    payload=b'{"error": "internal_server_error"}',
+                )
+        finally:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
+    async def _serve_healthz(self, writer: asyncio.StreamWriter) -> None:
+        payload = (
+            self._health_provider() if self._health_provider is not None else {"status": "ok"}
+        )
+        body = json.dumps(payload, sort_keys=True).encode("utf-8")
+        healthy = payload.get("status") == "ok"
+        await _write_http_response(
+            writer,
+            status=200 if healthy else 503,
+            content_type="application/json",
+            payload=body,
+        )
+
+    async def _read_request_line(
+        self,
+        reader: asyncio.StreamReader,
+    ) -> tuple[str, str, dict[str, str]]:
+        try:
+            raw = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5.0)
+        except (asyncio.TimeoutError, asyncio.IncompleteReadError) as exc:
+            raise _BadRequestError("invalid request") from exc
+        text = raw.decode("iso-8859-1")
+        lines = text.split("\r\n")
+        parts = lines[0].split()
+        if len(parts) != 3:
+            raise _BadRequestError("invalid request line")
+        method, target, _version = parts
+        headers: dict[str, str] = {}
+        for line in lines[1:]:
+            key, _, value = line.partition(":")
+            if key:
+                headers[key.strip().lower()] = value.strip()
+        return method.upper(), target, headers
+
+
+class _BadRequestError(Exception):
+    pass
+
+
+async def _write_http_response(
+    writer: asyncio.StreamWriter,
+    *,
+    status: int,
+    content_type: str,
+    payload: bytes,
+    extra_headers: dict[str, str] | None = None,
+) -> None:
+    reason = {
+        200: "OK",
+        404: "Not Found",
+        405: "Method Not Allowed",
+        500: "Internal Server Error",
+        503: "Service Unavailable",
+    }.get(status, "OK")
+    lines = [f"HTTP/1.1 {status} {reason}"]
+    if payload:
+        lines.append(f"Content-Type: {content_type}")
+    lines.append(f"Content-Length: {len(payload)}")
+    lines.append("Connection: close")
+    for key, value in (extra_headers or {}).items():
+        lines.append(f"{key}: {value}")
+    head = ("\r\n".join(lines) + "\r\n\r\n").encode("iso-8859-1")
+    writer.write(head + payload)
+    await writer.drain()
+
+
+def _build_health_snapshot(
+    app: OneStepApp,
+    *,
+    started_at_monotonic: float,
+) -> dict[str, Any]:
+    """Runtime + per-source liveness payload for ``/healthz``."""
+    tasks: list[dict[str, Any]] = []
+    for task in app.tasks:
+        source = task.source
+        source_info: dict[str, Any] | None = None
+        if source is not None:
+            source_info = {
+                "name": getattr(source, "name", type(source).__name__),
+                "kind": type(source).__name__,
+                "alive": bool(getattr(source, "is_open", True)),
+            }
+        tasks.append(
+            {
+                "task": task.name,
+                "source": source_info,
+                "inflight": (
+                    app.task_control_snapshot(task.name).get("inflight_task_count", 0)
+                    if source is not None
+                    else 0
+                ),
+            }
+        )
+
+    return {
+        "status": "ok",
+        "app": app.name,
+        "version": _resolve_version(),
+        "uptime_s": round(max(0.0, time.monotonic() - started_at_monotonic), 3),
+        "stopping": app.is_stopping,
+        "tasks": tasks,
+    }
+
+
+class MetricsHandle:
+    """Owns the exporter + server pair wired onto an app by
+    :func:`install_metrics`; ``close()`` tears the server down and detaches the
+    event handler."""
+
+    def __init__(self, server: MetricsServer, exporter: PrometheusExporter, app: OneStepApp) -> None:
+        self._server = server
+        self._exporter = exporter
+        self._app = app
+
+    @property
+    def exporter(self) -> PrometheusExporter:
+        return self._exporter
+
+    @property
+    def server(self) -> MetricsServer:
+        return self._server
+
+    @property
+    def bound_port(self) -> int:
+        return self._server.bound_port
+
+    async def close(self) -> None:
+        try:
+            self._app._event_handlers.remove(self._exporter)
+        except ValueError:
+            pass
+        await self._server.stop()
+
+
+def install_metrics(
+    app: OneStepApp,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 9100,
+) -> MetricsHandle:
+    """Wire a PrometheusExporter + MetricsServer onto ``app``.
+
+    Registers an event handler (fed by ``emit_event``), a startup hook that
+    binds the HTTP listener after resources open, and a shutdown hook that
+    releases it. ``port=0`` is supported for tests and embedded uses.
+    """
+    exporter = PrometheusExporter(
+        app_name=app.name,
+        custom_metrics=app.custom_metrics,
+    )
+    server = MetricsServer(
+        exporter,
+        host=host,
+        port=port,
+    )
+    started_at_monotonic = time.monotonic()
+
+    def _health() -> dict[str, Any]:
+        return _build_health_snapshot(app, started_at_monotonic=started_at_monotonic)
+
+    server._health_provider = _health
+
+    async def _startup() -> None:
+        await server.start()
+        logging.getLogger("onestep.observability").info(
+            "metrics server listening on %s:%d", host, server.bound_port
+        )
+
+    async def _shutdown() -> None:
+        await server.stop()
+
+    app.on_startup(_startup)
+    app.on_shutdown(_shutdown)
+    app.on_event(exporter)
+    return MetricsHandle(server, exporter, app)

--- a/src/onestep/runtime/executor.py
+++ b/src/onestep/runtime/executor.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 import math
 import time
+from uuid import uuid4
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
@@ -207,6 +208,23 @@ class DeliveryExecutor:
         failure: FailureInfo | None = None,
         event_meta: dict[str, Any] | None = None,
     ) -> None:
+        metadata = (
+            copy.deepcopy(event_meta)
+            if event_meta is not None
+            else copy.deepcopy(delivery.envelope.meta)
+        )
+        managed = self._managed_delivery(delivery)
+        attempt_id = str(managed.attempt_id) if managed is not None else None
+        if attempt_id is None:
+            attempt_id = getattr(delivery, "_onestep_attempt_id", None)
+            if not isinstance(attempt_id, str) or not attempt_id:
+                attempt_id = str(uuid4())
+                try:
+                    setattr(delivery, "_onestep_attempt_id", attempt_id)
+                except AttributeError:
+                    # A delivery implementation with slots cannot retain the
+                    # id; its event stream remains defensively accounted for.
+                    attempt_id = None
         event = TaskEvent(
             kind=kind,
             app=self.app.name,
@@ -215,11 +233,8 @@ class DeliveryExecutor:
             attempts=delivery.envelope.attempts,
             duration_s=duration_s,
             failure=failure,
-            meta=(
-                copy.deepcopy(event_meta)
-                if event_meta is not None
-                else copy.deepcopy(delivery.envelope.meta)
-            ),
+            meta=metadata,
+            attempt_id=attempt_id,
         )
         await self._event_emitter(event)
 

--- a/tests/test_metrics_server.py
+++ b/tests/test_metrics_server.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Optional
+
+import pytest
+
+from onestep.app import OneStepApp
+from onestep.events import TaskEvent, TaskEventKind
+from onestep.observability import MetricsServer, PrometheusExporter, install_metrics
+
+
+async def _http_get(port: int, path: str) -> tuple[int, str, str]:
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    request = f"GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+    writer.write(request.encode("iso-8859-1"))
+    await writer.drain()
+    raw = await reader.read(-1)
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except Exception:
+        pass
+    head, _, body = raw.partition(b"\r\n\r\n")
+    head_lines = head.decode("iso-8859-1").split("\r\n")
+    status = int(head_lines[0].split()[1])
+    headers: dict[str, str] = {}
+    for line in head_lines[1:]:
+        key, _, value = line.partition(":")
+        headers[key.strip().lower()] = value.strip()
+    return status, headers.get("content-type", ""), body.decode("utf-8", errors="replace")
+
+
+def make_event(
+    kind: TaskEventKind,
+    *,
+    app: str = "e2e",
+    task: str = "sync",
+    duration_s: Optional[float] = None,
+) -> TaskEvent:
+    return TaskEvent(
+        kind=kind,
+        app=app,
+        task=task,
+        source="incoming",
+        attempts=0,
+        duration_s=duration_s,
+    )
+
+
+@pytest.mark.asyncio
+async def test_metrics_server_serves_exporter_payload() -> None:
+    exporter = PrometheusExporter(app_name="solo")
+    server = MetricsServer(
+        exporter,
+        host="127.0.0.1",
+        port=0,
+        health_provider=lambda: {"status": "ok"},
+    )
+
+    await server.start()
+    try:
+        status, content_type, body = await _http_get(server.bound_port, "/metrics")
+        assert status == 200
+        assert content_type.startswith("text/plain")
+        assert "onestep_build_info" in body
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_install_metrics_wires_events_and_http_together() -> None:
+    app = OneStepApp("metrics-e2e")
+    handle = install_metrics(app, host="127.0.0.1", port=0)
+
+    await app.startup()
+    try:
+        status, _, body = await _http_get(handle.bound_port, "/metrics")
+        assert status == 200
+        assert "tasks" not in body or 'onestep_tasks_processed_total' in body
+
+        await app.emit_event(make_event(TaskEventKind.SUCCEEDED, duration_s=0.2))
+
+        status, _, body = await _http_get(handle.bound_port, "/metrics")
+        assert status == 200
+        assert (
+            'onestep_tasks_processed_total{app="e2e",task="sync",status="succeeded"} 1'
+            in body.splitlines()
+        )
+    finally:
+        await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_healthz_reports_runtime_and_sources() -> None:
+    app = OneStepApp("healthz-e2e")
+    handle = install_metrics(app, host="127.0.0.1", port=0)
+
+    await app.startup()
+    try:
+        status, content_type, body = await _http_get(handle.bound_port, "/healthz")
+        assert status == 200
+        assert content_type.startswith("application/json")
+        payload = json.loads(body)
+        assert payload["status"] == "ok"
+        assert payload["app"] == "healthz-e2e"
+        assert isinstance(payload["tasks"], list)
+    finally:
+        await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_unknown_path_returns_404() -> None:
+    exporter = PrometheusExporter(app_name="solo")
+    server = MetricsServer(exporter, host="127.0.0.1", port=0)
+    await server.start()
+    try:
+        status, _, _ = await _http_get(server.bound_port, "/nope")
+        assert status == 404
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_server_stop_releases_port() -> None:
+    exporter = PrometheusExporter(app_name="solo")
+    server = MetricsServer(exporter, host="127.0.0.1", port=0)
+    await server.start()
+    port = server.bound_port
+    await server.stop()
+
+    next_server = MetricsServer(exporter, host="127.0.0.1", port=port)
+    await next_server.start()
+    try:
+        assert next_server.bound_port == port
+    finally:
+        await next_server.stop()
+
+
+def test_run_accepts_metrics_addr_flag() -> None:
+    from onestep.cli import parse_args
+
+    args = parse_args(["run", "app.yaml", "--metrics-addr", ":9100"])
+    assert args.metrics_addr == ":9100"
+
+    args_default = parse_args(["run", "app.yaml"])
+    assert args_default.metrics_addr is None

--- a/tests/test_metrics_server.py
+++ b/tests/test_metrics_server.py
@@ -7,6 +7,7 @@ from typing import Optional
 import pytest
 
 from onestep.app import OneStepApp
+from onestep.connectors.memory import MemoryQueue
 from onestep.events import TaskEvent, TaskEventKind
 from onestep.observability import MetricsServer, PrometheusExporter, install_metrics
 
@@ -111,6 +112,34 @@ async def test_healthz_reports_runtime_and_sources() -> None:
 
 
 @pytest.mark.asyncio
+async def test_healthz_reports_source_liveness() -> None:
+    source = MemoryQueue("incoming")
+    app = OneStepApp("healthz-source")
+
+    @app.task(source=source)
+    async def consume(ctx, payload):
+        return payload
+
+    handle = install_metrics(app, host="127.0.0.1", port=0)
+    await app.startup()
+    try:
+        status, _, body = await _http_get(handle.bound_port, "/healthz")
+        assert status == 200
+        payload = json.loads(body)
+        assert payload["status"] == "ok"
+        assert payload["tasks"][0]["source"]["alive"] is True
+
+        source._set_open_state(False)
+        status, _, body = await _http_get(handle.bound_port, "/healthz")
+        assert status == 503
+        payload = json.loads(body)
+        assert payload["status"] == "degraded"
+        assert payload["tasks"][0]["source"]["alive"] is False
+    finally:
+        await app.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_unknown_path_returns_404() -> None:
     exporter = PrometheusExporter(app_name="solo")
     server = MetricsServer(exporter, host="127.0.0.1", port=0)
@@ -139,7 +168,16 @@ async def test_server_stop_releases_port() -> None:
 
 
 def test_run_accepts_metrics_addr_flag() -> None:
-    from onestep.cli import parse_args
+    from onestep.cli import _parse_metrics_addr, parse_args
+
+    assert _parse_metrics_addr(":9100") == ("127.0.0.1", 9100)
+    assert _parse_metrics_addr("9100") == ("127.0.0.1", 9100)
+    assert _parse_metrics_addr("0.0.0.0:9100") == ("0.0.0.0", 9100)
+    assert _parse_metrics_addr("[::1]:9100") == ("::1", 9100)
+
+    for value in ("", ":", "host:not-a-port", "host:0", "host:65536"):
+        with pytest.raises(ValueError):
+            _parse_metrics_addr(value)
 
     args = parse_args(["run", "app.yaml", "--metrics-addr", ":9100"])
     assert args.metrics_addr == ":9100"

--- a/tests/test_prometheus_metrics.py
+++ b/tests/test_prometheus_metrics.py
@@ -158,6 +158,28 @@ def test_exporter_does_not_double_close_cancelled_retry_pair() -> None:
     assert 'onestep_inflight_tasks{app="billing",task="sync"} 0' in render_lines(exporter)
 
 
+def test_exporter_counts_cancel_retry_duration_once() -> None:
+    """CANCELLED and its trailing RETRIED carry the same attempt and the same
+    duration_s (see DeliveryExecutor._handle_cancel); the histogram must
+    observe that duration exactly once. A fresh retry whose attempt is still
+    open keeps observing its duration."""
+    exporter = PrometheusExporter(app_name="billing")
+
+    exporter(make_event(TaskEventKind.STARTED, attempt_id="a"))
+    exporter(make_event(TaskEventKind.CANCELLED, duration_s=0.5, attempt_id="a"))
+    exporter(make_event(TaskEventKind.RETRIED, duration_s=0.5, attempt_id="a"))
+    exporter(make_event(TaskEventKind.STARTED, attempt_id="b"))
+    exporter(make_event(TaskEventKind.RETRIED, duration_s=0.2, attempt_id="b"))
+
+    lines = render_lines(exporter)
+    assert (
+        'onestep_task_duration_seconds_count{app="billing",task="sync"} 2' in lines
+    )
+    assert (
+        'onestep_task_duration_seconds_sum{app="billing",task="sync"} 0.7' in lines
+    )
+
+
 def test_exporter_keeps_processed_total_free_of_double_counting() -> None:
     """A dead-lettered delivery emits DEAD_LETTERED and then FAILED (see
     DeliveryExecutor._handle_failure). processed_total must count that as one

--- a/tests/test_prometheus_metrics.py
+++ b/tests/test_prometheus_metrics.py
@@ -18,6 +18,7 @@ def make_event(
     attempts: int = 0,
     duration_s: Optional[float] = None,
     failure: Optional[FailureInfo] = None,
+    attempt_id: str | None = None,
 ) -> TaskEvent:
     return TaskEvent(
         kind=kind,
@@ -27,6 +28,7 @@ def make_event(
         attempts=attempts,
         duration_s=duration_s,
         failure=failure,
+        attempt_id=attempt_id,
     )
 
 
@@ -103,7 +105,7 @@ def test_exporter_inflight_gauge_never_goes_negative() -> None:
 def test_exporter_counts_retries_dead_letters_and_failure_kinds() -> None:
     exporter = PrometheusExporter(app_name="billing")
 
-    exporter(make_event(TaskEventKind.RETRIED, duration_s=0.2))
+    exporter(make_event(TaskEventKind.RETRIED, duration_s=0.2, attempt_id="retry"))
     exporter(make_event(TaskEventKind.DEAD_LETTERED))
     exporter(
         make_event(
@@ -116,14 +118,15 @@ def test_exporter_counts_retries_dead_letters_and_failure_kinds() -> None:
             ),
         )
     )
-    exporter(make_event(TaskEventKind.CANCELLED))
+    exporter(make_event(TaskEventKind.CANCELLED, attempt_id="cancel"))
     exporter(make_event(TaskEventKind.FETCHED))
     lines = render_lines(exporter)
 
     assert 'onestep_tasks_retried_total{app="billing",task="sync"} 1' in lines
     assert 'onestep_tasks_dead_lettered_total{app="billing",task="sync"} 1' in lines
     assert 'onestep_tasks_cancelled_total{app="billing",task="sync"} 1' in lines
-    assert 'onestep_deliveries_fetched_total{app="billing",task="sync"} 1' in lines
+    fetched = [line for line in lines if line.startswith("onestep_deliveries_fetched_total")]
+    assert fetched == ['onestep_deliveries_fetched_total{app="billing",task="sync"} 1']
     assert (
         'onestep_tasks_processed_total{app="billing",task="sync",status="failed"} 1'
         in lines
@@ -132,6 +135,27 @@ def test_exporter_counts_retries_dead_letters_and_failure_kinds() -> None:
         'onestep_task_failures_total{app="billing",task="sync",failure_kind="timeout"} 1'
         in lines
     )
+
+
+def test_exporter_matches_cancelled_and_retried_by_attempt_id() -> None:
+    exporter = PrometheusExporter(app_name="billing")
+
+    exporter(make_event(TaskEventKind.STARTED, attempt_id="a"))
+    exporter(make_event(TaskEventKind.STARTED, attempt_id="b"))
+    exporter(make_event(TaskEventKind.CANCELLED, attempt_id="a"))
+    exporter(make_event(TaskEventKind.RETRIED, attempt_id="b"))
+
+    assert 'onestep_inflight_tasks{app="billing",task="sync"} 0' in render_lines(exporter)
+
+
+def test_exporter_does_not_double_close_cancelled_retry_pair() -> None:
+    exporter = PrometheusExporter(app_name="billing")
+
+    exporter(make_event(TaskEventKind.STARTED, attempt_id="a"))
+    exporter(make_event(TaskEventKind.CANCELLED, attempt_id="a"))
+    exporter(make_event(TaskEventKind.RETRIED, attempt_id="a"))
+
+    assert 'onestep_inflight_tasks{app="billing",task="sync"} 0' in render_lines(exporter)
 
 
 def test_exporter_keeps_processed_total_free_of_double_counting() -> None:

--- a/tests/test_prometheus_metrics.py
+++ b/tests/test_prometheus_metrics.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from onestep.events import TaskEvent, TaskEventKind
+from onestep.metrics import CustomMetricsRegistry
+from onestep.observability import PrometheusExporter
+from onestep.retry import FailureInfo, FailureKind
+
+
+def make_event(
+    kind: TaskEventKind,
+    *,
+    app: str = "billing",
+    task: str = "sync",
+    source: str = "incoming",
+    attempts: int = 0,
+    duration_s: Optional[float] = None,
+    failure: Optional[FailureInfo] = None,
+) -> TaskEvent:
+    return TaskEvent(
+        kind=kind,
+        app=app,
+        task=task,
+        source=source,
+        attempts=attempts,
+        duration_s=duration_s,
+        failure=failure,
+    )
+
+
+def render_lines(exporter: PrometheusExporter) -> list[str]:
+    return [
+        line
+        for line in exporter.render().splitlines()
+        if line and not line.startswith("#")
+    ]
+
+
+def test_exporter_counts_succeeded_tasks_with_status_label() -> None:
+    exporter = PrometheusExporter(app_name="billing")
+
+    exporter(make_event(TaskEventKind.SUCCEEDED, duration_s=0.25))
+
+    assert (
+        'onestep_tasks_processed_total{app="billing",task="sync",status="succeeded"} 1'
+        in render_lines(exporter)
+    )
+
+
+def test_exporter_declares_counter_type_metadata() -> None:
+    exporter = PrometheusExporter(app_name="billing")
+
+    exporter(make_event(TaskEventKind.SUCCEEDED, duration_s=0.25))
+    body = exporter.render()
+
+    assert "# TYPE onestep_tasks_processed_total counter" in body
+    assert "# HELP onestep_tasks_processed_total" in body
+
+
+def test_exporter_observes_duration_histogram() -> None:
+    exporter = PrometheusExporter(app_name="billing")
+
+    exporter(make_event(TaskEventKind.SUCCEEDED, duration_s=0.3))
+    lines = render_lines(exporter)
+
+    assert (
+        'onestep_task_duration_seconds_bucket{app="billing",task="sync",le="0.25"} 0'
+        in lines
+    )
+    assert (
+        'onestep_task_duration_seconds_bucket{app="billing",task="sync",le="0.5"} 1'
+        in lines
+    )
+    assert (
+        'onestep_task_duration_seconds_bucket{app="billing",task="sync",le="+Inf"} 1'
+        in lines
+    )
+    assert 'onestep_task_duration_seconds_count{app="billing",task="sync"} 1' in lines
+    assert 'onestep_task_duration_seconds_sum{app="billing",task="sync"} 0.3' in lines
+
+
+def test_exporter_tracks_inflight_gauge_from_lifecycle_events() -> None:
+    exporter = PrometheusExporter(app_name="billing")
+
+    exporter(make_event(TaskEventKind.STARTED))
+    exporter(make_event(TaskEventKind.STARTED))
+    assert 'onestep_inflight_tasks{app="billing",task="sync"} 2' in render_lines(exporter)
+
+    exporter(make_event(TaskEventKind.SUCCEEDED, duration_s=0.1))
+    assert 'onestep_inflight_tasks{app="billing",task="sync"} 1' in render_lines(exporter)
+
+
+def test_exporter_inflight_gauge_never_goes_negative() -> None:
+    exporter = PrometheusExporter(app_name="billing")
+
+    exporter(make_event(TaskEventKind.SUCCEEDED, duration_s=0.1))
+
+    assert 'onestep_inflight_tasks{app="billing",task="sync"} 0' in render_lines(exporter)
+
+
+def test_exporter_counts_retries_dead_letters_and_failure_kinds() -> None:
+    exporter = PrometheusExporter(app_name="billing")
+
+    exporter(make_event(TaskEventKind.RETRIED, duration_s=0.2))
+    exporter(make_event(TaskEventKind.DEAD_LETTERED))
+    exporter(
+        make_event(
+            TaskEventKind.FAILED,
+            duration_s=0.2,
+            failure=FailureInfo(
+                kind=FailureKind.TIMEOUT,
+                exception_type="TimeoutError",
+                message="slow",
+            ),
+        )
+    )
+    exporter(make_event(TaskEventKind.CANCELLED))
+    exporter(make_event(TaskEventKind.FETCHED))
+    lines = render_lines(exporter)
+
+    assert 'onestep_tasks_retried_total{app="billing",task="sync"} 1' in lines
+    assert 'onestep_tasks_dead_lettered_total{app="billing",task="sync"} 1' in lines
+    assert 'onestep_tasks_cancelled_total{app="billing",task="sync"} 1' in lines
+    assert 'onestep_deliveries_fetched_total{app="billing",task="sync"} 1' in lines
+    assert (
+        'onestep_tasks_processed_total{app="billing",task="sync",status="failed"} 1'
+        in lines
+    )
+    assert (
+        'onestep_task_failures_total{app="billing",task="sync",failure_kind="timeout"} 1'
+        in lines
+    )
+
+
+def test_exporter_keeps_processed_total_free_of_double_counting() -> None:
+    """A dead-lettered delivery emits DEAD_LETTERED and then FAILED (see
+    DeliveryExecutor._handle_failure). processed_total must count that as one
+    terminal outcome, not two."""
+    exporter = PrometheusExporter(app_name="billing")
+
+    exporter(make_event(TaskEventKind.STARTED))
+    exporter(make_event(TaskEventKind.DEAD_LETTERED))
+    exporter(
+        make_event(
+            TaskEventKind.FAILED,
+            duration_s=0.1,
+            failure=FailureInfo(
+                kind=FailureKind.ERROR,
+                exception_type="ValueError",
+                message="boom",
+            ),
+        )
+    )
+    lines = render_lines(exporter)
+    processed = [line for line in lines if line.startswith("onestep_tasks_processed_total")]
+
+    assert processed == [
+        'onestep_tasks_processed_total{app="billing",task="sync",status="failed"} 1'
+    ]
+
+
+def test_exporter_exposes_build_info() -> None:
+    from onestep import __version__
+
+    exporter = PrometheusExporter(app_name="billing")
+
+    assert (
+        f'onestep_build_info{{version="{__version__}"}} 1' in render_lines(exporter)
+    )
+
+
+def test_exporter_escapes_label_values() -> None:
+    exporter = PrometheusExporter(app_name='we"ird\napp')
+
+    exporter(make_event(TaskEventKind.STARTED, app='we"ird\napp', task="back\\slash"))
+    body = exporter.render()
+
+    assert 'app="we\\"ird\\napp"' in body
+    assert 'task="back\\\\slash"' in body
+
+
+def test_exporter_renders_custom_metrics_with_task_label() -> None:
+    registry = CustomMetricsRegistry()
+    exporter = PrometheusExporter(app_name="billing", custom_metrics=registry)
+    metrics = registry.for_task("sync")
+    metrics.counter("rows_synced", labels={"table": "orders"}).inc(3)
+    metrics.gauge("queue_depth").set(7)
+
+    lines = render_lines(exporter)
+
+    assert 'rows_synced{task="sync",table="orders"} 3' in lines
+    assert 'queue_depth{task="sync"} 7' in lines
+
+
+def test_custom_metric_counters_stay_monotonic_across_control_plane_rotation() -> None:
+    """rotate_task() resets counters because the control-plane reporter reports
+    per-window deltas. Prometheus counters must not go backwards, so the
+    non-destructive snapshot has to keep cumulative totals."""
+    registry = CustomMetricsRegistry()
+    exporter = PrometheusExporter(app_name="billing", custom_metrics=registry)
+    counter = registry.for_task("sync").counter("rows_synced")
+
+    counter.inc(2)
+    registry.rotate_task("sync")
+    counter.inc(3)
+
+    assert 'rows_synced{task="sync"} 5' in render_lines(exporter)
+
+
+def test_custom_metrics_snapshot_does_not_reset_reporter_window() -> None:
+    registry = CustomMetricsRegistry()
+    registry.for_task("sync").counter("rows_synced").inc(4)
+
+    registry.snapshot()
+
+    assert registry.rotate_task("sync") == [
+        {"name": "rows_synced", "kind": "counter", "value": 4, "labels": {}}
+    ]
+
+
+def test_exporter_ignores_unknown_event_kinds_without_raising() -> None:
+    exporter = PrometheusExporter(app_name="billing")
+
+    async def scenario() -> None:
+        await asyncio.sleep(0)
+
+    asyncio.run(scenario())
+    exporter(make_event(TaskEventKind.FETCHED))
+
+    assert exporter.render().endswith("\n")

--- a/uv.lock
+++ b/uv.lock
@@ -1540,7 +1540,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'test'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6.0" },
 ]
-provides-extras = ["control-plane", "yaml", "mysql", "postgres", "sql", "sqlite", "rabbitmq", "redis", "sqs", "cloudflare", "kafka", "elasticsearch", "clickhouse", "mongodb", "test", "integration", "all", "dev"]
+provides-extras = ["control-plane", "yaml", "mysql", "postgres", "sql", "sqlite", "rabbitmq", "redis", "sqs", "cloudflare", "metrics", "kafka", "elasticsearch", "clickhouse", "mongodb", "test", "integration", "all", "dev"]
 
 [[package]]
 name = "onestep-cf-queues"


### PR DESCRIPTION
## Summary

Implements #153. Zero-dependency Prometheus observability for onestep workers:

- **`PrometheusExporter`** (`src/onestep/observability.py`, new): consumes the `TaskEvent` stream and renders Prometheus text exposition (format 0.0.4) directly — no third-party client library.
- **Non-destructive `snapshot()`** (`metrics.py`): `CustomMetricsRegistry` gains a parallel `_cumulative` ledger so counters stay monotonic across the control-plane reporter's `rotate_task()` window resets. `rotate_task()` return shape and reset semantics are unchanged.
- **`MetricsServer`**: lightweight `asyncio.start_server` HTTP server (same pattern as webhook source), serving:
  - `GET /metrics` — `text/plain; version=0.0.4`
  - `GET /healthz` — JSON with runtime/app/version/uptime/stopping plus per-source liveness, usable as a K8s liveness/readiness probe
  - proper 404/405/500 handling
- **CLI**: `onestep run --metrics-addr host:port` (accepts `:9100` shorthand; disabled by default).
- **`install_metrics(app, ...)`**: pure composition via `on_event` + startup/shutdown hooks — no changes to `OneStepApp`; coexists with webhook servers on a separate port.
- **`examples/prometheus/`**: full docker-compose stack (onestep + Prometheus + Grafana with provisioned datasource + dashboard), loadable sample `onestep.yaml` + `handlers.py` (passes `onestep check`).
- **`pyproject.toml`**: `metrics` extra (empty dependency list — zero-dependency entry point, `pip install 'onestep[metrics]'`).

## Metric inventory

`onestep_build_info`, `onestep_deliveries_fetched_total{source}`, `onestep_tasks_processed_total{app,task,status}`, `onestep_task_duration_seconds` (histogram), `onestep_inflight_tasks{task}`, `onestep_tasks_retried_total`, `onestep_tasks_dead_lettered_total`, `onestep_tasks_cancelled_total`, `onestep_task_failures_total{failure_kind}`, plus all custom task metrics via `snapshot()`.

## Test plan

- [x] 19 new tests (`tests/test_prometheus_metrics.py`, `tests/test_metrics_server.py`) — all green
- [x] Full suite: **610 passed** (1 pre-existing failure in legacy-shim contract test reproduces on clean `main`; environment-only, see below)
- [x] Exposition validated with the official `prometheus_client` parser (one-shot, not a project dependency): 10 metric families parse clean
- [x] Sample YAML + handler pass `onestep check`
- [x] Live smoke test: `onestep run onestep.yaml --metrics-addr` → `/healthz` reports `IntervalSource alive:true`; `/metrics` scraped real data (`fetched=2, succeeded=2, duration sum≈0.10s`)

Pre-existing failure: `tests/contract/test_onestep_sql_shared.py::test_legacy_forwarders_still_alias_the_shared_backend_objects` fails on clean `main` in this venv (missing legacy shim install); unrelated to this PR.

Closes #153
