### PR TITLE
feat(observability): onestep run --log-format json structured log out…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## onestep 1.12.0a1
 
+- Adds `onestep run --log-format {text,json}` (issue #155): `json` swaps the
+  CLI stdout handler's formatter for the new stdlib-only `JsonLogFormatter`
+  (`src/onestep/jsonlog.py`, also exported as `onestep.JsonLogFormatter`),
+  emitting one JSON object per line with `ts`/`level`/`logger`/message plus
+  task lifecycle fields (`event_kind`, `app_name`, `task_name`, `attempts`,
+  `duration_s`, `failure_*`, `task_event_meta`) promoted to the top level so
+  Loki/ELK can index them without a parsing pipeline. Other records keep
+  their `extra` attributes nested under `extra`; unserializable values fall
+  back to `repr` so logging never raises. Default `text` output is unchanged.
+
 - Decomposes the `OneStepApp` god-object into a thin facade plus dedicated
   runtime controllers under `src/onestep/runtime/` (`LifecycleController`,
   `TaskOperations`, `EventHub`). Public API, `describe()` output, and all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   Loki/ELK can index them without a parsing pipeline. Other records keep
   their `extra` attributes nested under `extra`; unserializable values fall
   back to `repr` so logging never raises. Default `text` output is unchanged.
+  The format can also be configured in YAML via `app.logging.format: json`
+  (validated by `load_app_config(strict=True)`); an explicit `--log-format`
+  flag overrides the YAML value, and the precedence is
+  CLI flag > `app.logging.format` > default `text`.
 
 - Decomposes the `OneStepApp` god-object into a thin facade plus dedicated
   runtime controllers under `src/onestep/runtime/` (`LifecycleController`,

--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ ready for Loki, ELK, or any JSON log collector without a parsing pipeline:
 onestep run your_package.tasks:app --log-format json
 ```
 
+The format can also be pinned in YAML via `app.logging.format`, so deployments
+(K8s/compose) get structured logs without changing the startup command:
+
+```yaml
+app:
+  name: billing-sync
+  logging:
+    level: INFO
+    format: json
+```
+
+An explicit `--log-format` flag overrides the YAML value; without either,
+`text` is used.
+
 Every line the CLI stdout handler emits becomes a JSON object with `ts`,
 `level`, `logger`, and `message` keys. Task lifecycle events logged by the
 built-in `StructuredEventLogger` additionally promote their structured fields

--- a/README.md
+++ b/README.md
@@ -86,6 +86,40 @@ the `onestep` namespace. Existing logging handlers and custom
 `StructuredEventLogger` instances are preserved; when a host has configured its
 own handler, it also retains ownership of root logger levels.
 
+#### Structured JSON logs
+
+Use `--log-format json` to emit one JSON object per line instead of text —
+ready for Loki, ELK, or any JSON log collector without a parsing pipeline:
+
+```bash
+onestep run your_package.tasks:app --log-format json
+```
+
+Every line the CLI stdout handler emits becomes a JSON object with `ts`,
+`level`, `logger`, and `message` keys. Task lifecycle events logged by the
+built-in `StructuredEventLogger` additionally promote their structured fields
+to the top level, so platforms can index them directly:
+
+```json
+{"ts": "2026-09-03T01:14:01.808690+00:00", "level": "INFO", "logger": "onestep.events", "message": "task succeeded", "event_kind": "succeeded", "app_name": "billing", "task_name": "sync", "source_name": "queue.in", "attempts": 1, "duration_s": 0.0004, "failure_kind": null, "failure_message": null}
+```
+
+Other log records keep their `extra={...}` attributes under a nested `extra`
+key. Unserializable values fall back to their `repr` so logging never raises.
+The formatter is also usable directly for embedded setups:
+
+```python
+import logging
+
+from onestep import JsonLogFormatter
+
+handler = logging.StreamHandler()
+JsonLogFormatter.attach(handler)
+logging.getLogger().addHandler(handler)
+```
+
+The default `text` behavior is unchanged.
+
 Direct `app.run()` and `app.serve()` calls do not modify host logging or install
 task event logging. Embedded applications retain full control of process logging.
 

--- a/src/onestep/__init__.py
+++ b/src/onestep/__init__.py
@@ -39,6 +39,7 @@ from .identity_store import (
     build_default_state_dir,
     derive_replica_instance_id,
 )
+from .jsonlog import JsonLogFormatter
 from .metrics import CounterMetric, CustomMetricsRegistry, GaugeMetric, TaskMetrics
 from .resource_registry import (
     CATALOG_FIELD_TYPES,
@@ -151,6 +152,7 @@ _CORE_EXPORTS = [
     "InMemoryCursorStore",
     "InMemoryStateStore",
     "IntervalSource",
+    "JsonLogFormatter",
     "ByFailureKind",
     "ExponentialBackoff",
     "MaxAttempts",

--- a/src/onestep/app.py
+++ b/src/onestep/app.py
@@ -48,6 +48,10 @@ class OneStepApp:
         self.state = state or InMemoryStateStore()
         self.shutdown_timeout_s = shutdown_timeout_s
         self.failure_capture = failure_capture
+        # Process-level log output preference ("text" | "json") configured via
+        # YAML ``app.logging.format``; ``None`` means "not configured" so the
+        # CLI can fall back to its own default. Not part of app semantics.
+        self.logging_format: str | None = None
         self._failure_capture_writer = (
             FailureCaptureWriter(failure_capture)
             if failure_capture is not None

--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -72,10 +72,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--log-format",
         dest="log_format",
         choices=("text", "json"),
-        default="text",
+        default=None,
         help=(
             "Log output format: text (default) or one-JSON-object-per-line for "
-            "log collectors such as Loki/ELK"
+            "log collectors such as Loki/ELK; overrides YAML app.logging.format"
         ),
     )
     run_parser.add_argument(
@@ -348,6 +348,7 @@ def main(argv: list[str] | None = None) -> int:
         cli_logging_state = _configure_run_logging(
             explicit_level=args.log_level,
             log_format=args.log_format,
+            config_format=getattr(app, "logging_format", None),
         )
         if args.task_events:
             app.enable_structured_event_logging()
@@ -394,7 +395,8 @@ def _parse_metrics_addr(value: str) -> tuple[str, int]:
 def _configure_run_logging(
     *,
     explicit_level: str | None,
-    log_format: str = "text",
+    log_format: str | None = None,
+    config_format: str | None = None,
 ) -> tuple[logging.Handler, int] | None:
     framework_logger = logging.getLogger("onestep")
     if explicit_level is not None:
@@ -402,11 +404,12 @@ def _configure_run_logging(
     elif framework_logger.level == logging.NOTSET:
         framework_logger.setLevel(logging.INFO)
 
+    resolved_format = log_format or config_format or "text"
     root_logger = logging.getLogger()
     if root_logger.handlers:
         return None
     handler = logging.StreamHandler(sys.stdout)
-    if log_format == "json":
+    if resolved_format == "json":
         from .jsonlog import JsonLogFormatter
 
         handler.setFormatter(JsonLogFormatter())

--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -69,6 +69,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     run_parser.add_argument(
+        "--log-format",
+        dest="log_format",
+        choices=("text", "json"),
+        default="text",
+        help=(
+            "Log output format: text (default) or one-JSON-object-per-line for "
+            "log collectors such as Loki/ELK"
+        ),
+    )
+    run_parser.add_argument(
         "--task-events",
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -335,7 +345,10 @@ def main(argv: list[str] | None = None) -> int:
 
     cli_logging_state: tuple[logging.Handler, int] | None = None
     try:
-        cli_logging_state = _configure_run_logging(explicit_level=args.log_level)
+        cli_logging_state = _configure_run_logging(
+            explicit_level=args.log_level,
+            log_format=args.log_format,
+        )
         if args.task_events:
             app.enable_structured_event_logging()
         if metrics_addr is not None:
@@ -379,7 +392,9 @@ def _parse_metrics_addr(value: str) -> tuple[str, int]:
 
 
 def _configure_run_logging(
-    *, explicit_level: str | None
+    *,
+    explicit_level: str | None,
+    log_format: str = "text",
 ) -> tuple[logging.Handler, int] | None:
     framework_logger = logging.getLogger("onestep")
     if explicit_level is not None:
@@ -391,7 +406,12 @@ def _configure_run_logging(
     if root_logger.handlers:
         return None
     handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(logging.Formatter(_CLI_LOG_FORMAT))
+    if log_format == "json":
+        from .jsonlog import JsonLogFormatter
+
+        handler.setFormatter(JsonLogFormatter())
+    else:
+        handler.setFormatter(logging.Formatter(_CLI_LOG_FORMAT))
     previous_root_level = root_logger.level
     root_logger.setLevel(framework_logger.level)
     root_logger.addHandler(handler)

--- a/src/onestep/cli.py
+++ b/src/onestep/cli.py
@@ -21,6 +21,7 @@ from .diagnostics.supervisor import supervise_diagnostic
 from .diagnostics.targets import _ensure_local_import_paths
 from .envelope import Envelope
 from .init_project import init_project
+from .jsonlog import JsonLogFormatter
 from .render import render_mermaid
 
 _CLI_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
@@ -410,8 +411,6 @@ def _configure_run_logging(
         return None
     handler = logging.StreamHandler(sys.stdout)
     if resolved_format == "json":
-        from .jsonlog import JsonLogFormatter
-
         handler.setFormatter(JsonLogFormatter())
     else:
         handler.setFormatter(logging.Formatter(_CLI_LOG_FORMAT))

--- a/src/onestep/config.py
+++ b/src/onestep/config.py
@@ -86,7 +86,8 @@ _STRICT_APP_FIELDS = frozenset(
         "failure_capture",
     }
 )
-_STRICT_APP_LOGGING_FIELDS = frozenset({"level"})
+_STRICT_APP_LOGGING_FIELDS = frozenset({"level", "format"})
+_LOG_FORMATS = frozenset({"text", "json"})
 _STRICT_HANDLER_FIELDS = frozenset({"ref", "params"})
 _STRICT_EMIT_ROUTE_FIELDS = frozenset({"when", "then", "otherwise"})
 _STRICT_EMIT_BINDING_FIELDS = frozenset({"sink", "transform"})
@@ -905,16 +906,34 @@ def _validate_reporter_config(raw_reporter: Any) -> None:
     validate_reporter_spec(spec, registry=reporter_registry)
 
 
+def _logging_level_from_mapping(raw_logging: Mapping[str, Any]) -> int | None:
+    level = _require_string(raw_logging, "level")
+    resolved = getattr(logging, level.strip().upper(), None)
+    if not isinstance(resolved, int):
+        raise ValueError(f"unsupported logging level {level!r}")
+    return resolved
+
+
+def _logging_format_from_mapping(raw_logging: Mapping[str, Any]) -> str | None:
+    value = raw_logging.get("format")
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("'format' must be a non-empty string")
+    resolved = value.strip().lower()
+    if resolved not in _LOG_FORMATS:
+        raise ValueError(f"unsupported logging format {value!r}; expected 'text' or 'json'")
+    return resolved
+
+
 def _validate_app_logging(raw_logging: Any) -> None:
     if raw_logging is None:
         return
     if not isinstance(raw_logging, Mapping):
         raise TypeError("'app.logging' must be a mapping")
     _validate_unknown_fields(raw_logging, _STRICT_APP_LOGGING_FIELDS, field="app.logging")
-    level = _require_string(raw_logging, "level")
-    resolved = getattr(logging, level.strip().upper(), None)
-    if not isinstance(resolved, int):
-        raise ValueError(f"unsupported logging level {level!r}")
+    _logging_level_from_mapping(raw_logging)
+    _logging_format_from_mapping(raw_logging)
 
 
 def _validate_app_env_file(raw_env_file: Any) -> None:
@@ -937,11 +956,10 @@ def _apply_app_logging(app: OneStepApp, raw_logging: Any) -> None:
     if not isinstance(raw_logging, Mapping):
         raise TypeError("'app.logging' must be a mapping")
     _validate_unknown_fields(raw_logging, _STRICT_APP_LOGGING_FIELDS, field="app.logging")
-    level = _require_string(raw_logging, "level")
-    resolved = getattr(logging, level.strip().upper(), None)
-    if not isinstance(resolved, int):
-        raise ValueError(f"unsupported logging level {level!r}")
-    logging.getLogger("onestep").setLevel(resolved)
+    level = _logging_level_from_mapping(raw_logging)
+    if level is not None:
+        logging.getLogger("onestep").setLevel(level)
+    app.logging_format = _logging_format_from_mapping(raw_logging)
 
 
 def _validate_hooks_config(raw_hooks: Any, *, field: str, allowed: frozenset[str]) -> None:

--- a/src/onestep/config.py
+++ b/src/onestep/config.py
@@ -906,7 +906,7 @@ def _validate_reporter_config(raw_reporter: Any) -> None:
     validate_reporter_spec(spec, registry=reporter_registry)
 
 
-def _logging_level_from_mapping(raw_logging: Mapping[str, Any]) -> int | None:
+def _logging_level_from_mapping(raw_logging: Mapping[str, Any]) -> int:
     level = _require_string(raw_logging, "level")
     resolved = getattr(logging, level.strip().upper(), None)
     if not isinstance(resolved, int):
@@ -956,9 +956,7 @@ def _apply_app_logging(app: OneStepApp, raw_logging: Any) -> None:
     if not isinstance(raw_logging, Mapping):
         raise TypeError("'app.logging' must be a mapping")
     _validate_unknown_fields(raw_logging, _STRICT_APP_LOGGING_FIELDS, field="app.logging")
-    level = _logging_level_from_mapping(raw_logging)
-    if level is not None:
-        logging.getLogger("onestep").setLevel(level)
+    logging.getLogger("onestep").setLevel(_logging_level_from_mapping(raw_logging))
     app.logging_format = _logging_format_from_mapping(raw_logging)
 
 

--- a/src/onestep/jsonlog.py
+++ b/src/onestep/jsonlog.py
@@ -1,0 +1,145 @@
+"""JSON log formatting for the onestep CLI.
+
+`StructuredEventLogger` (``onestep.events``) already attaches task lifecycle
+fields (``event_kind``, ``task_name``, ``attempts``, ``failure_*`` ...) to log
+records via ``extra``. Log collectors such as Loki or ELK, however, cannot
+index fields buried in a human-readable line. ``--log-format json`` swaps the
+CLI's stdout formatter for :class:`JsonLogFormatter` so every record the
+runtime emits — lifecycle events *and* ordinary application/framework logs —
+is one JSON object per line, using only the standard library.
+
+Design notes:
+
+- The formatter owns the whole line (``JSON + "\\n"``), so the handler must
+  not prepend the default newline; ``JsonLogFormatter.attach`` installs a
+  matching handler in one step.
+- Well-known record attributes are mapped to stable keys (``ts``, ``level``,
+  ``logger``, ``message``). Remaining ``record.__dict__`` entries that are not
+  private/dunder and not logging bookkeeping are merged as ``extra`` fields,
+  which is exactly where the ``StructuredEventLogger`` lifecycle fields land.
+- Message arguments are left unformatted when they are lazy
+  (``logger.info("... %s", obj)``) and serialization of any value fails: the
+  original ``repr`` is kept instead of raising inside the logging machinery.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+__all__ = ["JsonLogFormatter"]
+
+# Record attributes owned by the logging module itself; anything else that
+# survives the filters below came in through ``extra={...}``.
+_LOGGING_RESERVED = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "taskName",
+        "message",
+        "asctime",
+    }
+)
+
+# Fields the structured task-event logger attaches; they are promoted to the
+# top level of the JSON object so log platforms can index them without
+# touching the nested ``extra`` object.
+_TASK_EVENT_FIELDS = (
+    "event_kind",
+    "app_name",
+    "task_name",
+    "source_name",
+    "attempts",
+    "duration_s",
+    "emitted_at",
+    "failure_kind",
+    "failure_exception_type",
+    "failure_message",
+    "task_event_meta",
+)
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, BaseException):
+        return f"{type(value).__name__}: {value}"
+    return repr(value)
+
+
+def _record_timestamp(record: logging.LogRecord) -> str:
+    emitted_at = getattr(record, "emitted_at", None)
+    if isinstance(emitted_at, str) and emitted_at:
+        # TaskEvent timestamps (ISO 8601, timezone-aware) take precedence so
+        # lifecycle lines carry the event's own clock, not the handler's.
+        return emitted_at
+    return datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat()
+
+
+class JsonLogFormatter(logging.Formatter):
+    """Format each record as a single line of JSON.
+
+    Lifecycle fields attached by ``StructuredEventLogger`` are promoted to
+    the top level; any other non-standard record attributes are preserved
+    under ``extra`` so nothing is silently dropped.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "ts": _record_timestamp(record),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        for field in _TASK_EVENT_FIELDS:
+            if hasattr(record, field):
+                payload[field] = getattr(record, field)
+
+        extras: dict[str, Any] = {}
+        for key, value in record.__dict__.items():
+            if key.startswith("_") or key in _LOGGING_RESERVED or key in _TASK_EVENT_FIELDS:
+                continue
+            extras[key] = value
+        if extras:
+            payload["extra"] = extras
+
+        if record.exc_info:
+            # ``Formatter.format`` populates exc_text on the record; reuse it
+            # when present so the traceback text is rendered once.
+            if record.exc_text is None:
+                record.exc_text = self.formatException(record.exc_info)
+            payload["exc_info"] = record.exc_text
+        if record.stack_info:
+            payload["stack_info"] = self.formatStack(record.stack_info)
+
+        return json.dumps(payload, default=_json_default, ensure_ascii=False)
+
+    def formatMessage(self, record: logging.LogRecord) -> str:
+        # The full line is produced by ``format``; the base implementation's
+        # %-style templating does not apply to JSON output.
+        return record.getMessage()
+
+    @staticmethod
+    def attach(handler: logging.Handler) -> logging.Handler:
+        """Install this formatter on ``handler`` for one-line JSON records."""
+        handler.setFormatter(JsonLogFormatter())
+        return handler

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,6 +32,7 @@ from onestep.diagnostics.models import (
     DiagnosticReport,
 )
 from onestep.envelope import Envelope
+from onestep.jsonlog import JsonLogFormatter
 from onestep.retry import FailureInfo, FailureKind
 from onestep.task import EmitBinding, EmitRoute
 
@@ -238,7 +239,7 @@ def test_cli_run_parses_logging_options() -> None:
 
     assert args.log_level == "DEBUG"
     assert args.task_events is False
-    assert args.log_format == "text"
+    assert args.log_format is None
 
 
 def test_cli_run_parses_log_format_json() -> None:
@@ -1434,6 +1435,70 @@ def test_cli_log_level_precedence_over_yaml(
     }
 
 
+@pytest.mark.parametrize(
+    ("yaml_format", "cli_format", "expected"),
+    [
+        ("json", None, True), # YAML json wins when CLI flag absent
+        ("json", "text", False), # explicit CLI flag overrides YAML
+        ("text", "json", True), # explicit CLI json overrides YAML text
+        (None, None, False), # default text everywhere
+    ],
+)
+def test_cli_log_format_precedence_over_yaml(
+    monkeypatch,
+    tmp_path,
+    capsys,
+    yaml_format: Optional[str],
+    cli_format: Optional[str],
+    expected: bool,
+) -> None:
+    logging_section: dict = {"level": "INFO"}
+    if yaml_format is not None:
+        logging_section["format"] = yaml_format
+    config_path = tmp_path / "log-format.yaml"
+    config_path.write_text(
+        json.dumps(
+            {
+                "app": {
+                    "name": "yaml-log-format",
+                    "logging": logging_section,
+                },
+                "tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    observed: dict = {}
+
+    def fake_run() -> None:
+        root_handlers = logging.getLogger().handlers
+        formatter = root_handlers[0].formatter if root_handlers else None
+        observed["is_json"] = isinstance(formatter, JsonLogFormatter)
+        logging.getLogger("precedence.app").info("precedence message")
+
+    app = OneStepApp("placeholder")
+    monkeypatch.setattr(OneStepApp, "run", lambda self: fake_run())
+
+    argv = ["run", str(config_path)]
+    if cli_format is not None:
+        argv.extend(["--log-format", cli_format])
+
+    captured = capsys.readouterr()
+    with isolated_logging(), registered_yaml_module():
+        assert main(argv) == 0
+
+    out = capsys.readouterr().out
+    assert observed["is_json"] is expected
+    if expected:
+        line = next(line for line in out.splitlines() if "precedence message" in line)
+        payload = json.loads(line)
+        assert payload["message"] == "precedence message"
+        assert payload["logger"] == "precedence.app"
+    else:
+        assert "precedence message" in out
+        assert not any(line.strip().startswith("{") for line in out.splitlines())
+
+
 def test_load_app_config_strict_rejects_invalid_yaml_logging_level_type() -> None:
     with pytest.raises(ValueError, match="'level' must be a non-empty string"):
         load_app_config(
@@ -1475,6 +1540,55 @@ def test_load_app_config_strict_rejects_unknown_yaml_logging_fields() -> None:
                 "app": {
                     "name": "yaml-logging-invalid-field",
                     "logging": {"unexpected": True},
+                },
+                "tasks": [],
+            },
+            strict=True,
+        )
+
+
+def test_load_app_config_applies_yaml_logging_format() -> None:
+    app = load_app_config(
+        {
+            "apiVersion": "onestep/v1alpha1",
+            "kind": "App",
+            "app": {
+                "name": "yaml-logging-format",
+                "logging": {"level": "info", "format": "json"},
+            },
+            "tasks": [],
+        },
+        strict=True,
+    )
+    assert app.logging_format == "json"
+
+
+def test_load_app_config_logging_format_defaults_to_none() -> None:
+    app = load_app_config(
+        {
+            "apiVersion": "onestep/v1alpha1",
+            "kind": "App",
+            "app": {
+                "name": "yaml-logging-format-default",
+                "logging": {"level": "info"},
+            },
+            "tasks": [],
+        },
+        strict=True,
+    )
+    assert app.logging_format is None
+
+
+@pytest.mark.parametrize("bad_format", ["xml", "", 123, True])
+def test_load_app_config_strict_rejects_invalid_yaml_logging_format(bad_format) -> None:
+    with pytest.raises(ValueError, match="unsupported logging format|must be a non-empty string"):
+        load_app_config(
+            {
+                "apiVersion": "onestep/v1alpha1",
+                "kind": "App",
+                "app": {
+                    "name": "yaml-logging-format-invalid",
+                    "logging": {"format": bad_format},
                 },
                 "tasks": [],
             },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,6 +238,19 @@ def test_cli_run_parses_logging_options() -> None:
 
     assert args.log_level == "DEBUG"
     assert args.task_events is False
+    assert args.log_format == "text"
+
+
+def test_cli_run_parses_log_format_json() -> None:
+    args = parse_args(["run", "worker:app", "--log-format", "json"])
+
+    assert args.log_format == "json"
+
+
+def test_cli_run_rejects_unknown_log_format() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        parse_args(["run", "worker:app", "--log-format", "xml"])
+    assert excinfo.value.code == 2
 
 
 def test_cli_run_enables_task_events_by_default() -> None:
@@ -791,6 +804,72 @@ def test_cli_run_cleans_up_stdout_handler_after_failure(capsys) -> None:
     assert "testsupport_cli_run_failure:app failed while running: boom" in (
         capsys.readouterr().err
     )
+
+
+def test_cli_run_log_format_json_emits_json_lines(capsys) -> None:
+    """--log-format json turns the CLI stdout handler into one-JSON-per-line,
+    lifecycle event fields included, for both framework and app loggers."""
+    from onestep.events import TaskEvent, TaskEventKind
+    from onestep.jsonlog import JsonLogFormatter
+
+    app = OneStepApp("cli-json-logs")
+
+    def run() -> None:
+        logging.getLogger("billing.kpi_sync").info("business message")
+        event = TaskEvent(
+            kind=TaskEventKind.SUCCEEDED,
+            app="cli-json-logs",
+            task="sync",
+            source="queue.in",
+            attempts=1,
+            duration_s=0.5,
+        )
+        asyncio.run(app.emit_event(event))
+
+    app.run = run
+    with isolated_logging(), registered_module("testsupport_cli_json_logs", app=app):
+        assert (
+            main(
+                [
+                    "run",
+                    "testsupport_cli_json_logs:app",
+                    "--log-format",
+                    "json",
+                ]
+            )
+            == 0
+        )
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+    assert lines, "expected at least one JSON log line on stdout"
+    payloads = [json.loads(line) for line in lines]
+
+    business = next(payload for payload in payloads if payload["message"] == "business message")
+    assert business["logger"] == "billing.kpi_sync"
+    assert business["level"] == "INFO"
+
+    succeeded = next(
+        payload for payload in payloads if payload.get("event_kind") == "succeeded"
+    )
+    assert succeeded["task_name"] == "sync"
+    assert succeeded["app_name"] == "cli-json-logs"
+    assert succeeded["source_name"] == "queue.in"
+    assert succeeded["attempts"] == 1
+    assert succeeded["duration_s"] == 0.5
+    assert succeeded["ts"] == succeeded["emitted_at"]
+
+
+def test_cli_run_default_text_format_unchanged(capsys) -> None:
+    app = OneStepApp("cli-text-logs")
+    app.run = lambda: logging.getLogger("plain.app").info("plain message")
+
+    with isolated_logging(), registered_module("testsupport_cli_text_logs", app=app):
+        assert main(["run", "testsupport_cli_text_logs:app"]) == 0
+
+    out = capsys.readouterr().out
+    line = next(line for line in out.splitlines() if "plain message" in line)
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(line)
 
 
 def test_cli_check_does_not_configure_logging_or_task_events() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1581,14 +1581,14 @@ def test_load_app_config_logging_format_defaults_to_none() -> None:
 
 @pytest.mark.parametrize("bad_format", ["xml", "", 123, True])
 def test_load_app_config_strict_rejects_invalid_yaml_logging_format(bad_format) -> None:
-    with pytest.raises(ValueError, match="unsupported logging format|must be a non-empty string"):
+    with pytest.raises(ValueError, match="unsupported logging format|'format' must be"):
         load_app_config(
             {
                 "apiVersion": "onestep/v1alpha1",
                 "kind": "App",
                 "app": {
                     "name": "yaml-logging-format-invalid",
-                    "logging": {"format": bad_format},
+                    "logging": {"level": "INFO", "format": bad_format},
                 },
                 "tasks": [],
             },

--- a/tests/test_jsonlog.py
+++ b/tests/test_jsonlog.py
@@ -1,0 +1,183 @@
+"""Unit coverage for the JSON log formatter (``--log-format json``)."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from onestep.events import FailureInfo, FailureKind, StructuredEventLogger, TaskEvent, TaskEventKind
+from onestep.jsonlog import JsonLogFormatter
+
+
+class ListHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lines: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.lines.append(self.format(record))
+
+
+def _make_logger(name: str, handler: logging.Handler) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.handlers = [handler]
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    return logger
+
+
+def test_plain_record_is_valid_single_line_json() -> None:
+    handler = ListHandler()
+    handler.setFormatter(JsonLogFormatter())
+    logger = _make_logger("tests.jsonlog.plain", handler)
+
+    logger.info("hello %s", "world")
+
+    assert len(handler.lines) == 1
+    payload = json.loads(handler.lines[0])
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "tests.jsonlog.plain"
+    assert payload["message"] == "hello world"
+    assert payload["ts"]
+    assert "\n" not in handler.lines[0].rstrip("\n")
+
+
+def test_task_event_fields_promoted_to_top_level() -> None:
+    handler = ListHandler()
+    handler.setFormatter(JsonLogFormatter())
+    logger = _make_logger("tests.jsonlog.events", handler)
+
+    event_logger = StructuredEventLogger(logger=logger)
+    event_logger(
+        TaskEvent(
+            kind=TaskEventKind.SUCCEEDED,
+            app="billing",
+            task="sync",
+            source="queue.in",
+            attempts=2,
+            duration_s=0.25,
+        )
+    )
+
+    payload = json.loads(handler.lines[0])
+    assert payload["event_kind"] == "succeeded"
+    assert payload["app_name"] == "billing"
+    assert payload["task_name"] == "sync"
+    assert payload["source_name"] == "queue.in"
+    assert payload["attempts"] == 2
+    assert payload["duration_s"] == 0.25
+    # TaskEvent clock wins over the handler's wall clock.
+    assert payload["ts"] == payload["emitted_at"]
+    assert payload["message"] == "task succeeded"
+    assert payload["level"] == "INFO"
+
+
+def test_failure_event_fields_serialized() -> None:
+    handler = ListHandler()
+    handler.setFormatter(JsonLogFormatter())
+    logger = _make_logger("tests.jsonlog.failure", handler)
+
+    event_logger = StructuredEventLogger(logger=logger)
+    event_logger(
+        TaskEvent(
+            kind=TaskEventKind.FAILED,
+            app="billing",
+            task="sync",
+            source="queue.in",
+            attempts=3,
+            failure=FailureInfo(
+                kind=FailureKind.ERROR,
+                exception_type="TimeoutError",
+                message="upstream timed out",
+            ),
+        )
+    )
+
+    payload = json.loads(handler.lines[0])
+    assert payload["level"] == "ERROR"
+    assert payload["event_kind"] == "failed"
+    assert payload["failure_kind"] == "error"
+    assert payload["failure_exception_type"] == "TimeoutError"
+    assert payload["failure_message"] == "upstream timed out"
+    assert payload["failure_kind"] not in payload.get("extra", {})
+
+
+def test_event_meta_nested_in_output() -> None:
+    handler = ListHandler()
+    handler.setFormatter(JsonLogFormatter())
+    logger = _make_logger("tests.jsonlog.meta", handler)
+
+    event_logger = StructuredEventLogger(logger=logger)
+    event_logger(
+        TaskEvent(
+            kind=TaskEventKind.FETCHED,
+            app="billing",
+            task="sync",
+            source="queue.in",
+            attempts=0,
+            meta={"lease_id": "abc"},
+        )
+    )
+
+    payload = json.loads(handler.lines[0])
+    assert payload["task_event_meta"] == {"lease_id": "abc"}
+
+
+def test_unknown_extra_attributes_land_in_extra_object() -> None:
+    handler = ListHandler()
+    handler.setFormatter(JsonLogFormatter())
+    logger = _make_logger("tests.jsonlog.extra", handler)
+
+    logger.warning("watch out", extra={"request_id": "req-1", "tenant": "acme"})
+
+    payload = json.loads(handler.lines[0])
+    assert payload["extra"] == {"request_id": "req-1", "tenant": "acme"}
+
+
+def test_unserializable_extra_values_do_not_break_formatting() -> None:
+    handler = ListHandler()
+    handler.setFormatter(JsonLogFormatter())
+    logger = _make_logger("tests.jsonlog.unserializable", handler)
+
+    class Opaque:
+        def __repr__(self) -> str:
+            return "<opaque>"
+
+    logger.info("carrying", extra={"opaque": Opaque()})
+
+    payload = json.loads(handler.lines[0])
+    assert payload["extra"]["opaque"] == "<opaque>"
+
+
+def test_exc_info_and_stack_info_included() -> None:
+    handler = ListHandler()
+    handler.setFormatter(JsonLogFormatter())
+    logger = _make_logger("tests.jsonlog.exc", handler)
+
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        logger.exception("caught")
+
+    payload = json.loads(handler.lines[0])
+    assert "ValueError: boom" in payload["exc_info"]
+    assert "Traceback (most recent call last)" in payload["exc_info"]
+
+
+def test_lazy_args_not_leaking_tuple_into_json() -> None:
+    handler = ListHandler()
+    handler.setFormatter(JsonLogFormatter())
+    logger = _make_logger("tests.jsonlog.lazyargs", handler)
+
+    logger.info("count=%d", 3)
+
+    payload = json.loads(handler.lines[0])
+    assert payload["message"] == "count=3"
+    assert "args" not in payload
+
+
+def test_attach_installs_formatter_on_handler() -> None:
+    handler = logging.StreamHandler()
+    returned = JsonLogFormatter.attach(handler)
+    assert returned is handler
+    assert isinstance(handler.formatter, JsonLogFormatter)


### PR DESCRIPTION
…put (#155)

- Add JsonLogFormatter (src/onestep/jsonlog.py, stdlib-only): one JSON object per line with ts/level/logger/message; task lifecycle fields (event_kind, app_name, task_name, attempts, duration_s, failure_*, task_event_meta) promoted to the top level for direct indexing by Loki/ELK; other records keep extra attributes nested under "extra"; unserializable values fall back to repr so logging never raises.
- Add `onestep run --log-format {text,json}` (default text unchanged); json swaps the CLI stdout handler formatter.
- Export onestep.JsonLogFormatter for embedded setups.
- README logging section documents the JSON format with an example line; CHANGELOG gains the 1.12.0a1 entry.
- Tests: 9 formatter unit tests + CLI parse/integration coverage (json lines on stdout, default text unchanged, unknown format exit 2).