### PR TITLE
fix(cf-queues): mask api_token in repr, decode payloads by content type

### DIFF
--- a/docs/broker/cf-queues.md
+++ b/docs/broker/cf-queues.md
@@ -120,8 +120,9 @@ ack 与 retry 会被缓冲，达到 `ack_batch_size` 或经过 `ack_flush_interv
 ## Content type 与编码
 
 拉取消费者只能处理 `text`、`bytes`、`json` content type（默认 `json`），无法解码
-Workers 专用的 `v8`。对于 `json` 和 `bytes`，body 会以 base64 传输，连接器会自动
-base64 解码后再交给 envelope 编解码器。
+Workers 专用的 `v8`。对于 `json` 和 `bytes`，body 会以 base64 传输，连接器按消息
+`CF-Content-Type` 元数据解码后再交给 envelope 编解码器；`bytes` 负载若不是有效
+UTF-8/JSON，解码结果（字符串或原始 bytes）会原样作为 envelope body。
 
 ## 失败处理（`on_fail`）
 

--- a/plugins/onestep-cf-queues/src/onestep_cf_queues/connector.py
+++ b/plugins/onestep-cf-queues/src/onestep_cf_queues/connector.py
@@ -25,7 +25,14 @@ _MAX_VISIBILITY_TIMEOUT_MS = 12 * 60 * 60 * 1000  # 12 hours
 _MAX_DELAY_SECONDS = 24 * 60 * 60  # 24 hours
 
 
-def _decode_message_body(raw: Any) -> Envelope:
+def _try_base64_decode(value: str) -> bytes | None:
+    try:
+        return base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
+
+def _decode_message_body(raw: Any, content_type: str | None = None) -> Envelope:
     """Decode a Cloudflare pull message ``body`` into an onestep Envelope.
 
     Pull consumers may receive the body as a structured JSON value, a plain
@@ -36,16 +43,31 @@ def _decode_message_body(raw: Any) -> Envelope:
     if isinstance(raw, (dict, list)):
         return decode_envelope(raw)
     if isinstance(raw, (bytes, bytearray)):
-        return decode_envelope(bytes(raw))
-    if isinstance(raw, str):
-        # json / bytes content types arrive base64-encoded; text arrives as a
-        # plain (possibly already-JSON) string. Try base64 first, but only
-        # accept it when the decoded bytes parse as JSON, otherwise treat the
-        # string as-is.
+        data = bytes(raw)
         try:
-            decoded = base64.b64decode(raw, validate=True)
-        except (binascii.Error, ValueError):
-            decoded = None
+            return decode_envelope(data)
+        except UnicodeDecodeError:
+            # Undecodable binary payload: keep the decoded bytes as the body.
+            return Envelope(body=data)
+    if isinstance(raw, str):
+        if content_type == "text":
+            return decode_envelope(raw)
+        if content_type in ("json", "bytes"):
+            # These content types always travel base64-encoded, so decode
+            # unconditionally instead of inferring from JSON-parsability:
+            # a non-JSON ``bytes`` payload must keep its decoded body rather
+            # than degrade to the raw base64 string.
+            decoded = _try_base64_decode(raw)
+            if decoded is None:
+                # Malformed base64: fall back to plain-string handling.
+                return decode_envelope(raw)
+            try:
+                return decode_envelope(decoded)
+            except UnicodeDecodeError:
+                return Envelope(body=decoded)
+        # Unknown content type: accept base64 only when the decoded bytes
+        # parse as JSON, otherwise treat the string as-is.
+        decoded = _try_base64_decode(raw)
         if decoded is not None:
             try:
                 json.loads(decoded.decode("utf-8"))
@@ -67,7 +89,11 @@ def _message_field(message: Any, key: str) -> Any:
 class CFQueuesDelivery(Delivery):
     def __init__(self, queue: "CFQueue", message: Any) -> None:
         body = _message_field(message, "body")
-        envelope = _decode_message_body(body)
+        metadata = _message_field(message, "metadata")
+        content_type = (
+            metadata.get("CF-Content-Type") if isinstance(metadata, dict) else None
+        )
+        envelope = _decode_message_body(body, content_type)
         existing_meta = envelope.meta.get("cf_queues")
         cf_meta = dict(existing_meta) if isinstance(existing_meta, dict) else {}
         for key in ("id", "timestamp_ms", "attempts", "metadata"):
@@ -81,7 +107,6 @@ class CFQueuesDelivery(Delivery):
         attempts = _message_field(message, "attempts")
         if attempts is not None:
             cf_meta["attempts"] = attempts
-        metadata = _message_field(message, "metadata")
         if isinstance(metadata, dict):
             cf_meta["metadata"] = dict(metadata)
         envelope.meta["cf_queues"] = cf_meta
@@ -124,7 +149,9 @@ class CFQueuesDelivery(Delivery):
 @dataclass
 class CFQueuesConnector:
     account_id: str
-    api_token: str
+    # Secret-bearing: excluded from repr so logging/exception rendering of the
+    # connector can never leak the token (see _secret_tokens).
+    api_token: str = field(repr=False)
     base_url: str | None = None
     timeout_s: float = 10.0
     client: Any | None = None

--- a/plugins/onestep-cf-queues/tests/test_cf_queues_connector.py
+++ b/plugins/onestep-cf-queues/tests/test_cf_queues_connector.py
@@ -289,6 +289,63 @@ def test_decode_message_body_handles_structured_dict():
     assert envelope.attempts == 3
 
 
+def test_connector_repr_hides_api_token():
+    connector = _connector(FakeCFClient())
+    assert "secret-token" not in repr(connector)
+
+
+def test_decode_message_body_decodes_non_json_bytes_content_type():
+    encoded = base64.b64encode("plain text, not json".encode("utf-8")).decode("ascii")
+    envelope = _decode_message_body(encoded, "bytes")
+    assert envelope.body == "plain text, not json"
+
+
+def test_decode_message_body_keeps_binary_bytes_content_type():
+    payload = bytes([0x00, 0xFF, 0x10, 0x80])
+    encoded = base64.b64encode(payload).decode("ascii")
+    envelope = _decode_message_body(encoded, "bytes")
+    assert envelope.body == payload
+
+
+def test_decode_message_body_without_content_type_keeps_base64_fallback():
+    # Unknown content type keeps the legacy heuristic: base64 is accepted only
+    # when it decodes to JSON, otherwise the raw string stays the body.
+    encoded = base64.b64encode(b"plain text, not json").decode("ascii")
+    envelope = _decode_message_body(encoded)
+    assert envelope.body == encoded
+
+
+def test_decode_message_body_text_content_type_skips_base64():
+    raw = '{"body": {"a": 1}}'
+    envelope = _decode_message_body(raw, "text")
+    assert envelope.body == {"a": 1}
+
+
+def test_cf_queue_fetch_decodes_bytes_content_type_metadata():
+    async def scenario():
+        client = FakeCFClient()
+        encoded = base64.b64encode("raw payload".encode("utf-8")).decode("ascii")
+        client.available.append(
+            SDKMessage(
+                id="id-bytes",
+                body=encoded,
+                timestamp_ms=1689615013586,
+                attempts=1,
+                metadata={"CF-Content-Type": "bytes"},
+                lease_id="lease-bytes",
+            )
+        )
+        queue = _connector(client).queue("q1", ack_flush_interval_s=0)
+
+        deliveries = await queue.fetch(5)
+        assert len(deliveries) == 1
+        assert deliveries[0].payload == "raw payload"
+        cf_meta = deliveries[0].envelope.meta["cf_queues"]
+        assert cf_meta["metadata"] == {"CF-Content-Type": "bytes"}
+
+    asyncio.run(scenario())
+
+
 def test_cf_queue_sdk_transport_error_is_normalized():
     async def scenario():
         class ErrorMessages(FakeMessages):

--- a/scripts/run-reliability-checks.sh
+++ b/scripts/run-reliability-checks.sh
@@ -13,28 +13,38 @@ cd "$ROOT_DIR"
 echo "==> Running core non-integration tests"
 "$PYTHON_BIN" -m pytest -q -m "not integration" tests "$@"
 
-plugin_paths=(
-  "plugins/onestep-clickhouse/tests"
-  "plugins/onestep-control-plane/tests"
-  "plugins/onestep-elasticsearch/tests"
-  "plugins/onestep-feishu-bitable/tests"
-  "plugins/onestep-mongodb/tests"
-  "plugins/onestep-mysql/tests"
-  "plugins/onestep-postgres/tests"
-  "plugins/onestep-rabbitmq/tests"
-  "plugins/onestep-redis/tests"
-  "plugins/onestep-sqs/tests"
-  "plugins/onestep-cf-queues/tests"
+# "<import name> <tests path>" per plugin
+plugin_tests=(
+  "onestep_clickhouse plugins/onestep-clickhouse/tests"
+  "onestep_control_plane plugins/onestep-control-plane/tests"
+  "onestep_elasticsearch plugins/onestep-elasticsearch/tests"
+  "onestep_feishu_bitable plugins/onestep-feishu-bitable/tests"
+  "onestep_mongodb plugins/onestep-mongodb/tests"
+  "onestep_mysql plugins/onestep-mysql/tests"
+  "onestep_postgres plugins/onestep-postgres/tests"
+  "onestep_rabbitmq plugins/onestep-rabbitmq/tests"
+  "onestep_redis plugins/onestep-redis/tests"
+  "onestep_sqs plugins/onestep-sqs/tests"
+  "onestep_cf_queues plugins/onestep-cf-queues/tests"
 )
 
 echo "==> Running plugin non-integration tests in isolated pytest processes"
-for path in "${plugin_paths[@]}"; do
-  if find "$ROOT_DIR/$path" -maxdepth 1 -type f -name 'test_*.py' | grep -q .; then
-    echo "==> $path"
-    "$PYTHON_BIN" -m pytest -q -m "not integration" "$path" "$@"
-  else
+for entry in "${plugin_tests[@]}"; do
+  package="${entry%% *}"
+  path="${entry#* }"
+  if ! find "$ROOT_DIR/$path" -maxdepth 1 -type f -name 'test_*.py' | grep -q .; then
     echo "==> $path (no tests found, skipped)"
+    continue
   fi
+  # A partially-synced .venv must not abort the whole run with collection
+  # errors; CI installs every plugin via `uv sync --all-packages` so nothing
+  # is skipped there.
+  if ! "$PYTHON_BIN" -c "import $package" >/dev/null 2>&1; then
+    echo "==> $path (skipped: $package not importable; run 'uv sync' to install plugin deps)"
+    continue
+  fi
+  echo "==> $path"
+  "$PYTHON_BIN" -m pytest -q -m "not integration" "$path" "$@"
 done
 
 if "$PYTHON_BIN" - <<'PY'

--- a/tests/test_reliability_checks_script.py
+++ b/tests/test_reliability_checks_script.py
@@ -20,6 +20,7 @@ def test_reliability_check_script_runs_plugin_suites_in_isolated_processes() -> 
     assert '"$PYTHON_BIN" -m pytest -q -m "not integration" tests "$@"' in text
     for plugin in (
         "plugins/onestep-clickhouse/tests",
+        "plugins/onestep-control-plane/tests",
         "plugins/onestep-elasticsearch/tests",
         "plugins/onestep-feishu-bitable/tests",
         "plugins/onestep-mongodb/tests",
@@ -28,7 +29,16 @@ def test_reliability_check_script_runs_plugin_suites_in_isolated_processes() -> 
         "plugins/onestep-rabbitmq/tests",
         "plugins/onestep-redis/tests",
         "plugins/onestep-sqs/tests",
+        "plugins/onestep-cf-queues/tests",
     ):
         assert plugin in text
-    assert 'for path in "${plugin_paths[@]}"' in text
+    assert 'for entry in "${plugin_tests[@]}"' in text
     assert '"$PYTHON_BIN" -m pytest -q -m "not integration" "$path" "$@"' in text
+
+
+def test_reliability_check_script_skips_plugins_with_missing_packages() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    # A partially-synced .venv must skip the plugin suite instead of aborting
+    # the whole run with collection errors.
+    assert 'if ! "$PYTHON_BIN" -c "import $package" >/dev/null 2>&1; then' in text
+    assert "not importable" in text


### PR DESCRIPTION
Fixes #152

## 变更

1. **`api_token` 不再出现在 repr**：`CFQueuesConnector.api_token` 改为 `field(repr=False)`（与 `_client` 同模式），打印连接器或渲染异常不会再泄露 token。
2. **按 `CF-Content-Type` 解码 pull 消息 body**：`_decode_message_body` 新增 `content_type` 参数，由 `CFQueuesDelivery` 从消息 metadata 取值传入：
   - `json`/`bytes`：无条件 base64 解码后交给 envelope 编解码器——非 JSON 的 `bytes` 负载保留解码后的 body，不再退化为原始 base64 字符串；非 UTF-8 二进制以 bytes 作为 body（此前会抛 `UnicodeDecodeError`）
   - `text`：直接按字符串处理
   - content type 未知/缺失：保留原 JSON 可解析性启发式，老消息行为不变
3. **可靠性脚本对缺失插件依赖加防护**：`run-reliability-checks.sh` 每个插件套件运行前检查包可导入，缺失则跳过并提示 `uv sync`，不再带着收集错误中止整个脚本。CI 通过 `uv sync --all-packages` 装齐全部插件，不受影响。

文档 `docs/broker/cf-queues.md` 同步了 bytes 负载解码语义；契约测试 `tests/test_reliability_checks_script.py` 同步了脚本新结构（并补上此前遗漏的 control-plane、cf-queues 两个目录断言）。

## 验证

- `plugins/onestep-cf-queues/tests`：57 passed（含 7 个新用例）
- `./scripts/run-reliability-checks.sh` 端到端通过：核心 653 + 全部 11 个插件套件